### PR TITLE
feat: settings panel + new-conversation button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useMemo, useState } from 'react';
-import { AgentProvider, ConversationPanel, INLINE_APPROVAL } from '@mast-ai/react-ui';
+import { AgentProvider, INLINE_APPROVAL } from '@mast-ai/react-ui';
 import { AgentRunner } from '@mast-ai/core';
 import { SplitPane } from './components/SplitPane';
 import { StatusBar } from './components/StatusBar';
@@ -10,6 +10,8 @@ import { Toolbar } from './components/Toolbar';
 import { ReplShell } from './components/ReplShell';
 import { CodeEditor } from './components/CodeEditor';
 import { FileNavigator } from './components/FileNavigator';
+import { SettingsPanel } from './components/SettingsPanel';
+import { AgentPanel } from './components/AgentPanel';
 import { useReplConnection } from './hooks/useReplConnection';
 import { useEditor } from './hooks/useEditor';
 import { useProviderConfig } from './hooks/useProviderConfig';
@@ -24,7 +26,7 @@ const models = createModels();
 export function App() {
   const { connectionState, connect, disconnect, reset, runCode, send, onData, replHistory } =
     useReplConnection();
-  const { config } = useProviderConfig();
+  const { config, save: saveConfig, clear: clearConfig } = useProviderConfig();
   const { theme, preference: themePreference, cycle: cycleTheme } = useTheme();
   const { editorRef, getContent, setContent } = useEditor(theme);
 
@@ -52,6 +54,7 @@ export function App() {
     [],
   );
 
+  const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [leftOpen, setLeftOpen] = useState(true);
   const [leftSize, setLeftSize] = useState(20);
   const [rightOpen, setRightOpen] = useState(true);
@@ -78,7 +81,7 @@ export function App() {
           onDisconnect={disconnect}
           onReset={reset}
           onRun={() => runCode(getContent())}
-          onOpenSettings={() => {}}
+          onOpenSettings={() => setIsSettingsOpen(true)}
           isAgentConfigured={config !== null}
           themePreference={themePreference}
           onCycleTheme={cycleTheme}
@@ -115,7 +118,12 @@ export function App() {
                       <ReplShell key="repl" onData={onData} onInput={send} theme={theme} />,
                     ]}
                   </SplitPane>,
-                  <ConversationPanel key="agent" inputPlaceholder="Ask the assistant…" theme={theme} />,
+                  <AgentPanel
+                    key="agent"
+                    theme={theme}
+                    inputPlaceholder="Ask the assistant…"
+                    onResetConversation={() => localStorage.removeItem('cobweb:conversation')}
+                  />,
                 ]}
               </SplitPane>,
             ]}
@@ -132,6 +140,13 @@ export function App() {
           onToggleRight={() => setRightOpen((o) => !o)}
         />
       </div>
+      <SettingsPanel
+        isOpen={isSettingsOpen}
+        onClose={() => setIsSettingsOpen(false)}
+        config={config}
+        onSave={saveConfig}
+        onClear={clearConfig}
+      />
     </AgentProvider>
   );
 }

--- a/src/components/AgentPanel.test.tsx
+++ b/src/components/AgentPanel.test.tsx
@@ -1,0 +1,87 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { AgentPanel } from './AgentPanel';
+import type { UseAgentReturn } from '@mast-ai/react-ui';
+
+const mockUseAgent = vi.fn<() => UseAgentReturn>();
+
+vi.mock('@mast-ai/react-ui', () => ({
+  useAgent: () => mockUseAgent(),
+  ConversationPanel: () => <div data-testid="conversation-panel" />,
+}));
+
+function makeAgentReturn(overrides: Partial<UseAgentReturn> = {}): UseAgentReturn {
+  return {
+    messages: [],
+    history: [],
+    sendMessage: vi.fn(),
+    cancel: vi.fn(),
+    isRunning: false,
+    reset: vi.fn(),
+    pendingApprovals: [],
+    isReady: true,
+    ...overrides,
+  };
+}
+
+describe('AgentPanel', () => {
+  beforeEach(() => {
+    mockUseAgent.mockReset();
+  });
+
+  it('renders the embedded ConversationPanel', () => {
+    mockUseAgent.mockReturnValue(makeAgentReturn());
+    render(<AgentPanel theme="light" />);
+    expect(screen.getByTestId('conversation-panel')).toBeInTheDocument();
+  });
+
+  it('disables the new-conversation button when no messages exist', () => {
+    mockUseAgent.mockReturnValue(makeAgentReturn({ messages: [] }));
+    render(<AgentPanel theme="light" />);
+    expect(screen.getByTitle('New conversation')).toBeDisabled();
+  });
+
+  it('disables the new-conversation button when the agent is not ready', () => {
+    mockUseAgent.mockReturnValue(
+      makeAgentReturn({
+        isReady: false,
+        messages: [{ kind: 'user', id: '1', text: 'hi' } as never],
+      }),
+    );
+    render(<AgentPanel theme="light" />);
+    expect(screen.getByTitle('New conversation')).toBeDisabled();
+  });
+
+  it('enables the button when ready and there is at least one message', () => {
+    mockUseAgent.mockReturnValue(
+      makeAgentReturn({
+        isReady: true,
+        messages: [{ kind: 'user', id: '1', text: 'hi' } as never],
+      }),
+    );
+    render(<AgentPanel theme="light" />);
+    expect(screen.getByTitle('New conversation')).not.toBeDisabled();
+  });
+
+  it('calls reset and onResetConversation when clicked', async () => {
+    const reset = vi.fn();
+    const onResetConversation = vi.fn();
+    mockUseAgent.mockReturnValue(
+      makeAgentReturn({
+        isReady: true,
+        messages: [{ kind: 'user', id: '1', text: 'hi' } as never],
+        reset,
+      }),
+    );
+    render(<AgentPanel theme="light" onResetConversation={onResetConversation} />);
+
+    await userEvent.click(screen.getByTitle('New conversation'));
+
+    expect(reset).toHaveBeenCalledOnce();
+    expect(onResetConversation).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -1,0 +1,41 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { ConversationPanel, useAgent } from '@mast-ai/react-ui';
+import { SquarePen } from 'lucide-react';
+
+interface AgentPanelProps {
+  theme: 'light' | 'dark';
+  inputPlaceholder?: string;
+  onResetConversation?: () => void;
+}
+
+export function AgentPanel({ theme, inputPlaceholder, onResetConversation }: AgentPanelProps) {
+  const { reset, messages, isReady } = useAgent();
+  const hasMessages = messages.length > 0;
+
+  function handleNewConversation() {
+    reset();
+    onResetConversation?.();
+  }
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center justify-between h-8 px-2 border-b border-border bg-muted shrink-0">
+        <span className="text-xs font-medium text-muted-foreground">Assistant</span>
+        <button
+          onClick={handleNewConversation}
+          disabled={!isReady || !hasMessages}
+          title="New conversation"
+          aria-label="New conversation"
+          className="p-1 rounded hover:bg-accent transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <SquarePen size={14} />
+        </button>
+      </div>
+      <div className="flex-1 min-h-0">
+        <ConversationPanel theme={theme} inputPlaceholder={inputPlaceholder} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -1,0 +1,130 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { SettingsPanel } from './SettingsPanel';
+import type { ProviderConfig } from '../providers/types';
+
+function makeDefaults(overrides: Partial<React.ComponentProps<typeof SettingsPanel>> = {}) {
+  return {
+    isOpen: true,
+    onClose: vi.fn(),
+    config: null as ProviderConfig | null,
+    onSave: vi.fn(),
+    onClear: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('SettingsPanel', () => {
+  it('renders nothing when closed', () => {
+    render(<SettingsPanel {...makeDefaults({ isOpen: false })} />);
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
+
+  it('renders the modal when open', () => {
+    render(<SettingsPanel {...makeDefaults()} />);
+    expect(screen.getByText('Settings')).toBeInTheDocument();
+    expect(screen.getByLabelText('API key')).toBeInTheDocument();
+  });
+
+  it('prefills the API key from an existing config', () => {
+    render(
+      <SettingsPanel
+        {...makeDefaults({
+          config: { provider: 'google-genai', apiKey: 'AIza-existing' },
+        })}
+      />,
+    );
+    expect(screen.getByLabelText<HTMLInputElement>('API key').value).toBe('AIza-existing');
+  });
+
+  it('prefills the model from an existing config', () => {
+    render(
+      <SettingsPanel
+        {...makeDefaults({
+          config: { provider: 'google-genai', apiKey: 'AIza', model: 'gemini-2.5-pro' },
+        })}
+      />,
+    );
+    expect(screen.getByLabelText<HTMLSelectElement>('Model').value).toBe('gemini-2.5-pro');
+  });
+
+  it('defaults the model to Gemini 3.1 Flash-Lite Preview when no config is set', () => {
+    render(<SettingsPanel {...makeDefaults()} />);
+    expect(screen.getByLabelText<HTMLSelectElement>('Model').value).toBe(
+      'gemini-3.1-flash-lite-preview',
+    );
+  });
+
+  it('disables Save when API key is empty', () => {
+    render(<SettingsPanel {...makeDefaults()} />);
+    expect(screen.getByRole('button', { name: 'Save' })).toBeDisabled();
+  });
+
+  it('disables Clear when there is no existing config', () => {
+    render(<SettingsPanel {...makeDefaults()} />);
+    expect(screen.getByRole('button', { name: 'Clear' })).toBeDisabled();
+  });
+
+  it('enables Clear when there is an existing config', () => {
+    render(
+      <SettingsPanel
+        {...makeDefaults({
+          config: { provider: 'google-genai', apiKey: 'AIza-existing' },
+        })}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Clear' })).not.toBeDisabled();
+  });
+
+  it('calls onSave with the trimmed API key and selected model, then closes', async () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(<SettingsPanel {...makeDefaults({ onSave, onClose })} />);
+
+    await userEvent.type(screen.getByLabelText('API key'), '  AIza-new  ');
+    await userEvent.selectOptions(screen.getByLabelText('Model'), 'gemini-2.5-flash');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(onSave).toHaveBeenCalledWith({
+      provider: 'google-genai',
+      apiKey: 'AIza-new',
+      model: 'gemini-2.5-flash',
+    });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClear and closes when Clear is clicked', async () => {
+    const onClear = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <SettingsPanel
+        {...makeDefaults({
+          config: { provider: 'google-genai', apiKey: 'AIza-existing' },
+          onClear,
+          onClose,
+        })}
+      />,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+    expect(onClear).toHaveBeenCalledOnce();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Cancel is clicked without saving', async () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(<SettingsPanel {...makeDefaults({ onSave, onClose })} />);
+
+    await userEvent.type(screen.getByLabelText('API key'), 'AIza-new');
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -1,0 +1,146 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { Dialog } from '@base-ui/react/dialog';
+import { useState } from 'react';
+import { X } from 'lucide-react';
+import type { ProviderConfig } from '../providers/types';
+import { Button } from './ui/button';
+
+type ProviderId = 'google-genai';
+
+const GEMINI_MODELS = [
+  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
+  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
+  { id: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash-Lite' },
+  { id: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' },
+  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview' },
+  { id: 'gemini-3.1-flash-lite-preview', label: 'Gemini 3.1 Flash-Lite Preview' },
+] as const;
+
+const DEFAULT_GEMINI_MODEL = 'gemini-3.1-flash-lite-preview';
+
+interface SettingsPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  config: ProviderConfig | null;
+  onSave: (config: ProviderConfig) => void;
+  onClear: () => void;
+}
+
+interface SettingsFormProps {
+  config: ProviderConfig | null;
+  onClose: () => void;
+  onSave: (config: ProviderConfig) => void;
+  onClear: () => void;
+}
+
+function SettingsForm({ config, onClose, onSave, onClear }: SettingsFormProps) {
+  const [provider, setProvider] = useState<ProviderId>('google-genai');
+  const [apiKey, setApiKey] = useState(
+    config?.provider === 'google-genai' ? config.apiKey : '',
+  );
+  const [model, setModel] = useState<string>(
+    config?.provider === 'google-genai' && config.model ? config.model : DEFAULT_GEMINI_MODEL,
+  );
+
+  function handleSave(event: React.FormEvent) {
+    event.preventDefault();
+    const trimmed = apiKey.trim();
+    if (!trimmed) return;
+    onSave({ provider: 'google-genai', apiKey: trimmed, model });
+    onClose();
+  }
+
+  function handleClear() {
+    onClear();
+    onClose();
+  }
+
+  return (
+    <form onSubmit={handleSave}>
+      <div className="flex items-center justify-between px-4 py-3 border-b border-border">
+        <Dialog.Title className="text-sm font-semibold">Settings</Dialog.Title>
+        <Dialog.Close
+          aria-label="Close settings"
+          className="p-1 rounded hover:bg-accent transition-colors"
+        >
+          <X size={14} />
+        </Dialog.Close>
+      </div>
+      <div className="px-4 py-4 flex flex-col gap-3">
+        <Dialog.Description className="text-xs text-muted-foreground">
+          Configure the LLM provider used by the assistant. The API key is stored in this
+          browser&apos;s localStorage.
+        </Dialog.Description>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium">Provider</span>
+          <select
+            value={provider}
+            onChange={(e) => setProvider(e.target.value as ProviderId)}
+            className="h-8 rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <option value="google-genai">Google Gemini</option>
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium">Model</span>
+          <select
+            value={model}
+            onChange={(e) => setModel(e.target.value)}
+            className="h-8 rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {GEMINI_MODELS.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-1.5">
+          <span className="text-xs font-medium">API key</span>
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            autoComplete="off"
+            spellCheck={false}
+            placeholder="AIza..."
+            className="h-8 rounded-md border border-input bg-background px-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          />
+        </label>
+      </div>
+      <div className="flex items-center justify-between gap-2 px-4 py-3 border-t border-border">
+        <Button type="button" variant="destructive" onClick={handleClear} disabled={!config}>
+          Clear
+        </Button>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={!apiKey.trim()}>
+            Save
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}
+
+export function SettingsPanel({ isOpen, onClose, config, onSave, onClear }: SettingsPanelProps) {
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 bg-black/40 z-40 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 transition-opacity duration-150" />
+        <Dialog.Popup className="fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2 w-[min(28rem,calc(100vw-2rem))] rounded-lg border border-border bg-card text-card-foreground shadow-xl outline-none data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[ending-style]:scale-95 transition-all duration-150">
+          {isOpen && (
+            <SettingsForm config={config} onClose={onClose} onSave={onSave} onClear={onClear} />
+          )}
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `<SettingsPanel>` modal to configure the LLM provider (Google Gemini), API key, and model. Six Gemini models exposed in a dropdown (Gemini 2.5 Pro/Flash/Flash-Lite, Gemini 3 Flash Preview, Gemini 3.1 Pro Preview, Gemini 3.1 Flash-Lite Preview — the default).
- Wrap `<ConversationPanel>` in `<AgentPanel>`, which adds a header with a "New conversation" button. Resets the agent via `useAgent().reset()` and clears `cobweb:conversation` from localStorage.
- Wire `<SettingsPanel>` into `<App>`; chat input is disabled until a key is saved.

Closes #24.

## Test plan
- [x] `npm run lint`, `npm run test` (123 tests), `npm run build`
- [x] Settings opens from the toolbar gear icon
- [x] Saving a Gemini API key enables the chat panel
- [x] Selected model persists across reload and is preselected on reopen
- [x] Clearing the API key disables the chat panel again
- [x] "New conversation" button resets the chat; conversation stays empty after reload