### PR TITLE
Document dark/light mode requirement

### DIFF
--- a/docs/react-migration/PRD.md
+++ b/docs/react-migration/PRD.md
@@ -13,6 +13,7 @@ This migration is also the right moment to introduce an AI coding assistant and 
 3. **AI coding assistant** — Integrate a mast-ai `AgentRunner` that can read and write the editor, run code in the REPL, and converse with the user in a dedicated chat panel backed by `@mast-ai/react-ui`.
 4. **Configurable provider** — The user supplies an API key and selects a provider (initially Google Gemini) via a settings UI. The architecture must make adding future providers straightforward without further restructuring.
 5. **Editor upgrade** — Replace the current pre-stable `@codemirror/*@0.18.x` packages with a modern editor (see SPEC for decision).
+6. **Dark/light mode** — The app respects the OS colour-scheme preference by default. The user can override it via a toggle in the toolbar. The chosen preference is persisted to `localStorage`.
 
 ## Out of Scope
 
@@ -30,3 +31,4 @@ This migration is also the right moment to introduce an AI coding assistant and 
 - When no provider is configured the chat panel is disabled but visible, and prompts the user to open settings.
 - No Lit dependency remains in `package.json`.
 - All React components are purely presentational — no component imports `ReplInterface` or `AgentRunner` directly.
+- The app defaults to the OS colour-scheme preference. A toolbar toggle lets the user switch between light and dark mode, and the choice is persisted across reloads.

--- a/docs/react-migration/SPEC.md
+++ b/docs/react-migration/SPEC.md
@@ -265,6 +265,19 @@ Creates the CodeMirror `EditorView` in a `useEffect` attached to `editorRef`. St
 
 See Provider Abstraction section above.
 
+### `useTheme()`
+
+```ts
+{
+  theme: 'light' | 'dark',
+  toggle(): void,
+}
+```
+
+On mount, reads `localStorage` key `cobweb:theme`. If absent, reads `window.matchMedia('(prefers-color-scheme: dark)')`. Applies/removes the `dark` class on `<html>` whenever `theme` changes. `toggle()` flips the value and persists it to `localStorage`.
+
+Used by `<Toolbar>` to render a sun/moon icon button. No other component needs to import it — `<html class="dark">` is all shadcn/ui requires.
+
 ### Agent state — `useAgent()` from `@mast-ai/react-ui`
 
 Agent streaming state is **not** a custom hook — it is provided by `useAgent()` from `@mast-ai/react-ui`, available to any component inside `<AgentProvider>`. No `useAgent` hook is implemented in this project.
@@ -295,7 +308,7 @@ Divider position in `useState`; pointer events on the divider handle dragging.
 
 ### `<Toolbar>`
 
-Props: `connectionState`, `onConnect`, `onDisconnect`, `onReset`, `onRun`, `onOpenSettings`, `isAgentConfigured: boolean`.
+Props: `connectionState`, `onConnect`, `onDisconnect`, `onReset`, `onRun`, `onOpenSettings`, `isAgentConfigured: boolean`, `theme: 'light' | 'dark'`, `onToggleTheme: () => void`.
 
 ### `<StatusBar>`
 
@@ -403,6 +416,7 @@ Replace the current `<body>` content with a single mount point:
 - `src/hooks/useReplConnection.ts`
 - `src/hooks/useEditor.ts`
 - `src/hooks/useProviderConfig.ts`
+- `src/hooks/useTheme.ts`
 - `src/agent/tools/ReadEditorTool.ts`
 - `src/agent/tools/WriteEditorTool.ts`
 - `src/agent/tools/RunCodeTool.ts`


### PR DESCRIPTION
## Summary

Adds the dark/light mode requirement (Goal 6) to the PRD and SPEC ahead of implementation in #28.

- PRD: new goal and success criterion for OS-preference-respecting colour scheme with user toggle
- SPEC: `useTheme()` hook interface, updated `<Toolbar>` props, `useTheme.ts` added to file map

Relates to #28.