### PR TITLE
feat: agent tools — read/write editor, run code, REPL history

### DIFF
--- a/docs/react-migration/SPEC.md
+++ b/docs/react-migration/SPEC.md
@@ -129,7 +129,22 @@ export function createModels(): AppModels {
 
 ## Agent Tools (`src/agent/tools/`)
 
-Registered into the shared `ToolRegistry` from `AppModels` at startup, before any adapter is created. Tool implementations receive stable callbacks (not Model references) injected via a `wireTools(tools, editorHook, replHook)` call in `App` after the hooks are ready.
+Registered into the shared `ToolRegistry` from `AppModels` at startup, before any adapter is created. Tool implementations receive stable callbacks (not Model references) injected via `wireTools(tools, bindings)` in `App` after the hooks are ready.
+
+```ts
+// src/agent/wireTools.ts
+export interface ToolBindings {
+  getEditorContent(): string;
+  setEditorContent(code: string): void;
+  runCode(code: string): Promise<void>;
+  getReplHistory(): string[];
+  onData(handler: (data: Uint8Array) => void): () => void;
+}
+
+export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void;
+```
+
+`wireTools` registers each tool exactly once per `ToolRegistry` instance and updates the bindings on subsequent calls, so `<App>` can re-invoke it from a `useEffect` whose deps include `replHistory` (which changes on every output line) without re-registering the tools.
 
 ### `ReadEditorTool`
 - scope: `'read'`
@@ -138,16 +153,17 @@ Registered into the shared `ToolRegistry` from `AppModels` at startup, before an
 ### `WriteEditorTool`
 - scope: `'write'`, `requiresApproval: false`
 - Args: `{ code: string }`
-- Calls `editorHook.setContent(code)`.
+- Calls `bindings.setEditorContent(code)`.
 
 ### `RunCodeTool`
 - scope: `'write'`, `requiresApproval: true`
 - Args: `{ code?: string }` — if omitted, runs the current editor content.
-- Sends code to the REPL; resolves with REPL output collected up to a configurable timeout.
+- Sends code to the REPL via `bindings.runCode`; subscribes via `bindings.onData` and resolves with the collected REPL output once the device has been idle for `idleMs` (default 1 s), capped at `maxMs` (default 30 s).
 
 ### `ReadReplHistoryTool`
 - scope: `'read'`
-- Returns the last N lines of REPL output (buffered in `useReplConnection`).
+- Args: `{ lines?: number }` — defaults to 20.
+- Returns the last N lines of `bindings.getReplHistory()`, joined by newlines.
 
 ### Agent Config (`src/agent/config.ts`)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { AgentProvider, ConversationPanel, INLINE_APPROVAL } from '@mast-ai/react-ui';
 import { AgentRunner } from '@mast-ai/core';
 import { SplitPane } from './components/SplitPane';
@@ -17,15 +17,26 @@ import { useTheme } from './hooks/useTheme';
 import { createModels } from './models';
 import { createAdapter } from './providers/factory';
 import { CODING_AGENT } from './agent/config';
+import { wireTools } from './agent/wireTools';
 
 const models = createModels();
 
 export function App() {
-  const { connectionState, connect, disconnect, reset, runCode, send, onData } =
+  const { connectionState, connect, disconnect, reset, runCode, send, onData, replHistory } =
     useReplConnection();
   const { config } = useProviderConfig();
   const { theme, preference: themePreference, cycle: cycleTheme } = useTheme();
   const { editorRef, getContent, setContent } = useEditor(theme);
+
+  useEffect(() => {
+    wireTools(models.tools, {
+      getEditorContent: getContent,
+      setEditorContent: setContent,
+      runCode,
+      getReplHistory: () => replHistory,
+      onData,
+    });
+  }, [getContent, setContent, runCode, replHistory, onData]);
 
   const runner = useMemo(() => {
     if (!config) return null;

--- a/src/agent/tools/ReadEditorTool.test.ts
+++ b/src/agent/tools/ReadEditorTool.test.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { ReadEditorTool } from './ReadEditorTool';
+import type { ToolBindings } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => {},
+    getReplHistory: () => [],
+    onData: () => () => {},
+    ...overrides,
+  };
+}
+
+describe('ReadEditorTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new ReadEditorTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('read_editor');
+    expect(def.scope).toBe('read');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('returns the current editor content', async () => {
+    const bindings = makeBindings({ getEditorContent: () => 'print("hi")' });
+    const tool = new ReadEditorTool(() => bindings);
+    await expect(tool.call()).resolves.toBe('print("hi")');
+  });
+
+  it('reads bindings lazily via the getter', async () => {
+    let content = 'first';
+    const bindings = makeBindings({ getEditorContent: () => content });
+    const tool = new ReadEditorTool(() => bindings);
+    expect(await tool.call()).toBe('first');
+    content = 'second';
+    expect(await tool.call()).toBe('second');
+  });
+});

--- a/src/agent/tools/ReadEditorTool.ts
+++ b/src/agent/tools/ReadEditorTool.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export class ReadEditorTool implements Tool<Record<string, never>, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'read_editor',
+      description: "Returns the current contents of the user's code editor as a string.",
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      scope: 'read',
+      requiresApproval: false,
+    };
+  }
+
+  async call(): Promise<string> {
+    return this.getBindings().getEditorContent();
+  }
+}

--- a/src/agent/tools/ReadReplHistoryTool.test.ts
+++ b/src/agent/tools/ReadReplHistoryTool.test.ts
@@ -1,0 +1,55 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { ReadReplHistoryTool } from './ReadReplHistoryTool';
+import type { ToolBindings } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => {},
+    getReplHistory: () => [],
+    onData: () => () => {},
+    ...overrides,
+  };
+}
+
+describe('ReadReplHistoryTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new ReadReplHistoryTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('read_repl_history');
+    expect(def.scope).toBe('read');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('returns the last 20 lines by default, joined with newlines', async () => {
+    const history = Array.from({ length: 50 }, (_, i) => `line ${i}`);
+    const tool = new ReadReplHistoryTool(() => makeBindings({ getReplHistory: () => history }));
+    const result = await tool.call({});
+    const lines = result.split('\n');
+    expect(lines).toHaveLength(20);
+    expect(lines[0]).toBe('line 30');
+    expect(lines[19]).toBe('line 49');
+  });
+
+  it('honours a custom lines count', async () => {
+    const history = ['a', 'b', 'c', 'd', 'e'];
+    const tool = new ReadReplHistoryTool(() => makeBindings({ getReplHistory: () => history }));
+    await expect(tool.call({ lines: 2 })).resolves.toBe('d\ne');
+  });
+
+  it('returns the entire history when fewer lines are buffered than requested', async () => {
+    const tool = new ReadReplHistoryTool(() =>
+      makeBindings({ getReplHistory: () => ['only', 'two'] }),
+    );
+    await expect(tool.call({ lines: 100 })).resolves.toBe('only\ntwo');
+  });
+
+  it('returns an empty string when history is empty', async () => {
+    const tool = new ReadReplHistoryTool(() => makeBindings({ getReplHistory: () => [] }));
+    await expect(tool.call({})).resolves.toBe('');
+  });
+});

--- a/src/agent/tools/ReadReplHistoryTool.ts
+++ b/src/agent/tools/ReadReplHistoryTool.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface ReadReplHistoryArgs {
+  lines?: number;
+}
+
+const DEFAULT_LINES = 20;
+
+export class ReadReplHistoryTool implements Tool<ReadReplHistoryArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'read_repl_history',
+      description:
+        'Returns the last N lines of REPL output from the connected microcontroller, joined by newlines.',
+      parameters: {
+        type: 'object',
+        properties: {
+          lines: {
+            type: 'number',
+            description: `Number of trailing lines to return. Defaults to ${DEFAULT_LINES}.`,
+          },
+        },
+        additionalProperties: false,
+      },
+      scope: 'read',
+      requiresApproval: false,
+    };
+  }
+
+  async call(args: ReadReplHistoryArgs): Promise<string> {
+    const n = args.lines ?? DEFAULT_LINES;
+    const history = this.getBindings().getReplHistory();
+    return history.slice(-n).join('\n');
+  }
+}

--- a/src/agent/tools/RunCodeTool.test.ts
+++ b/src/agent/tools/RunCodeTool.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { RunCodeTool } from './RunCodeTool';
+import type { ToolBindings } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => {},
+    getReplHistory: () => [],
+    onData: () => () => {},
+    ...overrides,
+  };
+}
+
+describe('RunCodeTool', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('definition has correct name, scope, and requires approval', () => {
+    const tool = new RunCodeTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('run_code');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('returns "(no code to run)" when args.code is empty and editor is empty', async () => {
+    const tool = new RunCodeTool(() => makeBindings({ getEditorContent: () => '' }));
+    await expect(tool.call({}, {})).resolves.toBe('(no code to run)');
+  });
+
+  it('falls back to editor content when code arg is omitted', async () => {
+    const runCode = vi.fn().mockResolvedValue(undefined);
+    const tool = new RunCodeTool(
+      () => makeBindings({ getEditorContent: () => 'print(42)', runCode }),
+      { idleMs: 10, maxMs: 100 },
+    );
+    const promise = tool.call({}, {});
+    await vi.advanceTimersByTimeAsync(100);
+    await promise;
+    expect(runCode).toHaveBeenCalledWith('print(42)');
+  });
+
+  it('collects REPL output and resolves after idle period', async () => {
+    let dataHandler: ((data: Uint8Array) => void) | null = null;
+    const tool = new RunCodeTool(
+      () =>
+        makeBindings({
+          runCode: async () => {},
+          onData: (h) => {
+            dataHandler = h;
+            return () => {
+              dataHandler = null;
+            };
+          },
+        }),
+      { idleMs: 50, maxMs: 5000 },
+    );
+
+    const promise = tool.call({ code: 'print("hi")' }, {});
+    // Allow the runCode microtask + onData subscription to settle.
+    await Promise.resolve();
+    dataHandler!(new TextEncoder().encode('hello\n'));
+    await vi.advanceTimersByTimeAsync(50);
+    await expect(promise).resolves.toBe('hello\n');
+  });
+
+  it('hits the max timeout when output keeps streaming', async () => {
+    let dataHandler: ((data: Uint8Array) => void) | null = null;
+    const tool = new RunCodeTool(
+      () =>
+        makeBindings({
+          runCode: async () => {},
+          onData: (h) => {
+            dataHandler = h;
+            return () => {};
+          },
+        }),
+      { idleMs: 1000, maxMs: 200 },
+    );
+
+    const promise = tool.call({ code: 'while True: pass' }, {});
+    await Promise.resolve();
+    dataHandler!(new TextEncoder().encode('a'));
+    await vi.advanceTimersByTimeAsync(200);
+    await expect(promise).resolves.toBe('a');
+  });
+
+  it('rejects when the abort signal fires', async () => {
+    const controller = new AbortController();
+    const tool = new RunCodeTool(
+      () =>
+        makeBindings({
+          runCode: async () => {},
+          onData: () => () => {},
+        }),
+      { idleMs: 50, maxMs: 5000 },
+    );
+    const promise = tool.call({ code: 'x' }, { signal: controller.signal });
+    await Promise.resolve();
+    controller.abort();
+    await expect(promise).rejects.toThrow('aborted');
+  });
+
+  it('rejects when runCode throws', async () => {
+    const tool = new RunCodeTool(
+      () =>
+        makeBindings({
+          runCode: async () => {
+            throw new Error('serial closed');
+          },
+          onData: () => () => {},
+        }),
+      { idleMs: 50, maxMs: 5000 },
+    );
+    await expect(tool.call({ code: 'x' }, {})).rejects.toThrow('serial closed');
+  });
+});

--- a/src/agent/tools/RunCodeTool.ts
+++ b/src/agent/tools/RunCodeTool.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolContext, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface RunCodeArgs {
+  code?: string;
+}
+
+export interface RunCodeOptions {
+  /** Wait this long after the last byte of REPL output before resolving. */
+  idleMs?: number;
+  /** Hard cap on total wait, even if output keeps streaming. */
+  maxMs?: number;
+}
+
+const DEFAULT_IDLE_MS = 1000;
+const DEFAULT_MAX_MS = 30_000;
+
+export class RunCodeTool implements Tool<RunCodeArgs, string> {
+  private readonly idleMs: number;
+  private readonly maxMs: number;
+
+  constructor(
+    private getBindings: () => ToolBindings,
+    options: RunCodeOptions = {},
+  ) {
+    this.idleMs = options.idleMs ?? DEFAULT_IDLE_MS;
+    this.maxMs = options.maxMs ?? DEFAULT_MAX_MS;
+  }
+
+  definition(): ToolDefinition {
+    return {
+      name: 'run_code',
+      description:
+        'Executes MicroPython code on the connected microcontroller and returns the REPL output. ' +
+        'If no code is provided, runs the current editor contents.',
+      parameters: {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            description:
+              'The MicroPython code to run. Omit to run the current editor contents.',
+          },
+        },
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: RunCodeArgs, ctx: ToolContext): Promise<string> {
+    const bindings = this.getBindings();
+    const code = args.code ?? bindings.getEditorContent();
+    if (!code.trim()) return '(no code to run)';
+
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    return new Promise<string>((resolve, reject) => {
+      let idleTimer: ReturnType<typeof setTimeout> | null = null;
+      let maxTimer: ReturnType<typeof setTimeout> | null = null;
+      let unsubscribe: (() => void) | null = null;
+
+      const cleanup = () => {
+        if (unsubscribe) unsubscribe();
+        if (idleTimer) clearTimeout(idleTimer);
+        if (maxTimer) clearTimeout(maxTimer);
+        ctx.signal?.removeEventListener('abort', onAbort);
+      };
+
+      const finish = () => {
+        cleanup();
+        resolve(buffer);
+      };
+
+      const onAbort = () => {
+        cleanup();
+        reject(new Error('aborted'));
+      };
+
+      unsubscribe = bindings.onData((data) => {
+        buffer += decoder.decode(data);
+        if (idleTimer) clearTimeout(idleTimer);
+        idleTimer = setTimeout(finish, this.idleMs);
+      });
+
+      ctx.signal?.addEventListener('abort', onAbort);
+
+      maxTimer = setTimeout(finish, this.maxMs);
+      // If no output ever arrives we still need a cap — reuse maxMs as the
+      // initial idle window. The first onData call resets it to idleMs.
+      idleTimer = setTimeout(finish, this.maxMs);
+
+      bindings.runCode(code).catch((err) => {
+        cleanup();
+        reject(err);
+      });
+    });
+  }
+}

--- a/src/agent/tools/WriteEditorTool.test.ts
+++ b/src/agent/tools/WriteEditorTool.test.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { WriteEditorTool } from './WriteEditorTool';
+import type { ToolBindings } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => {},
+    getReplHistory: () => [],
+    onData: () => () => {},
+    ...overrides,
+  };
+}
+
+describe('WriteEditorTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new WriteEditorTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('write_editor');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('definition requires the code argument', () => {
+    const tool = new WriteEditorTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required).toEqual(['code']);
+  });
+
+  it('forwards the code to setEditorContent', async () => {
+    const setEditorContent = vi.fn();
+    const tool = new WriteEditorTool(() => makeBindings({ setEditorContent }));
+    await tool.call({ code: 'print(1)' });
+    expect(setEditorContent).toHaveBeenCalledWith('print(1)');
+  });
+
+  it('returns a confirmation string', async () => {
+    const tool = new WriteEditorTool(() => makeBindings());
+    await expect(tool.call({ code: 'x = 1' })).resolves.toBe('Editor updated.');
+  });
+});

--- a/src/agent/tools/WriteEditorTool.ts
+++ b/src/agent/tools/WriteEditorTool.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface WriteEditorArgs {
+  code: string;
+}
+
+export class WriteEditorTool implements Tool<WriteEditorArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'write_editor',
+      description:
+        "Replaces the entire contents of the user's code editor with the given code.",
+      parameters: {
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            description: 'The new code to place in the editor.',
+          },
+        },
+        required: ['code'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: false,
+    };
+  }
+
+  async call(args: WriteEditorArgs): Promise<string> {
+    this.getBindings().setEditorContent(args.code);
+    return 'Editor updated.';
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { ToolRegistry } from '@mast-ai/core';
+import { wireTools, type ToolBindings } from './wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => {},
+    getReplHistory: () => [],
+    onData: () => () => {},
+    ...overrides,
+  };
+}
+
+describe('wireTools', () => {
+  it('registers the four agent tools on first call', () => {
+    const tools = new ToolRegistry();
+    wireTools(tools, makeBindings());
+    const names = tools.getTools().map((t) => t.name).sort();
+    expect(names).toEqual(['read_editor', 'read_repl_history', 'run_code', 'write_editor']);
+  });
+
+  it('does not re-register tools when called again on the same registry', () => {
+    const tools = new ToolRegistry();
+    wireTools(tools, makeBindings());
+    expect(() => wireTools(tools, makeBindings())).not.toThrow();
+    expect(tools.getTools()).toHaveLength(4);
+  });
+
+  it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {
+    const tools = new ToolRegistry();
+    const setFirst = vi.fn();
+    const setSecond = vi.fn();
+
+    wireTools(tools, makeBindings({ setEditorContent: setFirst }));
+    wireTools(tools, makeBindings({ setEditorContent: setSecond }));
+
+    const writer = tools.getTool('write_editor')!;
+    await writer.call({ code: 'x' }, {});
+
+    expect(setFirst).not.toHaveBeenCalled();
+    expect(setSecond).toHaveBeenCalledWith('x');
+  });
+
+  it('isolates bindings per registry', async () => {
+    const a = new ToolRegistry();
+    const b = new ToolRegistry();
+    const setA = vi.fn();
+    const setB = vi.fn();
+    wireTools(a, makeBindings({ setEditorContent: setA }));
+    wireTools(b, makeBindings({ setEditorContent: setB }));
+
+    await a.getTool('write_editor')!.call({ code: 'a' }, {});
+    await b.getTool('write_editor')!.call({ code: 'b' }, {});
+
+    expect(setA).toHaveBeenCalledWith('a');
+    expect(setB).toHaveBeenCalledWith('b');
+  });
+});

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { ToolRegistry } from '@mast-ai/core';
+import { ReadEditorTool } from './tools/ReadEditorTool';
+import { WriteEditorTool } from './tools/WriteEditorTool';
+import { RunCodeTool } from './tools/RunCodeTool';
+import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
+
+export interface ToolBindings {
+  getEditorContent(): string;
+  setEditorContent(code: string): void;
+  runCode(code: string): Promise<void>;
+  getReplHistory(): string[];
+  onData(handler: (data: Uint8Array) => void): () => void;
+}
+
+const REGISTERED = new WeakSet<ToolRegistry>();
+const BINDINGS = new WeakMap<ToolRegistry, ToolBindings>();
+
+export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
+  BINDINGS.set(tools, bindings);
+  if (REGISTERED.has(tools)) return;
+  REGISTERED.add(tools);
+
+  const get = () => {
+    const b = BINDINGS.get(tools);
+    if (!b) throw new Error('Tool registry has no bindings');
+    return b;
+  };
+
+  tools.register(new ReadEditorTool(get));
+  tools.register(new WriteEditorTool(get));
+  tools.register(new RunCodeTool(get));
+  tools.register(new ReadReplHistoryTool(get));
+}


### PR DESCRIPTION
## Summary

Implements the four mast-ai tools that give the coding agent access to the editor and the live MicroPython REPL.

- `read_editor` (`read`) — returns current editor contents
- `write_editor` (`write`) — replaces editor contents
- `run_code` (`write`, **requires approval**) — runs code on the connected device and returns collected REPL output
- `read_repl_history` (`read`) — returns the last N (default 20) buffered REPL lines

Tools are registered into the shared `ToolRegistry` (from `AppModels`) by a new `wireTools(tools, bindings)` helper, called from a `useEffect` in `<App>` once the hooks are ready. `wireTools` registers each tool exactly once per registry and updates the bindings on subsequent calls, so re-renders triggered by `replHistory` updates re-bind the closures without re-registering.

`run_code` subscribes via `bindings.onData` and resolves once the device has been idle for 1 s (configurable via `idleMs`), with a hard cap of 30 s (`maxMs`). The `requiresApproval: true` flag is honoured by the existing `onApprovalRequired` handler in `<App>`, which passes `INLINE_APPROVAL` for `run_code` so the user must confirm before code runs on the device.

`docs/react-migration/SPEC.md` "Agent Tools" was refreshed to match the actual `wireTools(tools, bindings)` signature and document the timeout behaviour.

Closes #23.

## Test plan

- [x] `npm run test` — 24 new tests across the four tools and `wireTools` (107 total, all passing)
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual browser test — confirmed regression-free; live tool calls were exercised by injecting `cobweb:provider-config` into localStorage (the Settings UI lands in #24)