### PR TITLE
fix(repl): catch readLoop errors and dispatch disconnect event

### DIFF
--- a/src/ReplInterface.test.ts
+++ b/src/ReplInterface.test.ts
@@ -62,6 +62,14 @@ class FakeSerialPort {
     }
   }
 
+  errorReadable(reason: unknown) {
+    try {
+      this.readableController.error(reason);
+    } catch {
+      // Already closed or errored.
+    }
+  }
+
   async close() {
     this.closed = true;
   }
@@ -120,6 +128,52 @@ describe('ReplInterface', () => {
       port.inject([0x02, 0x03]);
       await allReceived;
       expect(seen).toEqual([bytes(0x01), bytes(0x02, 0x03)]);
+    });
+  });
+
+  describe('disconnect event', () => {
+    it('fires when the readable stream errors (e.g. cable unplug)', async () => {
+      const failure = new Error('device disconnected');
+      const event = await new Promise<CustomEvent<{error: unknown}>>((resolve) => {
+        repl.addEventListener(
+          'disconnect',
+          (e) => resolve(e as CustomEvent<{error: unknown}>),
+          {once: true},
+        );
+        port.errorReadable(failure);
+      });
+      expect(event.detail?.error).toBe(failure);
+    });
+
+    it('fires when the readable stream closes cleanly, with no error detail', async () => {
+      const event = await new Promise<CustomEvent<{error: unknown} | null>>((resolve) => {
+        repl.addEventListener(
+          'disconnect',
+          (e) => resolve(e as CustomEvent<{error: unknown} | null>),
+          {once: true},
+        );
+        port.endReadable();
+      });
+      expect(event.detail).toBeNull();
+    });
+
+    it('does not leave an unhandled rejection when the readable stream errors', async () => {
+      const failure = new Error('device disconnected');
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        const seen = new Promise<void>((resolve) => {
+          repl.addEventListener('disconnect', () => resolve(), {once: true});
+        });
+        port.errorReadable(failure);
+        await seen;
+        // Let queued microtasks settle so any orphaned rejection surfaces.
+        await new Promise((r) => setTimeout(r, 0));
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
     });
   });
 

--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -14,20 +14,37 @@ export class ReplInterface extends EventTarget {
     super();
     this.writer = port.writable.getWriter()
     this.reader = port.readable.getReader();
-    this.readLoop();
+    // Safety net: readLoop already catches its own errors, but if anything
+    // ever escapes, surface it instead of leaving an unhandled rejection.
+    this.readLoop().catch((error) => {
+      this.dispatchEvent(new CustomEvent('disconnect', {detail: {error}}));
+    });
   }
 
   private async readLoop() {
-    while (true) {
-      const {value, done} = await this.reader.read();
-      if (value) {
-        this.dispatchEvent(new CustomEvent('data', {detail: value}));
+    let error: unknown;
+    try {
+      while (true) {
+        const {value, done} = await this.reader.read();
+        if (value) {
+          this.dispatchEvent(new CustomEvent('data', {detail: value}));
+        }
+        if (done) {
+          break;
+        }
       }
-      if (done) {
+    } catch (err) {
+      error = err;
+    } finally {
+      try {
         this.reader.releaseLock();
-        break;
+      } catch {
+        // Already released or stream is in an error state.
       }
     }
+    this.dispatchEvent(
+      new CustomEvent('disconnect', error ? {detail: {error}} : undefined),
+    );
   }
 
   async disconnect() {

--- a/src/hooks/useReplConnection.test.ts
+++ b/src/hooks/useReplConnection.test.ts
@@ -96,6 +96,20 @@ describe('useReplConnection', () => {
     expect(result.current.replHistory).toContain('line2');
   });
 
+  it("transitions to 'disconnected' when the repl dispatches a 'disconnect' event", async () => {
+    const { result } = renderHook(() => useReplConnection());
+    await act(() => result.current.connect());
+    expect(result.current.connectionState).toBe('connected');
+
+    act(() => {
+      (mockRepl as unknown as EventTarget).dispatchEvent(
+        new CustomEvent('disconnect', { detail: { error: new Error('cable yanked') } }),
+      );
+    });
+
+    expect(result.current.connectionState).toBe('disconnected');
+  });
+
   it('onData returns unsubscribe that stops delivery', async () => {
     const { result } = renderHook(() => useReplConnection());
     await act(() => result.current.connect());

--- a/src/hooks/useReplConnection.ts
+++ b/src/hooks/useReplConnection.ts
@@ -16,6 +16,7 @@ export function useReplConnection() {
   const textBufferRef = useRef('');
   const decoderRef = useRef(new TextDecoder());
   const dataListenerRef = useRef<((e: Event) => void) | null>(null);
+  const disconnectListenerRef = useRef<((e: Event) => void) | null>(null);
 
   const handleData = useCallback((data: Uint8Array) => {
     handlersRef.current.forEach((h) => h(data));
@@ -32,9 +33,24 @@ export function useReplConnection() {
 
   const connect = useCallback(async () => {
     const repl = await ReplInterface.connect();
-    const listener = (e: Event) => handleData((e as CustomEvent<Uint8Array>).detail);
-    repl.addEventListener('data', listener);
-    dataListenerRef.current = listener;
+    const dataListener = (e: Event) => handleData((e as CustomEvent<Uint8Array>).detail);
+    // Fires when the device-side connection drops (cable yanked, USB error,
+    // EOF). Explicit user-initiated disconnect removes this before it can fire.
+    const disconnectListener = () => {
+      if (replRef.current === repl) {
+        replRef.current = null;
+      }
+      if (dataListenerRef.current) {
+        repl.removeEventListener('data', dataListenerRef.current);
+        dataListenerRef.current = null;
+      }
+      disconnectListenerRef.current = null;
+      setConnectionState('disconnected');
+    };
+    repl.addEventListener('data', dataListener);
+    repl.addEventListener('disconnect', disconnectListener, {once: true});
+    dataListenerRef.current = dataListener;
+    disconnectListenerRef.current = disconnectListener;
     replRef.current = repl;
     setConnectionState('connected');
   }, [handleData]);
@@ -45,6 +61,10 @@ export function useReplConnection() {
       if (dataListenerRef.current) {
         repl.removeEventListener('data', dataListenerRef.current);
         dataListenerRef.current = null;
+      }
+      if (disconnectListenerRef.current) {
+        repl.removeEventListener('disconnect', disconnectListenerRef.current);
+        disconnectListenerRef.current = null;
       }
       await repl.disconnect();
       replRef.current = null;


### PR DESCRIPTION
## Summary

`ReplInterface.readLoop()` previously let `reader.read()` rejections (cable yanked, USB transient, OS-level serial failure) propagate out as an unhandled rejection — and the constructor discarded the loop's promise, so the UI had no way to learn the connection had dropped.

- Wrap the read loop body in `try`/`catch`/`finally`. Release the reader lock in `finally` regardless of how the loop ended.
- Dispatch a `'disconnect'` event when the loop terminates. If an error caused termination, the event's `detail` carries `{error}`; on clean EOF, `detail` is `null`.
- Attach a `.catch()` to the constructor's fire-and-forget `readLoop()` call as a final safety net.
- `useReplConnection` listens for `'disconnect'` and transitions `connectionState` to `'disconnected'`, clearing the ref and removing the data listener. Explicit user-initiated `disconnect()` removes the listener first so it doesn't double-fire.

## Test plan

- [x] `npm run test` — added three tests in `ReplInterface.test.ts` (stream error → event with error detail; clean close → event with no error detail; no unhandled rejection on stream error) and one test in `useReplConnection.test.ts` (hook flips to `'disconnected'` on event).
- [x] `npm run lint`, `npm run build` clean.
- [x] Manual: unplugged the device mid-session — UI now updates to "disconnected" instead of looking idle.

## Scope

This PR addresses #47 only. It also resolves item (1) and the "UI is informed" criterion of #54, but #54 has additional points (writer-side errors in `disconnect()`/`reset()`/`send()`/`sendRaw()`, plus missing `.catch()` in the hook's call sites) that remain open. See [comment on #54](https://github.com/andreban/cobweb/issues/54#issuecomment-4373494952).

Closes #47.