### PR TITLE
feat(repl): parse raw-REPL response, surface stdout/stderr

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -30,6 +30,7 @@ Wraps the Web Serial API and implements the MicroPython raw-REPL protocol.
 - **Output:** extends `EventTarget`; dispatches `'data'` events (`CustomEvent<Uint8Array>`) as bytes arrive from the device.
 - **Async coordination:** uses `AsyncBlockingQueue<Uint8Array>` from `src/Queues.ts` to serialise reads from the underlying `ReadableStream`.
 - **Write serialisation:** `send`, `sendRaw`, and `reset` are mutually exclusive end-to-end via an internal single-slot promise chain, so one caller's prologue cannot interleave with another's body in the underlying `WritableStream`. `disconnect` deliberately does not take this lock — it relies on `WritableStreamDefaultWriter.close()` to flush queued chunks.
+- **Raw-REPL response parsing:** `sendRaw(code, timeoutMs?)` returns `Promise<{stdout: string, stderr: string}>`. While a call is in flight, the read loop also feeds incoming bytes to an internal state machine that walks the protocol phases (banner → `OK` → stdout → `\x04` → stderr → `\x04`) and resolves after the second `\x04`. The `'data'` event is still fired with the full byte stream so the xterm mirror is unaffected. On timeout (default 30 s) or device disconnect, the call rejects; the `Ctrl-B` epilogue is sent best-effort either way so the device leaves raw mode.
 
 #### `CodeEditor`
 

--- a/docs/react-migration/SPEC.md
+++ b/docs/react-migration/SPEC.md
@@ -136,7 +136,7 @@ Registered into the shared `ToolRegistry` from `AppModels` at startup, before an
 export interface ToolBindings {
   getEditorContent(): string;
   setEditorContent(code: string): void;
-  runCode(code: string): Promise<void>;
+  runCode(code: string): Promise<{stdout: string; stderr: string}>;
   getReplHistory(): string[];
   onData(handler: (data: Uint8Array) => void): () => void;
 }
@@ -158,7 +158,7 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void;
 ### `RunCodeTool`
 - scope: `'write'`, `requiresApproval: true`
 - Args: `{ code?: string }` — if omitted, runs the current editor content.
-- Sends code to the REPL via `bindings.runCode`; subscribes via `bindings.onData` and resolves with the collected REPL output once the device has been idle for `idleMs` (default 1 s), capped at `maxMs` (default 30 s).
+- Sends code to the REPL via `bindings.runCode`, which now parses the raw-REPL response and resolves with `{stdout, stderr}`. The tool formats those into a single string for the agent (labels stderr when present), instead of relying on idle/max output timers.
 
 ### `ReadReplHistoryTool`
 - scope: `'read'`
@@ -261,7 +261,7 @@ Owns the `ReplInterface` lifecycle. `connect()` calls `ReplInterface.connect()` 
   connect(): Promise<void>,
   disconnect(): Promise<void>,
   reset(): Promise<void>,
-  runCode(code: string): Promise<void>,
+  runCode(code: string): Promise<{stdout: string; stderr: string}>,
   replHistory: string[],            // last N lines, for ReadReplHistoryTool
   onData(handler: (data: Uint8Array) => void): () => void,
 }

--- a/src/ReplInterface.test.ts
+++ b/src/ReplInterface.test.ts
@@ -21,6 +21,13 @@ class FakeSerialPort {
    */
   shouldRejectWrite?: (chunk: Uint8Array, index: number) => Error | null | undefined;
 
+  /**
+   * Optional hook fired after each successful write. Tests use it to inject
+   * device responses synchronously in lockstep with the SUT's protocol writes
+   * (e.g. emit the raw banner the moment the SUT sends Ctrl-A).
+   */
+  onWrite?: (chunk: Uint8Array, index: number) => void;
+
   writable: WritableStream<Uint8Array>;
   readable: ReadableStream<Uint8Array>;
 
@@ -32,7 +39,9 @@ class FakeSerialPort {
         const copy = new Uint8Array(chunk);
         const err = this.shouldRejectWrite?.(copy, this.written.length);
         if (err) throw err;
+        const index = this.written.length;
         this.written.push(copy);
+        this.onWrite?.(copy, index);
       },
       close: () => {
         this.writableClosed = true;
@@ -87,6 +96,39 @@ const concat = (chunks: Uint8Array[]): Uint8Array => {
     off += c.length;
   }
   return out;
+};
+
+/**
+ * A minimal canned raw-REPL response: banner, OK, the supplied stdout/stderr,
+ * the two `\x04` framing bytes, and the trailing `>`.
+ */
+const okResponse = (stdout = '', stderr = ''): Uint8Array =>
+  concat([
+    encode('\r\nraw REPL; CTRL-B to exit\r\n>OK'),
+    encode(stdout),
+    bytes(0x04),
+    encode(stderr),
+    bytes(0x04),
+    encode('>'),
+  ]);
+
+/**
+ * Auto-respond to any `sendRaw` issued during the test: when the SUT writes
+ * Ctrl-D (the last protocol write before it begins waiting), inject the
+ * canned response. Returns an unsubscribe so tests that need finer control
+ * can disable the auto-reply.
+ */
+const autoRespond = (port: FakeSerialPort, response: Uint8Array = okResponse()): (() => void) => {
+  const previous = port.onWrite;
+  port.onWrite = (chunk, index) => {
+    previous?.(chunk, index);
+    if (chunk.length === 1 && chunk[0] === 0x04) {
+      port.inject(response);
+    }
+  };
+  return () => {
+    port.onWrite = previous;
+  };
 };
 
 describe('ReplInterface', () => {
@@ -201,7 +243,8 @@ describe('ReplInterface', () => {
     it('does not deadlock when called while a sendRaw is in flight', async () => {
       // disconnect must not wait on the write-serialization chain — if it did,
       // a stalled write would prevent the writer from ever closing. We start
-      // a sendRaw and immediately disconnect; both promises must settle.
+      // a sendRaw (no auto-response, so the parser is hanging) and immediately
+      // disconnect; both promises must settle.
       const sendPromise = repl.sendRaw('print(1)').catch(() => undefined);
       const disconnectPromise = repl.disconnect();
       await Promise.race([
@@ -211,6 +254,14 @@ describe('ReplInterface', () => {
         ),
       ]);
       expect(port.writableClosed).toBe(true);
+    });
+
+    it('rejects an in-flight sendRaw when the read loop ends', async () => {
+      const failure = new Error('device disconnected');
+      const sendPromise = repl.sendRaw('print(1)');
+      // Bytes start arriving but the response never completes (no \x04 pair).
+      port.errorReadable(failure);
+      await expect(sendPromise).rejects.toBe(failure);
     });
   });
 
@@ -237,14 +288,16 @@ describe('ReplInterface', () => {
     });
   });
 
-  describe('sendRaw', () => {
+  describe('sendRaw — protocol writes', () => {
     it('opens with Ctrl-C twice and Ctrl-A', async () => {
+      autoRespond(port);
       await repl.sendRaw('print(1)');
       expect(port.written[0]).toEqual(bytes(0x03, 0x03));
       expect(port.written[1]).toEqual(bytes(0x01));
     });
 
     it('terminates with Ctrl-D then Ctrl-B', async () => {
+      autoRespond(port);
       await repl.sendRaw('print(1)');
       const last = port.written.length - 1;
       expect(port.written[last - 1]).toEqual(bytes(0x04));
@@ -252,38 +305,54 @@ describe('ReplInterface', () => {
     });
 
     it('writes a single-line payload as `<line>\\r`', async () => {
+      autoRespond(port);
       await repl.sendRaw('print(1)');
       const body = port.written.slice(2, -2);
       expect(body).toEqual([encode('print(1)\r')]);
     });
 
     it('writes each line of a multi-line payload in order, CR-terminated, before Ctrl-D', async () => {
+      autoRespond(port);
       await repl.sendRaw('a\nb\nc');
       const body = port.written.slice(2, -2);
       expect(body).toEqual([encode('a\r'), encode('b\r'), encode('c\r')]);
-      // And the body sits between the prologue and the Ctrl-D / Ctrl-B epilogue.
       expect(port.written[port.written.length - 2]).toEqual(bytes(0x04));
     });
 
     it('sends a single CR for empty content', async () => {
+      autoRespond(port);
       await repl.sendRaw('');
       const body = port.written.slice(2, -2);
       expect(body).toEqual([encode('\r')]);
     });
 
+    it('only writes the trailing Ctrl-B after the device finishes responding', async () => {
+      // Hook the writes: when the SUT issues Ctrl-D, snapshot what's been
+      // written so far, then inject the response. By the time `sendRaw`
+      // resolves we expect exactly one extra write — the Ctrl-B epilogue.
+      let snapshot: Uint8Array[] | null = null;
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          snapshot = port.written.slice();
+          port.inject(okResponse('', ''));
+        }
+      };
+      await repl.sendRaw('print(1)');
+      expect(snapshot).not.toBeNull();
+      // Snapshot taken at Ctrl-D: prologue + body + Ctrl-D = 4 chunks.
+      expect(snapshot!).toHaveLength(4);
+      // After resolution, Ctrl-B has been appended.
+      expect(port.written).toHaveLength(5);
+      expect(port.written[4]).toEqual(bytes(0x02));
+    });
+
     it('serializes concurrent calls so each prologue/body/epilogue runs contiguously', async () => {
-      // Two sendRaw calls in flight at the same time. Without a write mutex,
-      // the WritableStream's per-chunk queueing interleaves them: caller A
-      // enqueues its prologue, yields, caller B enqueues *its* prologue
-      // before A's body lands. End result on the wire is something like
-      // [A.Ctrl-CC, B.Ctrl-CC, A.Ctrl-A, B.Ctrl-A, ...] which breaks the
-      // raw-REPL state machine on the device.
+      autoRespond(port);
       await Promise.all([repl.sendRaw('a'), repl.sendRaw('b')]);
 
       // Each sendRaw produces 5 chunks: Ctrl-CC, Ctrl-A, body, Ctrl-D, Ctrl-B.
       expect(port.written).toHaveLength(10);
 
-      // First call's full sequence must appear before second call begins.
       expect(port.written.slice(0, 5)).toEqual([
         bytes(0x03, 0x03),
         bytes(0x01),
@@ -301,11 +370,11 @@ describe('ReplInterface', () => {
     });
 
     it('still serializes the next call after the previous one rejects mid-payload', async () => {
+      autoRespond(port);
       const failure = new Error('device hiccup');
       const target = encode('a\r');
       port.shouldRejectWrite = (chunk) => {
         if (chunk.length === target.length && chunk.every((b, i) => b === target[i])) {
-          // One-shot: clear the hook so subsequent calls succeed.
           port.shouldRejectWrite = undefined;
           return failure;
         }
@@ -331,22 +400,115 @@ describe('ReplInterface', () => {
         return null;
       };
 
-      // The original forEach-based implementation discarded each line write's
-      // promise, so a mid-payload failure surfaced as an unhandled rejection
-      // even though sendRaw still rejected (via the errored-stream epilogue).
-      // Verify both: sendRaw rejects with the original failure AND no rejection
-      // is left dangling.
       const unhandled: unknown[] = [];
       const onUnhandled = (reason: unknown) => unhandled.push(reason);
       process.on('unhandledRejection', onUnhandled);
       try {
         await expect(repl.sendRaw('a\nb\nc')).rejects.toBe(failure);
-        // Let queued microtasks settle so any orphaned rejection surfaces.
         await new Promise((r) => setTimeout(r, 0));
         expect(unhandled).toEqual([]);
       } finally {
         process.off('unhandledRejection', onUnhandled);
       }
+    });
+  });
+
+  describe('sendRaw — response parser', () => {
+    it('returns stdout from the captured response, with empty stderr on success', async () => {
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          port.inject(okResponse('1\r\n', ''));
+        }
+      };
+      const result = await repl.sendRaw('print(1)');
+      expect(result).toEqual({stdout: '1\r\n', stderr: ''});
+    });
+
+    it('captures stderr for a runtime exception, with stdout empty', async () => {
+      const traceback =
+        'Traceback (most recent call last):\r\n' +
+        '  File "<stdin>", line 1, in <module>\r\n' +
+        'NameError: name \'undefined\' is not defined\r\n';
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          port.inject(okResponse('', traceback));
+        }
+      };
+      const result = await repl.sendRaw('undefined');
+      expect(result.stdout).toBe('');
+      expect(result.stderr).toBe(traceback);
+    });
+
+    it('captures both stdout and stderr when the program prints before failing', async () => {
+      const traceback = 'Traceback (most recent call last):\r\nZeroDivisionError\r\n';
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          port.inject(okResponse('partial\r\n', traceback));
+        }
+      };
+      const result = await repl.sendRaw('print("partial"); 1/0');
+      expect(result.stdout).toBe('partial\r\n');
+      expect(result.stderr).toBe(traceback);
+    });
+
+    it('captures syntax-error tracebacks as stderr', async () => {
+      const traceback = 'Traceback (most recent call last):\r\nSyntaxError: invalid syntax\r\n';
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          port.inject(okResponse('', traceback));
+        }
+      };
+      const result = await repl.sendRaw(')');
+      expect(result.stderr).toBe(traceback);
+    });
+
+    it('still dispatches a `data` event with the device bytes for the xterm mirror', async () => {
+      const seen: Uint8Array[] = [];
+      repl.addEventListener('data', (e) => {
+        seen.push((e as CustomEvent<Uint8Array>).detail);
+      });
+      const response = okResponse('hi\r\n', '');
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          port.inject(response);
+        }
+      };
+      await repl.sendRaw('print("hi")');
+      // Every byte the device emitted should also be visible to the data listener.
+      expect(concat(seen)).toEqual(response);
+    });
+
+    it('parses a response delivered byte-by-byte', async () => {
+      const response = okResponse('ok\r\n', '');
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          for (const b of response) port.inject([b]);
+        }
+      };
+      const result = await repl.sendRaw('print("ok")');
+      expect(result).toEqual({stdout: 'ok\r\n', stderr: ''});
+    });
+
+    it('ignores leftover bytes from a previous program before the banner', async () => {
+      const leftover = encode('garbage from the previous run\r\n');
+      port.onWrite = (chunk) => {
+        if (chunk.length === 1 && chunk[0] === 0x04) {
+          port.inject(concat([leftover, okResponse('done\r\n', '')]));
+        }
+      };
+      const result = await repl.sendRaw('print("done")');
+      expect(result).toEqual({stdout: 'done\r\n', stderr: ''});
+    });
+
+    it('rejects when the timeout elapses before the response completes', async () => {
+      // No auto-respond: the parser will sit in the banner phase forever.
+      await expect(repl.sendRaw('print(1)', 20)).rejects.toThrow(/timed out/i);
+    });
+
+    it('still tries to send Ctrl-B after a timeout so the device leaves raw mode', async () => {
+      await expect(repl.sendRaw('print(1)', 20)).rejects.toThrow(/timed out/i);
+      // After timeout: prologue (Ctrl-CC, Ctrl-A) + body + Ctrl-D + Ctrl-B = 5 chunks.
+      expect(port.written[port.written.length - 1]).toEqual(bytes(0x02));
     });
   });
 

--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -1,6 +1,20 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
+const RAW_BANNER = 'raw REPL; CTRL-B to exit\r\n>';
+const OK = 'OK';
+const EOT = 0x04;
+
+export interface RunResult {
+  stdout: string;
+  stderr: string;
+}
+
+interface ResponseParser {
+  feed(chunk: Uint8Array): void;
+  abort(reason: unknown): void;
+}
+
 /**
  * An implementation of the MicroPython REPL interface. Documentation for the interface itself
  * is available at https://docs.micropython.org/en/latest/reference/repl.html.
@@ -14,6 +28,10 @@ export class ReplInterface extends EventTarget {
   // next begins, preventing one caller's prologue from interleaving with
   // another's body in the underlying WritableStream queue.
   private writeChain: Promise<void> = Promise.resolve();
+  // Active raw-REPL response parser. The read loop hands every incoming chunk
+  // to it (in addition to dispatching the `'data'` event). At most one parser
+  // is active because `sendRaw` runs under the write-serialization mutex.
+  private parser: ResponseParser | null = null;
 
   constructor(private port: SerialPort) {
     super();
@@ -47,6 +65,7 @@ export class ReplInterface extends EventTarget {
         const {value, done} = await this.reader.read();
         if (value) {
           this.dispatchEvent(new CustomEvent('data', {detail: value}));
+          this.parser?.feed(value);
         }
         if (done) {
           break;
@@ -61,6 +80,10 @@ export class ReplInterface extends EventTarget {
         // Already released or stream is in an error state.
       }
     }
+    // If a sendRaw was waiting for a response, surface the disconnect to it
+    // before firing the public event so callers see a real rejection instead
+    // of hanging until their timeout.
+    this.parser?.abort(error ?? new Error('disconnected'));
     this.dispatchEvent(
       new CustomEvent('disconnect', error ? {detail: {error}} : undefined),
     );
@@ -94,16 +117,143 @@ export class ReplInterface extends EventTarget {
     });
   }
 
-  sendRaw(content: string) {
+  /**
+   * Runs `content` in the device's raw REPL and returns its captured stdout
+   * and stderr. The raw protocol (per the MicroPython docs) is:
+   *
+   *   1. Ctrl-A  → device emits `\r\nraw REPL; CTRL-B to exit\r\n>`.
+   *   2. code + Ctrl-D → device emits `OK`, then stdout, `\x04`, stderr, `\x04`, `>`.
+   *
+   * Bytes are still dispatched via the `'data'` event so xterm mirrors the
+   * full conversation; the parser only inspects them.
+   *
+   * Rejects if `timeoutMs` elapses before both `\x04` framing bytes arrive,
+   * or if the connection drops mid-flight.
+   */
+  sendRaw(content: string, timeoutMs = 30_000): Promise<RunResult> {
     return this.runExclusive(async () => {
-      await this.writer.write(Uint8Array.from([0x03, 0x03]));
-      await this.writer.write(Uint8Array.from([0x01]));
-      for (const line of content.split('\n')) {
-        await this.writer.write(this.encoder.encode(line + '\r'));
+      const response = this.captureResponse(timeoutMs);
+      try {
+        await this.writer.write(Uint8Array.from([0x03, 0x03]));
+        await this.writer.write(Uint8Array.from([0x01]));
+        for (const line of content.split('\n')) {
+          await this.writer.write(this.encoder.encode(line + '\r'));
+        }
+        await this.writer.write(Uint8Array.from([0x04]));
+      } catch (err) {
+        // A write failed — bail out the parser so it doesn't sit waiting for
+        // a response that will never come. We still await `response.promise`
+        // below so the rejection is observed (otherwise it surfaces as an
+        // unhandled promise rejection).
+        response.abort(err);
       }
-      await this.writer.write(Uint8Array.from([0x04]));
-      await this.writer.write(Uint8Array.from([0x02]));
+      try {
+        return await response.promise;
+      } finally {
+        // Best-effort exit raw mode. If the writer is already errored (e.g.
+        // device disconnected mid-run) we don't want that to mask the real
+        // failure or cause an unhandled rejection.
+        try {
+          await this.writer.write(Uint8Array.from([0x02]));
+        } catch {
+          // Writer is already closed/errored; nothing useful to do.
+        }
+      }
     });
+  }
+
+  /**
+   * Installs a parser into `this.parser` and returns its promise plus an
+   * `abort` hook for write-side failures. The parser walks the four phases
+   * of the raw-REPL response (banner → OK → stdout → stderr) and resolves
+   * after the second `\x04`.
+   */
+  private captureResponse(
+    timeoutMs: number,
+  ): {promise: Promise<RunResult>; abort: (reason: unknown) => void} {
+    let resolveResult!: (r: RunResult) => void;
+    let rejectResult!: (e: unknown) => void;
+    const promise = new Promise<RunResult>((res, rej) => {
+      resolveResult = res;
+      rejectResult = rej;
+    });
+
+    const decoder = new TextDecoder();
+    type Phase = 'banner' | 'ok' | 'stdout' | 'stderr' | 'done';
+    let phase: Phase = 'banner';
+    // Rolling text scratch for the banner and OK phases. Bounded to a few
+    // multiples of the longest needle so a chatty device leftover from a
+    // prior program can't grow the buffer without limit.
+    let scratch = '';
+    const stdoutBytes: number[] = [];
+    const stderrBytes: number[] = [];
+
+    const finish = () => {
+      if (phase === 'done') return;
+      phase = 'done';
+      this.parser = null;
+      clearTimeout(timer);
+      resolveResult({
+        stdout: decoder.decode(Uint8Array.from(stdoutBytes)),
+        stderr: decoder.decode(Uint8Array.from(stderrBytes)),
+      });
+    };
+
+    const fail = (reason: unknown) => {
+      if (phase === 'done') return;
+      phase = 'done';
+      this.parser = null;
+      clearTimeout(timer);
+      rejectResult(reason);
+    };
+
+    const timer = setTimeout(() => {
+      fail(new Error('Timed out waiting for raw REPL response'));
+    }, timeoutMs);
+
+    const SCRATCH_CAP = Math.max(RAW_BANNER.length, OK.length) * 4;
+
+    const parser: ResponseParser = {
+      feed: (chunk) => {
+        for (let i = 0; i < chunk.length; i++) {
+          const b = chunk[i];
+          if (phase === 'banner') {
+            scratch += String.fromCharCode(b);
+            if (scratch.length > SCRATCH_CAP) {
+              scratch = scratch.slice(-RAW_BANNER.length);
+            }
+            if (scratch.endsWith(RAW_BANNER)) {
+              phase = 'ok';
+              scratch = '';
+            }
+          } else if (phase === 'ok') {
+            scratch += String.fromCharCode(b);
+            if (scratch.endsWith(OK)) {
+              phase = 'stdout';
+              scratch = '';
+            } else if (scratch.length > SCRATCH_CAP) {
+              scratch = scratch.slice(-OK.length);
+            }
+          } else if (phase === 'stdout') {
+            if (b === EOT) {
+              phase = 'stderr';
+            } else {
+              stdoutBytes.push(b);
+            }
+          } else if (phase === 'stderr') {
+            if (b === EOT) {
+              finish();
+              return;
+            }
+            stderrBytes.push(b);
+          }
+        }
+      },
+      abort: (reason) => fail(reason),
+    };
+
+    this.parser = parser;
+    return {promise, abort: parser.abort};
   }
 
   static async connect(

--- a/src/agent/tools/ReadEditorTool.test.ts
+++ b/src/agent/tools/ReadEditorTool.test.ts
@@ -9,7 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
-    runCode: async () => {},
+    runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
     ...overrides,

--- a/src/agent/tools/ReadReplHistoryTool.test.ts
+++ b/src/agent/tools/ReadReplHistoryTool.test.ts
@@ -9,7 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
-    runCode: async () => {},
+    runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
     ...overrides,

--- a/src/agent/tools/RunCodeTool.test.ts
+++ b/src/agent/tools/RunCodeTool.test.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { RunCodeTool } from './RunCodeTool';
 import type { ToolBindings } from '../wireTools';
 
@@ -9,7 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
-    runCode: async () => {},
+    runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
     ...overrides,
@@ -17,14 +17,6 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
 }
 
 describe('RunCodeTool', () => {
-  beforeEach(() => {
-    vi.useFakeTimers();
-  });
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
-
   it('definition has correct name, scope, and requires approval', () => {
     const tool = new RunCodeTool(() => makeBindings());
     const def = tool.definition();
@@ -39,89 +31,69 @@ describe('RunCodeTool', () => {
   });
 
   it('falls back to editor content when code arg is omitted', async () => {
-    const runCode = vi.fn().mockResolvedValue(undefined);
+    const runCode = vi.fn().mockResolvedValue({stdout: '42\n', stderr: ''});
     const tool = new RunCodeTool(
       () => makeBindings({ getEditorContent: () => 'print(42)', runCode }),
-      { idleMs: 10, maxMs: 100 },
     );
-    const promise = tool.call({}, {});
-    await vi.advanceTimersByTimeAsync(100);
-    await promise;
+    await tool.call({}, {});
     expect(runCode).toHaveBeenCalledWith('print(42)');
   });
 
-  it('collects REPL output and resolves after idle period', async () => {
-    let dataHandler: ((data: Uint8Array) => void) | null = null;
+  it('returns stdout when stderr is empty', async () => {
     const tool = new RunCodeTool(
-      () =>
-        makeBindings({
-          runCode: async () => {},
-          onData: (h) => {
-            dataHandler = h;
-            return () => {
-              dataHandler = null;
-            };
-          },
-        }),
-      { idleMs: 50, maxMs: 5000 },
+      () => makeBindings({runCode: async () => ({stdout: 'hello\n', stderr: ''})}),
     );
-
-    const promise = tool.call({ code: 'print("hi")' }, {});
-    // Allow the runCode microtask + onData subscription to settle.
-    await Promise.resolve();
-    dataHandler!(new TextEncoder().encode('hello\n'));
-    await vi.advanceTimersByTimeAsync(50);
-    await expect(promise).resolves.toBe('hello\n');
+    await expect(tool.call({code: 'print("hello")'}, {})).resolves.toBe('hello\n');
   });
 
-  it('hits the max timeout when output keeps streaming', async () => {
-    let dataHandler: ((data: Uint8Array) => void) | null = null;
+  it('labels stderr when present alongside stdout', async () => {
     const tool = new RunCodeTool(
-      () =>
-        makeBindings({
-          runCode: async () => {},
-          onData: (h) => {
-            dataHandler = h;
-            return () => {};
-          },
-        }),
-      { idleMs: 1000, maxMs: 200 },
+      () => makeBindings({runCode: async () => ({stdout: 'partial\n', stderr: 'NameError: x\n'})}),
     );
-
-    const promise = tool.call({ code: 'while True: pass' }, {});
-    await Promise.resolve();
-    dataHandler!(new TextEncoder().encode('a'));
-    await vi.advanceTimersByTimeAsync(200);
-    await expect(promise).resolves.toBe('a');
+    await expect(tool.call({code: 'x'}, {})).resolves.toBe('partial\n\nstderr:\nNameError: x\n');
   });
 
-  it('rejects when the abort signal fires', async () => {
+  it('returns stderr only when stdout is empty', async () => {
+    const tool = new RunCodeTool(
+      () => makeBindings({runCode: async () => ({stdout: '', stderr: 'SyntaxError\n'})}),
+    );
+    await expect(tool.call({code: ')'}, {})).resolves.toBe('stderr:\nSyntaxError\n');
+  });
+
+  it('returns "(no output)" when stdout and stderr are both empty', async () => {
+    const tool = new RunCodeTool(
+      () => makeBindings({runCode: async () => ({stdout: '', stderr: ''})}),
+    );
+    await expect(tool.call({code: 'pass'}, {})).resolves.toBe('(no output)');
+  });
+
+  it('rejects when the abort signal fires before runCode resolves', async () => {
     const controller = new AbortController();
+    let neverResolve!: () => void;
     const tool = new RunCodeTool(
       () =>
         makeBindings({
-          runCode: async () => {},
-          onData: () => () => {},
+          runCode: () => new Promise<{stdout: string; stderr: string}>((res) => {
+            // Stash so the test can release it after asserting (avoids hanging Vitest).
+            neverResolve = () => res({stdout: '', stderr: ''});
+          }),
         }),
-      { idleMs: 50, maxMs: 5000 },
     );
-    const promise = tool.call({ code: 'x' }, { signal: controller.signal });
-    await Promise.resolve();
+    const promise = tool.call({code: 'x'}, {signal: controller.signal});
     controller.abort();
     await expect(promise).rejects.toThrow('aborted');
+    neverResolve();
   });
 
-  it('rejects when runCode throws', async () => {
+  it('rejects when runCode rejects', async () => {
     const tool = new RunCodeTool(
       () =>
         makeBindings({
           runCode: async () => {
             throw new Error('serial closed');
           },
-          onData: () => () => {},
         }),
-      { idleMs: 50, maxMs: 5000 },
     );
-    await expect(tool.call({ code: 'x' }, {})).rejects.toThrow('serial closed');
+    await expect(tool.call({code: 'x'}, {})).rejects.toThrow('serial closed');
   });
 });

--- a/src/agent/tools/RunCodeTool.ts
+++ b/src/agent/tools/RunCodeTool.ts
@@ -8,27 +8,8 @@ export interface RunCodeArgs {
   code?: string;
 }
 
-export interface RunCodeOptions {
-  /** Wait this long after the last byte of REPL output before resolving. */
-  idleMs?: number;
-  /** Hard cap on total wait, even if output keeps streaming. */
-  maxMs?: number;
-}
-
-const DEFAULT_IDLE_MS = 1000;
-const DEFAULT_MAX_MS = 30_000;
-
 export class RunCodeTool implements Tool<RunCodeArgs, string> {
-  private readonly idleMs: number;
-  private readonly maxMs: number;
-
-  constructor(
-    private getBindings: () => ToolBindings,
-    options: RunCodeOptions = {},
-  ) {
-    this.idleMs = options.idleMs ?? DEFAULT_IDLE_MS;
-    this.maxMs = options.maxMs ?? DEFAULT_MAX_MS;
-  }
+  constructor(private getBindings: () => ToolBindings) {}
 
   definition(): ToolDefinition {
     return {
@@ -57,48 +38,21 @@ export class RunCodeTool implements Tool<RunCodeArgs, string> {
     const code = args.code ?? bindings.getEditorContent();
     if (!code.trim()) return '(no code to run)';
 
-    const decoder = new TextDecoder();
-    let buffer = '';
-
-    return new Promise<string>((resolve, reject) => {
-      let idleTimer: ReturnType<typeof setTimeout> | null = null;
-      let maxTimer: ReturnType<typeof setTimeout> | null = null;
-      let unsubscribe: (() => void) | null = null;
-
-      const cleanup = () => {
-        if (unsubscribe) unsubscribe();
-        if (idleTimer) clearTimeout(idleTimer);
-        if (maxTimer) clearTimeout(maxTimer);
-        ctx.signal?.removeEventListener('abort', onAbort);
-      };
-
-      const finish = () => {
-        cleanup();
-        resolve(buffer);
-      };
-
-      const onAbort = () => {
-        cleanup();
-        reject(new Error('aborted'));
-      };
-
-      unsubscribe = bindings.onData((data) => {
-        buffer += decoder.decode(data);
-        if (idleTimer) clearTimeout(idleTimer);
-        idleTimer = setTimeout(finish, this.idleMs);
-      });
-
-      ctx.signal?.addEventListener('abort', onAbort);
-
-      maxTimer = setTimeout(finish, this.maxMs);
-      // If no output ever arrives we still need a cap — reuse maxMs as the
-      // initial idle window. The first onData call resets it to idleMs.
-      idleTimer = setTimeout(finish, this.maxMs);
-
-      bindings.runCode(code).catch((err) => {
-        cleanup();
-        reject(err);
-      });
+    const run = bindings.runCode(code);
+    const aborted = new Promise<never>((_, reject) => {
+      const onAbort = () => reject(new Error('aborted'));
+      if (ctx.signal?.aborted) {
+        onAbort();
+        return;
+      }
+      ctx.signal?.addEventListener('abort', onAbort, {once: true});
     });
+
+    const {stdout, stderr} = await Promise.race([run, aborted]);
+
+    if (!stdout && !stderr) return '(no output)';
+    if (!stderr) return stdout;
+    if (!stdout) return `stderr:\n${stderr}`;
+    return `${stdout}\nstderr:\n${stderr}`;
   }
 }

--- a/src/agent/tools/WriteEditorTool.test.ts
+++ b/src/agent/tools/WriteEditorTool.test.ts
@@ -9,7 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
-    runCode: async () => {},
+    runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
     ...overrides,

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -9,7 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
-    runCode: async () => {},
+    runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
     ...overrides,

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { ToolRegistry } from '@mast-ai/core';
+import type { RunResult } from '../ReplInterface';
 import { ReadEditorTool } from './tools/ReadEditorTool';
 import { WriteEditorTool } from './tools/WriteEditorTool';
 import { RunCodeTool } from './tools/RunCodeTool';
@@ -10,7 +11,7 @@ import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
 export interface ToolBindings {
   getEditorContent(): string;
   setEditorContent(code: string): void;
-  runCode(code: string): Promise<void>;
+  runCode(code: string): Promise<RunResult>;
   getReplHistory(): string[];
   onData(handler: (data: Uint8Array) => void): () => void;
 }

--- a/src/hooks/useReplConnection.test.ts
+++ b/src/hooks/useReplConnection.test.ts
@@ -11,7 +11,7 @@ function makeMockRepl(): ReplInterface {
   return Object.assign(et, {
     disconnect: vi.fn().mockResolvedValue(undefined),
     reset: vi.fn().mockResolvedValue(undefined),
-    sendRaw: vi.fn().mockResolvedValue(undefined),
+    sendRaw: vi.fn().mockResolvedValue({stdout: '', stderr: ''}),
     send: vi.fn().mockResolvedValue(undefined),
   }) as unknown as ReplInterface;
 }
@@ -61,6 +61,25 @@ describe('useReplConnection', () => {
     await act(() => result.current.connect());
     await act(() => result.current.runCode('print("hello")'));
     expect(mockRepl.sendRaw).toHaveBeenCalledWith('print("hello")');
+  });
+
+  it("runCode() resolves with the device's stdout/stderr", async () => {
+    (mockRepl.sendRaw as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      stdout: 'hi\n',
+      stderr: '',
+    });
+    const { result } = renderHook(() => useReplConnection());
+    await act(() => result.current.connect());
+    let runResult: {stdout: string; stderr: string} | undefined;
+    await act(async () => {
+      runResult = await result.current.runCode('print("hi")');
+    });
+    expect(runResult).toEqual({stdout: 'hi\n', stderr: ''});
+  });
+
+  it('runCode() rejects when not connected', async () => {
+    const { result } = renderHook(() => useReplConnection());
+    await expect(result.current.runCode('print("hi")')).rejects.toThrow(/not connected/i);
   });
 
   it('onData handler receives data dispatched by repl', async () => {

--- a/src/hooks/useReplConnection.ts
+++ b/src/hooks/useReplConnection.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useRef, useState } from 'react';
-import { ReplInterface } from '../ReplInterface';
+import { ReplInterface, type RunResult } from '../ReplInterface';
 
 const MAX_HISTORY_LINES = 100;
 
@@ -78,10 +78,11 @@ export function useReplConnection() {
     }
   }, []);
 
-  const runCode = useCallback(async (code: string) => {
-    if (replRef.current) {
-      await replRef.current.sendRaw(code);
+  const runCode = useCallback(async (code: string): Promise<RunResult> => {
+    if (!replRef.current) {
+      throw new Error('Not connected');
     }
+    return replRef.current.sendRaw(code);
   }, []);
 
   const send = useCallback(async (data: string) => {


### PR DESCRIPTION
## Summary
- `ReplInterface.sendRaw(content, timeoutMs?)` now returns `Promise<{stdout, stderr}>`. An internal 4-phase parser (banner → `OK` → stdout → `\x04` → stderr → `\x04`) taps the existing read loop; the `'data'` event still fires with every byte so the xterm mirror is unchanged.
- Default 30 s timeout, with rejection on timeout or device disconnect. `Ctrl-B` is sent best-effort either way so the device exits raw mode.
- `RunCodeTool` drops the idle/max output-timer heuristic and formats the framed `{stdout, stderr}` directly. Labels stderr when present; returns `(no output)` when both are empty.
- Tests cover success, syntax error, runtime exception, mixed stdout+stderr, byte-by-byte chunking, leftover-bytes-before-banner, transparent `'data'` mirror, in-flight disconnect rejection, deferred `Ctrl-B`, and timeout.

Closes #49

## Test plan
- [x] `npm run lint`, `npm run build`, `npm run test` all green (165 tests).
- [x] Manual: Run button still mirrors `print(...)` and tracebacks into xterm.
- [x] Manual: agent's `run_code` tool returns parsed stdout for success, labelled stderr for syntax errors, runtime exceptions, and mixed output, and `(no output)` when neither is produced.