### PR TITLE
fix(repl): await each line write in sendRaw so failures propagate

### DIFF
--- a/src/ReplInterface.test.ts
+++ b/src/ReplInterface.test.ts
@@ -14,6 +14,13 @@ class FakeSerialPort {
   writableClosed = false;
   readableCancelled = false;
 
+  /**
+   * Optional hook letting tests fail a specific write. Return an Error to
+   * reject the underlying sink (which errors the stream), or null/undefined
+   * to accept the chunk normally.
+   */
+  shouldRejectWrite?: (chunk: Uint8Array, index: number) => Error | null | undefined;
+
   writable: WritableStream<Uint8Array>;
   readable: ReadableStream<Uint8Array>;
 
@@ -22,8 +29,10 @@ class FakeSerialPort {
   constructor() {
     this.writable = new WritableStream<Uint8Array>({
       write: (chunk) => {
-        // Copy so later mutation by the SUT can't affect what we captured.
-        this.written.push(new Uint8Array(chunk));
+        const copy = new Uint8Array(chunk);
+        const err = this.shouldRejectWrite?.(copy, this.written.length);
+        if (err) throw err;
+        this.written.push(copy);
       },
       close: () => {
         this.writableClosed = true;
@@ -191,6 +200,34 @@ describe('ReplInterface', () => {
       await repl.sendRaw('');
       const body = port.written.slice(2, -2);
       expect(body).toEqual([encode('\r')]);
+    });
+
+    it('rejects when a line write fails mid-payload, with no unhandled rejections', async () => {
+      const failure = new Error('device disconnected');
+      const target = encode('b\r');
+      port.shouldRejectWrite = (chunk) => {
+        if (chunk.length === target.length && chunk.every((b, i) => b === target[i])) {
+          return failure;
+        }
+        return null;
+      };
+
+      // The original forEach-based implementation discarded each line write's
+      // promise, so a mid-payload failure surfaced as an unhandled rejection
+      // even though sendRaw still rejected (via the errored-stream epilogue).
+      // Verify both: sendRaw rejects with the original failure AND no rejection
+      // is left dangling.
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        await expect(repl.sendRaw('a\nb\nc')).rejects.toBe(failure);
+        // Let queued microtasks settle so any orphaned rejection surfaces.
+        await new Promise((r) => setTimeout(r, 0));
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
     });
   });
 

--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -64,9 +64,9 @@ export class ReplInterface extends EventTarget {
     console.log('>>>(raw): ', content);
     await this.writer.write(Uint8Array.from([0x03, 0x03]));
     await this.writer.write(Uint8Array.from([0x01]));
-    content.split('\n').forEach(
-        async line => await this.writer.write(this.encoder.encode(line + '\r'))
-    );
+    for (const line of content.split('\n')) {
+      await this.writer.write(this.encoder.encode(line + '\r'));
+    }
     await this.writer.write(Uint8Array.from([0x04]));
     await this.writer.write(Uint8Array.from([0x02]));    
   }


### PR DESCRIPTION
## Summary
- Replace `forEach(async ...)` with `for...of` in `ReplInterface.sendRaw()` so a mid-payload line write failure rejects the call instead of becoming an unhandled promise rejection.
- Extend `FakeSerialPort` with a `shouldRejectWrite` hook and add a regression test that injects a failure on the second line write of `sendRaw('a\nb\nc')`, asserting both that the call rejects with the original error AND that no rejection is left dangling. (The dangling-rejection check is what actually distinguishes the bug — the buggy version still rejects via the errored-stream epilogue, but leaves two unhandled rejections behind.)

Closes #45

## Test plan
- [x] `npm run test` — 143/143 pass
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] Manual: single-line run, multi-line run, run with blank lines, reset — all behave as before
- [x] Confirmed the new test fails on the pre-fix code (2 unhandled rejections) and passes on the fixed code