### PR TITLE
fix(repl): drop stray XOFF prefix from reset and sendRaw

### DIFF
--- a/src/ReplInterface.test.ts
+++ b/src/ReplInterface.test.ts
@@ -141,15 +141,12 @@ describe('ReplInterface', () => {
     // (raw mode), Ctrl-D (soft reset), Ctrl-B (exit raw mode).
     // See https://docs.micropython.org/en/latest/reference/repl.html.
 
-    // Pinned via `it.fails` until #44 lands. When the bug is fixed these tests
-    // will start passing, vitest will flag them as unexpected passes, and the
-    // bug-fix PR should convert them back to plain `it(...)`.
-    it.fails('begins with Ctrl-C twice (0x03 0x03), not XOFF', async () => {
+    it('begins with Ctrl-C twice (0x03 0x03), not XOFF', async () => {
       await repl.reset();
       expect(port.written[0]).toEqual(bytes(0x03, 0x03));
     });
 
-    it.fails('sends Ctrl-A then Ctrl-D then Ctrl-B', async () => {
+    it('sends Ctrl-A then Ctrl-D then Ctrl-B', async () => {
       await repl.reset();
       expect(port.written[1]).toEqual(bytes(0x01));
       expect(port.written[2]).toEqual(bytes(0x04));
@@ -163,8 +160,7 @@ describe('ReplInterface', () => {
   });
 
   describe('sendRaw', () => {
-    // Pinned via `it.fails` until #44 lands; see note in the `reset` block.
-    it.fails('opens with Ctrl-C twice and Ctrl-A', async () => {
+    it('opens with Ctrl-C twice and Ctrl-A', async () => {
       await repl.sendRaw('print(1)');
       expect(port.written[0]).toEqual(bytes(0x03, 0x03));
       expect(port.written[1]).toEqual(bytes(0x01));

--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -43,10 +43,10 @@ export class ReplInterface extends EventTarget {
   async reset() {
     console.log('>>><RESET>')
     // ctrl-C twice: interrupt any running program
-    await this.writer.write(Uint8Array.from([0x13, 0x03, 0x03]));
-    
+    await this.writer.write(Uint8Array.from([0x03, 0x03]));
+
     // Ctrl-A: enter raw REPL
-    await this.writer.write(Uint8Array.from([0x13, 0x01]));
+    await this.writer.write(Uint8Array.from([0x01]));
     
     //  ctrl-D: soft reset
     await this.writer.write(Uint8Array.from([0x04]));
@@ -62,8 +62,8 @@ export class ReplInterface extends EventTarget {
 
   async sendRaw(content: string) {
     console.log('>>>(raw): ', content);
-    await this.writer.write(Uint8Array.from([0x13, 0x03, 0x03]));
-    await this.writer.write(Uint8Array.from([0x13, 0x01]));
+    await this.writer.write(Uint8Array.from([0x03, 0x03]));
+    await this.writer.write(Uint8Array.from([0x01]));
     content.split('\n').forEach(
         async line => await this.writer.write(this.encoder.encode(line + '\r'))
     );


### PR DESCRIPTION
## Summary
- `reset()` and `sendRaw()` in `src/ReplInterface.ts` were prefixing every Ctrl-C and Ctrl-A write with `0x13` (XOFF), which tells the device to pause its UART output — the opposite of the intended interrupt / enter-raw-mode behavior.
- Send only the documented control bytes: `[0x03, 0x03]` for Ctrl-C twice and `[0x01]` for Ctrl-A.
- Unpin the three `ReplInterface.test.ts` cases that were left as `it.fails` waiting on this fix.

Closes #44

## Test plan
- [x] `npm run test` — 142/142 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Manual: Run from the editor (single- and multi-line) prints output promptly
- [x] Manual: Soft reset interrupts a running loop and reboots the board