### PR TITLE
chore(repl): clean up typo, dead fields, and debug logs

### DIFF
--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -1,8 +1,6 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-export type ReplMode = 'normal' | 'paste' | 'raw' | 'raw-paste';
-
 /**
  * An implementation of the MicroPython REPL interface. Documentation for the interface itself
  * is available at https://docs.micropython.org/en/latest/reference/repl.html.
@@ -11,8 +9,6 @@ export class ReplInterface extends EventTarget {
   private writer: WritableStreamDefaultWriter<Uint8Array>;
   private reader: ReadableStreamDefaultReader<Uint8Array>;
   private encoder = new TextEncoder();
-  private decoder = new TextDecoder();
-  private mode: ReplMode = 'normal';
 
   constructor(private port: SerialPort) {
     super();
@@ -41,7 +37,6 @@ export class ReplInterface extends EventTarget {
   }
 
   async reset() {
-    console.log('>>><RESET>')
     // ctrl-C twice: interrupt any running program
     await this.writer.write(Uint8Array.from([0x03, 0x03]));
 
@@ -56,12 +51,10 @@ export class ReplInterface extends EventTarget {
   }
 
   async send(content: string) {
-    console.log('>>>: ', content);
-    await this.writer.write(this.encoder.encode(content));      
+    await this.writer.write(this.encoder.encode(content));
   }
 
   async sendRaw(content: string) {
-    console.log('>>>(raw): ', content);
     await this.writer.write(Uint8Array.from([0x03, 0x03]));
     await this.writer.write(Uint8Array.from([0x01]));
     for (const line of content.split('\n')) {
@@ -72,7 +65,7 @@ export class ReplInterface extends EventTarget {
   }
 
   static async connect(
-        boundRate: number = 115200,
+        baudRate: number = 115200,
         dataBits: number = 8,
         stopBits: number = 1): Promise<ReplInterface> {
     if (!navigator.serial) {
@@ -80,7 +73,7 @@ export class ReplInterface extends EventTarget {
     }
     const port = await navigator.serial!.requestPort();
     await port.open({
-      baudRate: boundRate,
+      baudRate: baudRate,
       dataBits: dataBits,
       stopBits: stopBits,
     });


### PR DESCRIPTION
## Summary
- Rename `boundRate` parameter → `baudRate` in `ReplInterface.connect()` (typo on a public static method).
- Remove unused `decoder` and `mode` fields, plus the now-orphaned `ReplMode` type. `mode` was initialized but never read or written, even though the class transitions through raw mode — if/when that gets state-tracked properly, it should come back as a real state machine.
- Drop debug `console.log` calls from `reset()`, `send()`, and `sendRaw()` so they no longer ship to end users.

No runtime behaviour change.

Closes #46

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test` clean (143 passing)
- [x] Manually verified connect / reset / run-code / sendRaw still work against a real microcontroller