### PR TITLE
refactor(queues): tighten Queue/AsyncBlockingQueue API and add tests

### DIFF
--- a/src/Queues.test.ts
+++ b/src/Queues.test.ts
@@ -35,6 +35,26 @@ describe('Queue', () => {
   it('throws when dequeuing from an empty queue', () => {
     expect(() => new Queue().dequeue()).toThrow();
   });
+
+  it('handles drain-then-refill cycles correctly', () => {
+    const q = new Queue<number>();
+    q.enqueue(1);
+    expect(q.dequeue()).toBe(1);
+    expect(q.isEmpty()).toBe(true);
+    q.enqueue(2);
+    q.enqueue(3);
+    expect(q.dequeue()).toBe(2);
+    expect(q.dequeue()).toBe(3);
+    expect(q.isEmpty()).toBe(true);
+  });
+
+  it('clears the tail reference once the queue empties', () => {
+    const q = new Queue<number>();
+    q.enqueue(1);
+    q.dequeue();
+    // Access private field to verify the dequeued node isn't retained.
+    expect((q as unknown as { tail?: unknown }).tail).toBeUndefined();
+  });
 });
 
 describe('AsyncBlockingQueue', () => {
@@ -61,27 +81,59 @@ describe('AsyncBlockingQueue', () => {
     expect(await q.dequeue()).toBe(3);
   });
 
-  it('hasPendingPromises is false after dequeue on empty queue (promise was returned, not buffered)', () => {
+  it('delivers items in FIFO order when consumers wait first', async () => {
+    const q = new AsyncBlockingQueue<number>();
+    const p1 = q.dequeue();
+    const p2 = q.dequeue();
+    const p3 = q.dequeue();
+    q.enqueue(1);
+    q.enqueue(2);
+    q.enqueue(3);
+    expect(await p1).toBe(1);
+    expect(await p2).toBe(2);
+    expect(await p3).toBe(3);
+  });
+
+  it('hasBufferedValues is false after dequeue on empty queue (promise was returned, not buffered)', () => {
     const q = new AsyncBlockingQueue<number>();
     q.dequeue();
-    expect(q.hasPendingPromises()).toBe(false);
+    expect(q.hasBufferedValues()).toBe(false);
   });
 
-  it('hasPendingPromises is true after enqueue with no waiting consumer', () => {
+  it('hasBufferedValues is true after enqueue with no waiting consumer', () => {
     const q = new AsyncBlockingQueue<number>();
     q.enqueue(1);
-    expect(q.hasPendingPromises()).toBe(true);
+    expect(q.hasBufferedValues()).toBe(true);
   });
 
-  it('hasPendingResolvers is true when a dequeue is waiting for data', () => {
+  it('hasWaitingConsumers is true when a dequeue is waiting for data', () => {
     const q = new AsyncBlockingQueue<number>();
     q.dequeue();
-    expect(q.hasPendingResolvers()).toBe(true);
+    expect(q.hasWaitingConsumers()).toBe(true);
   });
 
-  it('hasPendingResolvers is false after enqueue with no waiting consumer', () => {
+  it('hasWaitingConsumers is false after enqueue with no waiting consumer', () => {
     const q = new AsyncBlockingQueue<number>();
     q.enqueue(1);
-    expect(q.hasPendingResolvers()).toBe(false);
+    expect(q.hasWaitingConsumers()).toBe(false);
+  });
+
+  it('clears waiting-consumer state once a matching enqueue arrives', async () => {
+    const q = new AsyncBlockingQueue<number>();
+    const pending = q.dequeue();
+    expect(q.hasWaitingConsumers()).toBe(true);
+    q.enqueue(1);
+    expect(q.hasWaitingConsumers()).toBe(false);
+    expect(q.hasBufferedValues()).toBe(false);
+    expect(await pending).toBe(1);
+  });
+
+  it('clears buffered-value state once a matching dequeue arrives', async () => {
+    const q = new AsyncBlockingQueue<number>();
+    q.enqueue(1);
+    expect(q.hasBufferedValues()).toBe(true);
+    expect(await q.dequeue()).toBe(1);
+    expect(q.hasBufferedValues()).toBe(false);
+    expect(q.hasWaitingConsumers()).toBe(false);
   });
 });

--- a/src/Queues.ts
+++ b/src/Queues.ts
@@ -1,11 +1,13 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-type Resolver<T> = (value?: T) => void;
+/** Callback used to fulfill a pending {@link AsyncBlockingQueue.dequeue} promise. */
+type Resolver<T> = (value: T) => void;
 
+/** Internal singly-linked node used by {@link Queue}. */
 class QueueEntry<T> {
   data: T;
-  next?: QueueEntry<T>
+  next?: QueueEntry<T>;
 
   constructor(data: T) {
     this.data = data;
@@ -13,16 +15,13 @@ class QueueEntry<T> {
 }
 
 /**
- * A linked queue implementation.
+ * A FIFO queue backed by a singly-linked list. Both `enqueue` and `dequeue` run in O(1).
  */
 export class Queue<T> {
-  head?: QueueEntry<T>;
-  tail?: QueueEntry<T>;
+  private head?: QueueEntry<T>;
+  private tail?: QueueEntry<T>;
 
-  /**
-   * Adds an item to the queue.
-   * @param data
-   */
+  /** Appends an item to the back of the queue. */
   enqueue(data: T): void {
     const newNode = new QueueEntry<T>(data);
     if (this.tail) {
@@ -30,16 +29,14 @@ export class Queue<T> {
     }
     this.tail = newNode;
 
-    // Queue is empty. Initialise the head.
     if (!this.head) {
       this.head = this.tail;
     }
   }
 
   /**
-   * Removes an item from the queue and returns it.
-   * @returns {T} the removed item.
-   * @throws an error if the list is empty.
+   * Removes and returns the item at the front of the queue.
+   * @throws Error if the queue is empty — callers should guard with {@link isEmpty}.
    */
   dequeue(): T {
     if (this.isEmpty()) {
@@ -47,29 +44,32 @@ export class Queue<T> {
     }
     const node = this.head!.data;
     this.head = this.head!.next;
+    if (!this.head) {
+      this.tail = undefined;
+    }
     return node;
   }
 
-  /**
-   * Checks if the Queues is empty
-   * @returns {boolean} true if the Queue is empty.
-   */
+  /** Returns `true` when the queue contains no items. */
   isEmpty(): boolean {
     return this.head == null;
   }
 }
 
 /**
- * The AsyncBlockingQueue implements a queue with an asynchronous programming model. Items can
- * be added to the Queue as usual. When dequeing, a Promise is returned.
+ * A FIFO queue with an asynchronous consumer side: {@link dequeue} returns a `Promise` that
+ * resolves with the next available item, or stays pending until one is enqueued. Producers
+ * never block.
  *
- * The promise will resolve instantly if the Queue is not empty. If the Queue is empty, the Promise
- * will be resolved when a new item is added to the queue.
+ * Internally the queue maintains two sub-queues such that exactly one of them is non-empty at
+ * any time: `promiseQueue` holds buffered (already-resolved) values waiting to be consumed,
+ * and `resolverQueue` holds resolvers for promises that have been handed out to consumers.
  */
 export class AsyncBlockingQueue<T> {
   private promiseQueue: Queue<Promise<T>> = new Queue<Promise<T>>();
   private resolverQueue: Queue<Resolver<T>> = new Queue<Resolver<T>>();
 
+  /** Creates a paired promise + resolver, appending each to its respective queue. */
   private add(): void {
     const promise = new Promise<T>(resolve => {
       this.resolverQueue.enqueue(resolve);
@@ -78,8 +78,8 @@ export class AsyncBlockingQueue<T> {
   }
 
   /**
-   * Enqueues an item
-   * @param data
+   * Adds an item to the queue. If a consumer is already waiting, its pending promise is
+   * resolved with `data`; otherwise the value is buffered for the next `dequeue` call.
    */
   enqueue(data: T): void {
     if (this.resolverQueue.isEmpty()) {
@@ -90,22 +90,24 @@ export class AsyncBlockingQueue<T> {
   }
 
   /**
-   * Asynchronously dequeues an item. If the queue is empty, the returned Promise is resolved when
-   * an item is added. Otherwise, it will return one o the existing items.
-   * @returns {Promise<T>} that resolves to the data.
+   * Returns a `Promise` for the next item. Resolves immediately if a value is already
+   * buffered; otherwise resolves when an item is enqueued. Items are delivered in FIFO
+   * order across both producers and consumers.
    */
-  async dequeue(): Promise<T> {
+  dequeue(): Promise<T> {
     if (this.promiseQueue.isEmpty()) {
       this.add();
     }
     return this.promiseQueue.dequeue();
   }
 
-  hasPendingPromises(): boolean {
+  /** Returns `true` when items have been enqueued and are waiting for a consumer. */
+  hasBufferedValues(): boolean {
     return !this.promiseQueue.isEmpty();
   }
 
-  hasPendingResolvers(): boolean {
+  /** Returns `true` when consumers are waiting for items to be enqueued. */
+  hasWaitingConsumers(): boolean {
     return !this.resolverQueue.isEmpty();
   }
 }


### PR DESCRIPTION
## Summary

Hygiene pass on `src/Queues.ts` plus expanded test coverage. No behavioral change for callers.

### Implementation
- **Memory:** `Queue.dequeue` now clears `tail` when the queue empties, so the just-dequeued node isn't retained until the next `enqueue`.
- **Encapsulation:** `Queue.head` / `Queue.tail` and `QueueEntry` are no longer publicly accessible.
- **Type tightening:** `Resolver<T>` changed from `(value?: T) => void` to `(value: T) => void`. The optional was misleading — `resolve(data)` is always called with a real `T`.
- **Naming:** `hasPendingPromises` → `hasBufferedValues`, `hasPendingResolvers` → `hasWaitingConsumers`. After `enqueue`, the entry on `promiseQueue` is already resolved (buffered for a future consumer), not pending — the old names had it backwards. Only `Queues.test.ts` referenced these.
- **Microtask:** dropped redundant `async` from `AsyncBlockingQueue.dequeue`.
- **Docs:** TSDoc on every type, class, and method, including the two-sub-queue invariant of `AsyncBlockingQueue`.

### Tests added
- `Queue` drain-then-refill cycle.
- `Queue` clears `tail` after the queue empties (verifies the leak fix).
- `AsyncBlockingQueue` FIFO when consumers wait first.
- `AsyncBlockingQueue` state-clearing transitions: `dequeue → enqueue` clears `hasWaitingConsumers`; `enqueue → dequeue` clears `hasBufferedValues`.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (128 passing, 17 in `Queues.test.ts`)
- [x] `npm run build`
- [x] Manual smoke test: REPL run + soft reset against a Pico