### PR TITLE
feat(device-files): add devicePath helpers and validateName

### DIFF
--- a/src/lib/devicePath.test.ts
+++ b/src/lib/devicePath.test.ts
@@ -1,0 +1,195 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { basename, dirname, join, normalise, validateName } from './devicePath';
+
+describe('normalise', () => {
+  it('preserves a simple absolute path', () => {
+    expect(normalise('/foo/bar')).toBe('/foo/bar');
+  });
+
+  it('returns root unchanged', () => {
+    expect(normalise('/')).toBe('/');
+  });
+
+  it('collapses repeated slashes', () => {
+    expect(normalise('//foo///bar//')).toBe('/foo/bar');
+  });
+
+  it('strips trailing slash', () => {
+    expect(normalise('/foo/bar/')).toBe('/foo/bar');
+  });
+
+  it('resolves `.` segments', () => {
+    expect(normalise('/foo/./bar')).toBe('/foo/bar');
+  });
+
+  it('resolves `..` segments', () => {
+    expect(normalise('/foo/bar/../baz')).toBe('/foo/baz');
+  });
+
+  it('clamps `..` at the root', () => {
+    expect(normalise('/../..')).toBe('/');
+    expect(normalise('/../foo')).toBe('/foo');
+  });
+
+  it('treats relative input as absolute', () => {
+    expect(normalise('foo/bar')).toBe('/foo/bar');
+  });
+
+  it('returns root for the empty string', () => {
+    expect(normalise('')).toBe('/');
+  });
+});
+
+describe('join', () => {
+  it('joins root with a name', () => {
+    expect(join('/', 'foo')).toBe('/foo');
+  });
+
+  it('joins multiple segments', () => {
+    expect(join('/foo', 'bar', 'baz')).toBe('/foo/bar/baz');
+  });
+
+  it('handles trailing slashes in base', () => {
+    expect(join('/foo/', 'bar')).toBe('/foo/bar');
+  });
+
+  it('normalises `..` while joining', () => {
+    expect(join('/foo/bar', '..', 'baz')).toBe('/foo/baz');
+  });
+
+  it('normalises embedded slashes in parts', () => {
+    expect(join('/foo', '/bar/', '/baz')).toBe('/foo/bar/baz');
+  });
+
+  it('returns root when no parts are given', () => {
+    expect(join('/')).toBe('/');
+  });
+});
+
+describe('dirname', () => {
+  it('returns root for root', () => {
+    expect(dirname('/')).toBe('/');
+  });
+
+  it('returns root for a top-level entry', () => {
+    expect(dirname('/foo')).toBe('/');
+  });
+
+  it('returns the parent directory', () => {
+    expect(dirname('/foo/bar')).toBe('/foo');
+  });
+
+  it('strips trailing slashes before resolving', () => {
+    expect(dirname('/foo/bar/')).toBe('/foo');
+  });
+
+  it('handles deeply nested paths', () => {
+    expect(dirname('/a/b/c/d')).toBe('/a/b/c');
+  });
+});
+
+describe('basename', () => {
+  it('returns empty string for root', () => {
+    expect(basename('/')).toBe('');
+  });
+
+  it('returns the final segment', () => {
+    expect(basename('/foo/bar')).toBe('bar');
+  });
+
+  it('strips trailing slashes', () => {
+    expect(basename('/foo/bar/')).toBe('bar');
+  });
+
+  it('returns top-level entry', () => {
+    expect(basename('/foo')).toBe('foo');
+  });
+});
+
+describe('validateName', () => {
+  it('accepts a normal filename', () => {
+    expect(validateName('main.py')).toEqual({ ok: true });
+  });
+
+  it('accepts a unicode name', () => {
+    expect(validateName('café.txt')).toEqual({ ok: true });
+  });
+
+  it('accepts dot-prefixed names', () => {
+    expect(validateName('.gitignore')).toEqual({ ok: true });
+    expect(validateName('..foo')).toEqual({ ok: true });
+  });
+
+  it('rejects empty string', () => {
+    const r = validateName('');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/empty/i);
+  });
+
+  it('rejects whitespace-only', () => {
+    const r = validateName('   ');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/empty/i);
+  });
+
+  it('rejects names containing a slash', () => {
+    const r = validateName('foo/bar');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toContain("/");
+  });
+
+  it('rejects "."', () => {
+    const r = validateName('.');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/'\.' or '\.\.'/);
+  });
+
+  it('rejects ".."', () => {
+    const r = validateName('..');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/'\.' or '\.\.'/);
+  });
+
+  it('rejects null bytes', () => {
+    const r = validateName('foo\x00bar');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/control/i);
+  });
+
+  it('rejects newlines', () => {
+    const r = validateName('foo\nbar');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/control/i);
+  });
+
+  it('rejects DEL (0x7f)', () => {
+    const r = validateName('foo\x7fbar');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/control/i);
+  });
+
+  it('accepts a 255-byte ASCII name', () => {
+    expect(validateName('a'.repeat(255))).toEqual({ ok: true });
+  });
+
+  it('rejects a 256-byte ASCII name', () => {
+    const r = validateName('a'.repeat(256));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/long/i);
+  });
+
+  it('counts UTF-8 bytes, not characters, for the length limit', () => {
+    // '€' is 3 UTF-8 bytes, so 86 of them is 258 bytes (> 255) although only 86 chars.
+    const r = validateName('€'.repeat(86));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toMatch(/long/i);
+  });
+
+  it('accepts a name right at the UTF-8 byte boundary', () => {
+    // 85 × 3 = 255 bytes — boundary inclusive.
+    expect(validateName('€'.repeat(85))).toEqual({ ok: true });
+  });
+});

--- a/src/lib/devicePath.ts
+++ b/src/lib/devicePath.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Absolute POSIX-style path utilities for the device filesystem.
+ *
+ * All paths begin with `/`; relative inputs are made absolute by prepending `/`.
+ * `.` and `..` segments are resolved during {@link normalise}; `..` cannot escape
+ * the root.
+ */
+
+const MAX_NAME_BYTES = 255;
+// eslint-disable-next-line no-control-regex -- intentionally rejects control characters in names
+const CONTROL_CHAR_RE = /[\x00-\x1f\x7f]/;
+const utf8Encoder = new TextEncoder();
+
+export type NameValidation = { ok: true } | { ok: false; reason: string };
+
+/** Resolve `.` and `..` segments and collapse repeated slashes. */
+export function normalise(path: string): string {
+  const absolute = path.startsWith('/') ? path : '/' + path;
+  const stack: string[] = [];
+  for (const part of absolute.split('/')) {
+    if (part === '' || part === '.') continue;
+    if (part === '..') {
+      stack.pop();
+      continue;
+    }
+    stack.push(part);
+  }
+  return '/' + stack.join('/');
+}
+
+/** Join a base path with additional segments and normalise the result. */
+export function join(base: string, ...parts: string[]): string {
+  return normalise([base, ...parts].join('/'));
+}
+
+/** Return the parent directory of a path. The parent of `/` is `/`. */
+export function dirname(path: string): string {
+  const norm = normalise(path);
+  if (norm === '/') return '/';
+  const idx = norm.lastIndexOf('/');
+  return idx === 0 ? '/' : norm.substring(0, idx);
+}
+
+/** Return the final segment of a path. The basename of `/` is the empty string. */
+export function basename(path: string): string {
+  const norm = normalise(path);
+  if (norm === '/') return '';
+  return norm.substring(norm.lastIndexOf('/') + 1);
+}
+
+/**
+ * Validate a single path component (no slashes) for use in create / rename UI.
+ * The returned `reason` is a short, user-facing string suitable for inline display.
+ */
+export function validateName(name: string): NameValidation {
+  if (name.trim() === '') {
+    return { ok: false, reason: 'Name cannot be empty' };
+  }
+  if (name.includes('/')) {
+    return { ok: false, reason: "Name cannot contain '/'" };
+  }
+  if (name === '.' || name === '..') {
+    return { ok: false, reason: "Name cannot be '.' or '..'" };
+  }
+  if (CONTROL_CHAR_RE.test(name)) {
+    return { ok: false, reason: 'Name cannot contain control characters' };
+  }
+  if (utf8Encoder.encode(name).length > MAX_NAME_BYTES) {
+    return { ok: false, reason: 'Name is too long (max 255 bytes)' };
+  }
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/devicePath.ts` exporting `join`, `dirname`, `basename`, `normalise`, `validateName`.
- `validateName` rejects empty/whitespace, embedded `/`, `.`/`..`, control chars (`\x00`–`\x1f`, `\x7f`), and names exceeding 255 UTF-8 bytes; each rejection returns a `reason` suitable for inline display.
- Path helpers are absolute POSIX-style; `normalise` resolves `.`/`..` (clamped at root) and collapses repeated slashes; relative inputs are made absolute.
- 39 Vitest cases in `src/lib/devicePath.test.ts` covering edge cases (root, trailing slashes, multi-byte UTF-8 length boundary, control chars, etc.).

Implements SPEC § "Path semantics" and § "Name validation (validateName)".

Closes #63

## Test plan
- [x] `npm run test` (234 passing, 39 new)
- [x] `npm run lint`
- [x] `npm run build`
- [x] Pure utility module with no UI surface and no current consumers — no in-browser exercise possible until #64 lands.