### PR TITLE
AppModels interface and createModels() factory

### DIFF
--- a/docs/react-migration/SPEC.md
+++ b/docs/react-migration/SPEC.md
@@ -111,17 +111,17 @@ Instantiated once at app startup:
 
 ```ts
 export interface AppModels {
-  repl: ReplInterface;
   tools: ToolRegistry;
 }
 
 export function createModels(): AppModels {
   return {
-    repl: new ReplInterface(),
-    tools: new ToolRegistry(),   // agent tools registered here
+    tools: new ToolRegistry(),
   };
 }
 ```
+
+`repl` is not in `AppModels` — `ReplInterface` can only be constructed after the user picks a serial port, so `useReplConnection` owns its lifecycle entirely (calling `ReplInterface.connect()` internally).
 
 `AgentRunner` is not in `AppModels` — it is owned by `useProviderConfig` and recreated when the provider config changes.
 
@@ -235,7 +235,9 @@ No Model or hook imports. A "Settings" button in `<Toolbar>` opens it.
 
 ## ViewModels (hooks)
 
-### `useReplConnection(repl: ReplInterface)`
+### `useReplConnection()`
+
+Owns the `ReplInterface` lifecycle. `connect()` calls `ReplInterface.connect()` to acquire a serial port and create the instance; `disconnect()` tears it down.
 
 ```ts
 {

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,0 +1,14 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { ToolRegistry } from '@mast-ai/core';
+
+export interface AppModels {
+  tools: ToolRegistry;
+}
+
+export function createModels(): AppModels {
+  return {
+    tools: new ToolRegistry(),
+  };
+}


### PR DESCRIPTION
## Summary

- `src/models.ts` — `AppModels` interface (`tools: ToolRegistry`) and `createModels()` factory; `ToolRegistry` is empty at this stage (tools registered in #23)
- `docs/react-migration/SPEC.md` — removed `repl: ReplInterface` from `AppModels`; `ReplInterface` can only be constructed after the user picks a serial port, so `useReplConnection` owns its lifecycle (calls `ReplInterface.connect()` internally). Updated `useReplConnection` signature to reflect no parameter.

## Test plan

- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm run test` passes (31 tests)

Closes #17