### PR TITLE
fix(repl): serialize concurrent writes in ReplInterface

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -29,6 +29,7 @@ Wraps the Web Serial API and implements the MicroPython raw-REPL protocol.
 - **Reset:** sends Ctrl-D in normal mode or calls `port.close()` + re-open sequence.
 - **Output:** extends `EventTarget`; dispatches `'data'` events (`CustomEvent<Uint8Array>`) as bytes arrive from the device.
 - **Async coordination:** uses `AsyncBlockingQueue<Uint8Array>` from `src/Queues.ts` to serialise reads from the underlying `ReadableStream`.
+- **Write serialisation:** `send`, `sendRaw`, and `reset` are mutually exclusive end-to-end via an internal single-slot promise chain, so one caller's prologue cannot interleave with another's body in the underlying `WritableStream`. `disconnect` deliberately does not take this lock — it relies on `WritableStreamDefaultWriter.close()` to flush queued chunks.
 
 #### `CodeEditor`
 

--- a/src/ReplInterface.test.ts
+++ b/src/ReplInterface.test.ts
@@ -197,6 +197,21 @@ describe('ReplInterface', () => {
       expect(port.readableCancelled).toBe(true);
       expect(port.closed).toBe(true);
     });
+
+    it('does not deadlock when called while a sendRaw is in flight', async () => {
+      // disconnect must not wait on the write-serialization chain — if it did,
+      // a stalled write would prevent the writer from ever closing. We start
+      // a sendRaw and immediately disconnect; both promises must settle.
+      const sendPromise = repl.sendRaw('print(1)').catch(() => undefined);
+      const disconnectPromise = repl.disconnect();
+      await Promise.race([
+        Promise.all([sendPromise, disconnectPromise]),
+        new Promise((_, reject) =>
+          setTimeout(() => reject(new Error('disconnect deadlocked')), 1000),
+        ),
+      ]);
+      expect(port.writableClosed).toBe(true);
+    });
   });
 
   describe('reset', () => {
@@ -254,6 +269,56 @@ describe('ReplInterface', () => {
       await repl.sendRaw('');
       const body = port.written.slice(2, -2);
       expect(body).toEqual([encode('\r')]);
+    });
+
+    it('serializes concurrent calls so each prologue/body/epilogue runs contiguously', async () => {
+      // Two sendRaw calls in flight at the same time. Without a write mutex,
+      // the WritableStream's per-chunk queueing interleaves them: caller A
+      // enqueues its prologue, yields, caller B enqueues *its* prologue
+      // before A's body lands. End result on the wire is something like
+      // [A.Ctrl-CC, B.Ctrl-CC, A.Ctrl-A, B.Ctrl-A, ...] which breaks the
+      // raw-REPL state machine on the device.
+      await Promise.all([repl.sendRaw('a'), repl.sendRaw('b')]);
+
+      // Each sendRaw produces 5 chunks: Ctrl-CC, Ctrl-A, body, Ctrl-D, Ctrl-B.
+      expect(port.written).toHaveLength(10);
+
+      // First call's full sequence must appear before second call begins.
+      expect(port.written.slice(0, 5)).toEqual([
+        bytes(0x03, 0x03),
+        bytes(0x01),
+        encode('a\r'),
+        bytes(0x04),
+        bytes(0x02),
+      ]);
+      expect(port.written.slice(5, 10)).toEqual([
+        bytes(0x03, 0x03),
+        bytes(0x01),
+        encode('b\r'),
+        bytes(0x04),
+        bytes(0x02),
+      ]);
+    });
+
+    it('still serializes the next call after the previous one rejects mid-payload', async () => {
+      const failure = new Error('device hiccup');
+      const target = encode('a\r');
+      port.shouldRejectWrite = (chunk) => {
+        if (chunk.length === target.length && chunk.every((b, i) => b === target[i])) {
+          // One-shot: clear the hook so subsequent calls succeed.
+          port.shouldRejectWrite = undefined;
+          return failure;
+        }
+        return null;
+      };
+
+      const failed = repl.sendRaw('a');
+      const next = repl.sendRaw('b');
+      await expect(failed).rejects.toBe(failure);
+      // `next` must still run — a failed task shouldn't poison the chain. But
+      // the writable stream itself errors on the rejected write, so this call
+      // rejects too; what matters is that it actually attempts to run.
+      await expect(next).rejects.toBeDefined();
     });
 
     it('rejects when a line write fails mid-payload, with no unhandled rejections', async () => {

--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -9,6 +9,11 @@ export class ReplInterface extends EventTarget {
   private writer: WritableStreamDefaultWriter<Uint8Array>;
   private reader: ReadableStreamDefaultReader<Uint8Array>;
   private encoder = new TextEncoder();
+  // Tail of the write-serialization chain. Public write methods (`send`,
+  // `sendRaw`, `reset`) chain off this so each runs to completion before the
+  // next begins, preventing one caller's prologue from interleaving with
+  // another's body in the underlying WritableStream queue.
+  private writeChain: Promise<void> = Promise.resolve();
 
   constructor(private port: SerialPort) {
     super();
@@ -19,6 +24,20 @@ export class ReplInterface extends EventTarget {
     this.readLoop().catch((error) => {
       this.dispatchEvent(new CustomEvent('disconnect', {detail: {error}}));
     });
+  }
+
+  /**
+   * Runs `task` mutually exclusive with every other call routed through this
+   * method. Failures of one task don't break the chain — the next task still
+   * runs — but they do propagate to the caller of the failing task.
+   */
+  private runExclusive<T>(task: () => Promise<T>): Promise<T> {
+    const result = this.writeChain.then(task);
+    this.writeChain = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   private async readLoop() {
@@ -53,32 +72,38 @@ export class ReplInterface extends EventTarget {
     await this.port.close();
   }
 
-  async reset() {
-    // ctrl-C twice: interrupt any running program
-    await this.writer.write(Uint8Array.from([0x03, 0x03]));
+  reset() {
+    return this.runExclusive(async () => {
+      // ctrl-C twice: interrupt any running program
+      await this.writer.write(Uint8Array.from([0x03, 0x03]));
 
-    // Ctrl-A: enter raw REPL
-    await this.writer.write(Uint8Array.from([0x01]));
-    
-    //  ctrl-D: soft reset
-    await this.writer.write(Uint8Array.from([0x04]));
+      // Ctrl-A: enter raw REPL
+      await this.writer.write(Uint8Array.from([0x01]));
 
-    // ctrl+B: exit raw REPL
-    await this.writer.write(Uint8Array.from([0x02]));    
+      //  ctrl-D: soft reset
+      await this.writer.write(Uint8Array.from([0x04]));
+
+      // ctrl+B: exit raw REPL
+      await this.writer.write(Uint8Array.from([0x02]));
+    });
   }
 
-  async send(content: string) {
-    await this.writer.write(this.encoder.encode(content));
+  send(content: string) {
+    return this.runExclusive(async () => {
+      await this.writer.write(this.encoder.encode(content));
+    });
   }
 
-  async sendRaw(content: string) {
-    await this.writer.write(Uint8Array.from([0x03, 0x03]));
-    await this.writer.write(Uint8Array.from([0x01]));
-    for (const line of content.split('\n')) {
-      await this.writer.write(this.encoder.encode(line + '\r'));
-    }
-    await this.writer.write(Uint8Array.from([0x04]));
-    await this.writer.write(Uint8Array.from([0x02]));    
+  sendRaw(content: string) {
+    return this.runExclusive(async () => {
+      await this.writer.write(Uint8Array.from([0x03, 0x03]));
+      await this.writer.write(Uint8Array.from([0x01]));
+      for (const line of content.split('\n')) {
+        await this.writer.write(this.encoder.encode(line + '\r'));
+      }
+      await this.writer.write(Uint8Array.from([0x04]));
+      await this.writer.write(Uint8Array.from([0x02]));
+    });
   }
 
   static async connect(


### PR DESCRIPTION
## Summary
- `send`, `sendRaw`, and `reset` now run through a single-slot promise-chain mutex (`writeChain` + `runExclusive`) so one method's prologue can no longer interleave with another's body in the underlying `WritableStream` queue.
- `disconnect` deliberately stays out of the lock — `writer.close()` already flushes queued chunks, and skipping the lock keeps disconnect responsive even when a write is stalled.
- Documented the write-serialisation guarantee in `docs/SPEC.md`.

## Why
`WritableStream` preserves byte order within one `write()` chain but not across concurrent callers. xterm.js forwards user keystrokes back to the device via `send()` while a Run-from-editor `sendRaw()` is in flight, so this latent bug is reachable in practice — the raw-REPL state machine sees Ctrl-CC, Ctrl-CC, Ctrl-A, Ctrl-A, body, body, … and breaks.

## Test plan
- [x] `npm run test` — 150 passed, including:
  - `sendRaw` › serializes concurrent calls so each prologue/body/epilogue runs contiguously (verified to fail before the fix)
  - `sendRaw` › still serializes the next call after the previous one rejects mid-payload
  - `disconnect` › does not deadlock when called while a sendRaw is in flight
- [x] `npm run lint`
- [x] `npm run build`
- [x] Manual smoke test in browser: connect, Run, hammer keystrokes mid-Run, Reset — confirmed working by repo owner.

Closes #48