### PR TITLE
Add license copyright headers to all source files

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2021 Google Inc
+   Copyright 2026 Andre Cipriani Bandarra
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import js from '@eslint/js';
 import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';

--- a/index.html
+++ b/index.html
@@ -1,19 +1,6 @@
+<!-- Copyright 2026 Andre Cipriani Bandarra -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <!DOCTYPE html>
-<!--
- Copyright 2021 Google Inc. All Rights Reserved.
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-      http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
--->
 <html lang="en">
   <head>
     <meta charset="utf-8">

--- a/public/404.html
+++ b/public/404.html
@@ -1,3 +1,5 @@
+<!-- Copyright 2026 Andre Cipriani Bandarra -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
 <!DOCTYPE html>
 <html>
   <head>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,18 +1,5 @@
-/*
- * Copyright 2021 Google Inc. All Rights Reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
 
 onfetch = (event) => {
 

--- a/src/CodeEditor.ts
+++ b/src/CodeEditor.ts
@@ -1,18 +1,5 @@
-/*
- * Copyright 2021 Google Inc. All Rights Reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
 
 import {EditorState, EditorView, basicSetup} from '@codemirror/basic-setup';
 import {python} from '@codemirror/lang-python';

--- a/src/Queues.test.ts
+++ b/src/Queues.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from 'vitest';
 import { Queue, AsyncBlockingQueue } from './Queues';
 

--- a/src/Queues.ts
+++ b/src/Queues.ts
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 Google Inc. All Rights Reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
 
 type Resolver<T> = (value?: T) => void;
 

--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -1,18 +1,5 @@
-/*
- * Copyright 2021 Google Inc. All Rights Reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
 
 export type ReplMode = 'normal' | 'paste' | 'raw' | 'raw-paste';
 

--- a/src/components/FileNavigator.ts
+++ b/src/components/FileNavigator.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import {LitElement, html, css} from 'lit';
 
 export class FileNavigator extends LitElement {

--- a/src/components/ReplShell.ts
+++ b/src/components/ReplShell.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import {LitElement, html, css,} from 'lit';
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';

--- a/src/components/SplitPane.ts
+++ b/src/components/SplitPane.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import {LitElement, html, css} from 'lit';
 
 export class SplitPane extends LitElement {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { Button as ButtonPrimitive } from "@base-ui/react/button"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/src/hooks/useProviderConfig.test.ts
+++ b/src/hooks/useProviderConfig.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useProviderConfig } from './useProviderConfig';

--- a/src/hooks/useProviderConfig.ts
+++ b/src/hooks/useProviderConfig.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { useState } from 'react';
 import type { ProviderConfig } from '../providers/types';
 import {

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,6 @@
+/* Copyright 2026 Andre Cipriani Bandarra */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 @import "tailwindcss";
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,18 +1,5 @@
-/*
- * Copyright 2021 Google Inc. All Rights Reserved.
- *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
- */
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
 
 import {ReplInterface} from './ReplInterface';
 import {CodeEditor} from './CodeEditor';

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.css';

--- a/src/providers/factory.test.ts
+++ b/src/providers/factory.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect } from 'vitest';
 import { createAdapter } from './factory';
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { GoogleGenAIAdapter } from '@mast-ai/google-genai';
 import { UrpAdapter, HttpTransport } from '@mast-ai/core';
 import type { LlmAdapter } from '@mast-ai/core';

--- a/src/providers/storage.test.ts
+++ b/src/providers/storage.test.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   loadProviderConfig,

--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import type { ProviderConfig } from './types';
 
 const STORAGE_KEY = 'cobweb:provider-config';

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 export type ProviderConfig =
   | { provider: 'google-genai'; apiKey: string; model?: string }
   | { provider: 'urp'; endpoint: string };

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,4 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';


### PR DESCRIPTION
## Summary

- Replace old Google Apache 2.0 block comments with the new two-line SPDX header (`// Copyright 2026 Andre Cipriani Bandarra` / `// SPDX-License-Identifier: Apache-2.0`) in all source files that had them
- Add the same header to all source files that had none
- Update the copyright line in `LICENSE` to match
- Use appropriate comment syntax per file type (JS/TS, CSS, HTML)
- `manifest.json` and binary assets (PNG) are intentionally left without headers as they don't support comments