### PR TITLE
Provider abstraction: ProviderConfig, factory, storage, hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,14 @@ gh api graphql -f query='{
 }'
 ```
 
+## Testing
+
+- Write Vitest tests for every new module that contains logic (providers, hooks, utilities, tools).
+- Test files live alongside source files: `src/providers/storage.test.ts`, `src/hooks/useProviderConfig.test.ts`, etc.
+- Use `@testing-library/react` for hook tests (`renderHook`).
+- Use `happy-dom` as the Vitest environment (already configured via `src/test/setup.ts`).
+- Do not test React components purely through unit tests — those require browser testing.
+
 ## Git Conventions
 
 - Always use `Edit` to modify existing files — never rewrite them wholesale with `Write`. Small diffs make reviews easier.

--- a/src/hooks/useProviderConfig.test.ts
+++ b/src/hooks/useProviderConfig.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useProviderConfig } from './useProviderConfig';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useProviderConfig', () => {
+  it('returns null config on first load with empty localStorage', () => {
+    const { result } = renderHook(() => useProviderConfig());
+    expect(result.current.config).toBeNull();
+  });
+
+  it('reads an existing config from localStorage on mount', () => {
+    const stored = { provider: 'google-genai' as const, apiKey: 'key123' };
+    localStorage.setItem('cobweb:provider-config', JSON.stringify(stored));
+    const { result } = renderHook(() => useProviderConfig());
+    expect(result.current.config).toEqual(stored);
+  });
+
+  it('save updates config state', () => {
+    const { result } = renderHook(() => useProviderConfig());
+    const config = { provider: 'google-genai' as const, apiKey: 'new-key' };
+    act(() => result.current.save(config));
+    expect(result.current.config).toEqual(config);
+  });
+
+  it('save persists config to localStorage', () => {
+    const { result } = renderHook(() => useProviderConfig());
+    const config = { provider: 'urp' as const, endpoint: 'https://example.com' };
+    act(() => result.current.save(config));
+    expect(JSON.parse(localStorage.getItem('cobweb:provider-config')!)).toEqual(
+      config,
+    );
+  });
+
+  it('clear sets config to null', () => {
+    localStorage.setItem(
+      'cobweb:provider-config',
+      JSON.stringify({ provider: 'google-genai' as const, apiKey: 'k' }),
+    );
+    const { result } = renderHook(() => useProviderConfig());
+    act(() => result.current.clear());
+    expect(result.current.config).toBeNull();
+  });
+
+  it('clear removes config from localStorage', () => {
+    localStorage.setItem(
+      'cobweb:provider-config',
+      JSON.stringify({ provider: 'google-genai' as const, apiKey: 'k' }),
+    );
+    const { result } = renderHook(() => useProviderConfig());
+    act(() => result.current.clear());
+    expect(localStorage.getItem('cobweb:provider-config')).toBeNull();
+  });
+
+  it('saved config survives a remount', () => {
+    const { result: r1 } = renderHook(() => useProviderConfig());
+    const config = { provider: 'google-genai' as const, apiKey: 'persistent' };
+    act(() => r1.current.save(config));
+
+    const { result: r2 } = renderHook(() => useProviderConfig());
+    expect(r2.current.config).toEqual(config);
+  });
+});

--- a/src/hooks/useProviderConfig.ts
+++ b/src/hooks/useProviderConfig.ts
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import type { ProviderConfig } from '../providers/types';
+import {
+  loadProviderConfig,
+  saveProviderConfig,
+  clearProviderConfig,
+} from '../providers/storage';
+
+export function useProviderConfig() {
+  const [config, setConfig] = useState<ProviderConfig | null>(() =>
+    loadProviderConfig(),
+  );
+
+  function save(newConfig: ProviderConfig) {
+    saveProviderConfig(newConfig);
+    setConfig(newConfig);
+  }
+
+  function clear() {
+    clearProviderConfig();
+    setConfig(null);
+  }
+
+  return { config, save, clear };
+}

--- a/src/providers/factory.test.ts
+++ b/src/providers/factory.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { createAdapter } from './factory';
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
+import { UrpAdapter } from '@mast-ai/core';
+
+describe('createAdapter', () => {
+  it('returns a GoogleGenAIAdapter for google-genai config', () => {
+    const adapter = createAdapter({ provider: 'google-genai', apiKey: 'key' });
+    expect(adapter).toBeInstanceOf(GoogleGenAIAdapter);
+  });
+
+  it('returns a GoogleGenAIAdapter when optional model is supplied', () => {
+    const adapter = createAdapter({
+      provider: 'google-genai',
+      apiKey: 'key',
+      model: 'gemini-pro',
+    });
+    expect(adapter).toBeInstanceOf(GoogleGenAIAdapter);
+  });
+
+  it('returns a UrpAdapter for urp config', () => {
+    const adapter = createAdapter({
+      provider: 'urp',
+      endpoint: 'https://example.com/urp',
+    });
+    expect(adapter).toBeInstanceOf(UrpAdapter);
+  });
+
+  it('returned adapter exposes a generate method', () => {
+    const adapter = createAdapter({ provider: 'google-genai', apiKey: 'key' });
+    expect(typeof adapter.generate).toBe('function');
+  });
+});

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,0 +1,13 @@
+import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
+import { UrpAdapter, HttpTransport } from '@mast-ai/core';
+import type { LlmAdapter } from '@mast-ai/core';
+import type { ProviderConfig } from './types';
+
+export function createAdapter(config: ProviderConfig): LlmAdapter {
+  switch (config.provider) {
+    case 'google-genai':
+      return new GoogleGenAIAdapter(config.apiKey, config.model);
+    case 'urp':
+      return new UrpAdapter(new HttpTransport({ url: config.endpoint }));
+  }
+}

--- a/src/providers/storage.test.ts
+++ b/src/providers/storage.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  loadProviderConfig,
+  saveProviderConfig,
+  clearProviderConfig,
+} from './storage';
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('loadProviderConfig', () => {
+  it('returns null when nothing is stored', () => {
+    expect(loadProviderConfig()).toBeNull();
+  });
+
+  it('returns null when stored value is not valid JSON', () => {
+    localStorage.setItem('cobweb:provider-config', 'not-json');
+    expect(loadProviderConfig()).toBeNull();
+  });
+});
+
+describe('saveProviderConfig / loadProviderConfig', () => {
+  it('round-trips a google-genai config', () => {
+    const config = { provider: 'google-genai' as const, apiKey: 'abc123' };
+    saveProviderConfig(config);
+    expect(loadProviderConfig()).toEqual(config);
+  });
+
+  it('round-trips a google-genai config with optional model', () => {
+    const config = {
+      provider: 'google-genai' as const,
+      apiKey: 'key',
+      model: 'gemini-pro',
+    };
+    saveProviderConfig(config);
+    expect(loadProviderConfig()).toEqual(config);
+  });
+
+  it('round-trips a urp config', () => {
+    const config = {
+      provider: 'urp' as const,
+      endpoint: 'https://example.com/urp',
+    };
+    saveProviderConfig(config);
+    expect(loadProviderConfig()).toEqual(config);
+  });
+
+  it('overwrites a previous config', () => {
+    saveProviderConfig({ provider: 'google-genai' as const, apiKey: 'old' });
+    const newConfig = {
+      provider: 'urp' as const,
+      endpoint: 'https://new.example.com',
+    };
+    saveProviderConfig(newConfig);
+    expect(loadProviderConfig()).toEqual(newConfig);
+  });
+});
+
+describe('clearProviderConfig', () => {
+  it('removes the stored config', () => {
+    saveProviderConfig({ provider: 'google-genai' as const, apiKey: 'key' });
+    clearProviderConfig();
+    expect(loadProviderConfig()).toBeNull();
+  });
+
+  it('is a no-op when nothing is stored', () => {
+    expect(() => clearProviderConfig()).not.toThrow();
+  });
+});

--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -1,0 +1,21 @@
+import type { ProviderConfig } from './types';
+
+const STORAGE_KEY = 'cobweb:provider-config';
+
+export function loadProviderConfig(): ProviderConfig | null {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as ProviderConfig;
+  } catch {
+    return null;
+  }
+}
+
+export function saveProviderConfig(config: ProviderConfig): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+}
+
+export function clearProviderConfig(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,0 +1,5 @@
+export type ProviderConfig =
+  | { provider: 'google-genai'; apiKey: string; model?: string }
+  | { provider: 'urp'; endpoint: string };
+  // Future: | { provider: 'built-in-ai' }
+  //         | { provider: 'openai'; apiKey: string; model?: string }


### PR DESCRIPTION
## Summary

- `src/providers/types.ts` — `ProviderConfig` discriminated union with `google-genai` and `urp` variants; adding a new provider requires only a new union member here and a new `case` in `factory.ts`
- `src/providers/factory.ts` — `createAdapter(config)` switches on `config.provider` to construct the right `LlmAdapter`; `UrpAdapter` receives an `HttpTransport({ url: config.endpoint })` matching the SDK's `HttpTransportOptions` shape
- `src/providers/storage.ts` — thin wrappers over `localStorage` key `cobweb:provider-config`; `loadProviderConfig` returns `null` on missing or malformed data
- `src/hooks/useProviderConfig.ts` — lazy-initialised state from storage; `save` and `clear` update both state and storage atomically
- Co-located Vitest tests for all three modules (storage round-trips, factory instanceof checks, hook state + persistence)
- `CLAUDE.md` — new **Testing** section requiring tests for every new module with logic

Closes #16