### PR TITLE
feat(device-files): add DeviceFs model

### DIFF
--- a/src/DeviceFs.test.ts
+++ b/src/DeviceFs.test.ts
@@ -1,0 +1,305 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { DeviceFs, DeviceFsError } from './DeviceFs';
+import type { RunResult } from './ReplInterface';
+
+function ok(stdout = ''): RunResult {
+  return { stdout, stderr: '' };
+}
+
+function makeRunRaw(result: RunResult | (() => RunResult | Promise<RunResult>)) {
+  const fn = vi.fn(async (): Promise<RunResult> => {
+    return typeof result === 'function' ? await result() : result;
+  });
+  return fn;
+}
+
+describe('DeviceFs.list', () => {
+  it('parses a directory listing', async () => {
+    const runRaw = makeRunRaw(ok('[{"name": "main.py", "isDir": false}, {"name": "lib", "isDir": true}]\n'));
+    const fs = new DeviceFs(runRaw);
+    const entries = await fs.list('/');
+    expect(entries).toEqual([
+      { name: 'main.py', isDir: false },
+      { name: 'lib', isDir: true },
+    ]);
+  });
+
+  it('embeds the path as a Python string literal', async () => {
+    const runRaw = makeRunRaw(ok('[]'));
+    const fs = new DeviceFs(runRaw);
+    await fs.list('/lib');
+    expect(runRaw).toHaveBeenCalledOnce();
+    const code = runRaw.mock.calls[0][0];
+    expect(code).toContain("_p = '/lib'");
+    expect(code).toContain('os.listdir(_p)');
+    expect(code).toContain('json.dumps(_r)');
+  });
+
+  it('escapes single quotes and backslashes in the path', async () => {
+    const runRaw = makeRunRaw(ok('[]'));
+    const fs = new DeviceFs(runRaw);
+    await fs.list("/o'brien\\dir");
+    const code = runRaw.mock.calls[0][0];
+    expect(code).toContain("_p = '/o\\'brien\\\\dir'");
+  });
+
+  it('returns an empty array for empty directories', async () => {
+    const runRaw = makeRunRaw(ok('[]\n'));
+    const fs = new DeviceFs(runRaw);
+    expect(await fs.list('/empty')).toEqual([]);
+  });
+
+  it('throws DeviceFsError on an ERR: line', async () => {
+    const runRaw = makeRunRaw(ok('ERR:[Errno 2] ENOENT\n'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.list('/missing')).rejects.toBeInstanceOf(DeviceFsError);
+    await expect(fs.list('/missing')).rejects.toThrow('[Errno 2] ENOENT');
+  });
+
+  it('throws Error when stdout is empty', async () => {
+    const runRaw = makeRunRaw(ok(''));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.list('/')).rejects.toThrow(/no output/);
+  });
+
+  it('throws Error when JSON is invalid', async () => {
+    const runRaw = makeRunRaw(ok('not json\n'));
+    const fs = new DeviceFs(runRaw);
+    const promise = fs.list('/');
+    await expect(promise).rejects.not.toBeInstanceOf(DeviceFsError);
+    await expect(promise).rejects.toThrow(/parse JSON/);
+  });
+
+  it('throws Error when stderr is non-empty', async () => {
+    const runRaw = makeRunRaw({ stdout: '', stderr: 'SyntaxError: invalid syntax\n' });
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.list('/')).rejects.toThrow(/stderr/);
+  });
+});
+
+describe('DeviceFs.stat', () => {
+  it('parses a stat result', async () => {
+    const runRaw = makeRunRaw(ok('{"isDir": false, "size": 1234}\n'));
+    const fs = new DeviceFs(runRaw);
+    expect(await fs.stat('/main.py')).toEqual({ isDir: false, size: 1234 });
+  });
+
+  it('embeds the path in os.stat', async () => {
+    const runRaw = makeRunRaw(ok('{"isDir": true, "size": 0}'));
+    const fs = new DeviceFs(runRaw);
+    await fs.stat('/lib');
+    const code = runRaw.mock.calls[0][0];
+    expect(code).toContain("os.stat('/lib')");
+  });
+
+  it('surfaces ERR: as DeviceFsError', async () => {
+    const runRaw = makeRunRaw(ok('ERR:[Errno 2] ENOENT'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.stat('/nope')).rejects.toBeInstanceOf(DeviceFsError);
+  });
+});
+
+describe('DeviceFs.readBytes', () => {
+  it('decodes base64 stdout to bytes', async () => {
+    // 'hello' base64 encoded
+    const runRaw = makeRunRaw(ok('aGVsbG8=\n'));
+    const fs = new DeviceFs(runRaw);
+    const bytes = await fs.readBytes('/foo.txt');
+    expect(Array.from(bytes)).toEqual([0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+  });
+
+  it('embeds the size limit in the snippet', async () => {
+    const runRaw = makeRunRaw(ok('AA=='));
+    const fs = new DeviceFs(runRaw);
+    await fs.readBytes('/foo.bin');
+    const code = runRaw.mock.calls[0][0];
+    expect(code).toContain(`if _s[6] > ${256 * 1024}:`);
+    expect(code).toContain("print('ERR:File too large to open')");
+    expect(code).toContain("open('/foo.bin', 'rb')");
+  });
+
+  it('surfaces "File too large to open" as DeviceFsError', async () => {
+    const runRaw = makeRunRaw(ok('ERR:File too large to open\n'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.readBytes('/big.bin')).rejects.toBeInstanceOf(DeviceFsError);
+    await expect(fs.readBytes('/big.bin')).rejects.toThrow('File too large to open');
+  });
+
+  it('throws Error on invalid base64', async () => {
+    const runRaw = makeRunRaw(ok('not_base64!!!\n'));
+    const fs = new DeviceFs(runRaw);
+    const promise = fs.readBytes('/foo');
+    await expect(promise).rejects.not.toBeInstanceOf(DeviceFsError);
+    await expect(promise).rejects.toThrow(/base64/);
+  });
+
+  it('returns an empty Uint8Array for an empty file', async () => {
+    // b2a_base64(b'').decode().strip() is '', so the device emits a single
+    // newline. The host treats empty stdout as a successful empty read.
+    const runRaw = makeRunRaw(ok('\n'));
+    const fs = new DeviceFs(runRaw);
+    const bytes = await fs.readBytes('/empty.bin');
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(bytes.byteLength).toBe(0);
+  });
+});
+
+describe('DeviceFs.readText', () => {
+  it('decodes UTF-8 bytes to a string', async () => {
+    const runRaw = makeRunRaw(ok('aGVsbG8=\n')); // 'hello'
+    const fs = new DeviceFs(runRaw);
+    expect(await fs.readText('/foo.txt')).toBe('hello');
+  });
+
+  it('throws on invalid UTF-8', async () => {
+    // 0xff is not a valid UTF-8 start byte
+    const runRaw = makeRunRaw(ok('/w==\n'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.readText('/binary')).rejects.toThrow(/UTF-8/);
+  });
+});
+
+describe('DeviceFs.writeBytes', () => {
+  it('embeds the path and base64 payload', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.writeBytes('/foo.bin', new Uint8Array([0x68, 0x69])); // 'hi'
+    const code = runRaw.mock.calls[0][0];
+    expect(code).toContain("open('/foo.bin', 'wb')");
+    expect(code).toContain("binascii.a2b_base64(b'aGk=')");
+  });
+
+  it('rejects oversized payloads host-side without calling runRaw', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    const tooBig = new Uint8Array(DeviceFs.MAX_WRITE_BYTES + 1);
+    const promise = fs.writeBytes('/big.bin', tooBig);
+    await expect(promise).rejects.not.toBeInstanceOf(DeviceFsError);
+    await expect(promise).rejects.toThrow(/too large/);
+    expect(runRaw).not.toHaveBeenCalled();
+  });
+
+  it('accepts payloads at exactly the limit', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.writeBytes('/ok.bin', new Uint8Array(DeviceFs.MAX_WRITE_BYTES));
+    expect(runRaw).toHaveBeenCalledOnce();
+  });
+
+  it('resolves when stdout is empty', async () => {
+    const runRaw = makeRunRaw(ok(''));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.writeBytes('/foo', new Uint8Array([1]))).resolves.toBeUndefined();
+  });
+
+  it('surfaces ERR: as DeviceFsError', async () => {
+    const runRaw = makeRunRaw(ok('ERR:[Errno 13] EACCES\n'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.writeBytes('/readonly', new Uint8Array([1]))).rejects.toBeInstanceOf(
+      DeviceFsError,
+    );
+  });
+});
+
+describe('DeviceFs.writeText', () => {
+  it('UTF-8 encodes and writes', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.writeText('/hi.txt', 'hi');
+    const code = runRaw.mock.calls[0][0];
+    expect(code).toContain("binascii.a2b_base64(b'aGk=')");
+  });
+
+  it('handles multibyte characters', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.writeText('/euro.txt', '€');
+    const code = runRaw.mock.calls[0][0];
+    // '€' = E2 82 AC = 'a' '4' 'K' 's' '=' in base64
+    expect(code).toContain("binascii.a2b_base64(b'4oKs')");
+  });
+});
+
+describe('DeviceFs.mkdir', () => {
+  it('emits os.mkdir', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.mkdir('/lib');
+    expect(runRaw.mock.calls[0][0]).toContain("os.mkdir('/lib')");
+  });
+
+  it('surfaces ERR: as DeviceFsError', async () => {
+    const runRaw = makeRunRaw(ok('ERR:[Errno 17] EEXIST\n'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.mkdir('/exists')).rejects.toBeInstanceOf(DeviceFsError);
+  });
+});
+
+describe('DeviceFs.rename', () => {
+  it('emits os.rename with both paths', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.rename('/a.py', '/b.py');
+    expect(runRaw.mock.calls[0][0]).toContain("os.rename('/a.py', '/b.py')");
+  });
+
+  it('escapes both source and target paths', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.rename("/o'a", "/o'b");
+    expect(runRaw.mock.calls[0][0]).toContain("os.rename('/o\\'a', '/o\\'b')");
+  });
+
+  it('surfaces ERR: as DeviceFsError', async () => {
+    const runRaw = makeRunRaw(ok('ERR:[Errno 2] ENOENT\n'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.rename('/from', '/to')).rejects.toBeInstanceOf(DeviceFsError);
+  });
+});
+
+describe('DeviceFs.removeFile', () => {
+  it('emits os.remove', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.removeFile('/foo.txt');
+    expect(runRaw.mock.calls[0][0]).toContain("os.remove('/foo.txt')");
+  });
+
+  it('surfaces ERR: as DeviceFsError', async () => {
+    const runRaw = makeRunRaw(ok('ERR:[Errno 2] ENOENT'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.removeFile('/nope')).rejects.toBeInstanceOf(DeviceFsError);
+  });
+});
+
+describe('DeviceFs.removeDir', () => {
+  it('emits os.rmdir', async () => {
+    const runRaw = makeRunRaw(ok());
+    const fs = new DeviceFs(runRaw);
+    await fs.removeDir('/lib');
+    expect(runRaw.mock.calls[0][0]).toContain("os.rmdir('/lib')");
+  });
+
+  it('surfaces device "directory not empty" as DeviceFsError', async () => {
+    const runRaw = makeRunRaw(ok('ERR:[Errno 39] ENOTEMPTY\n'));
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.removeDir('/notempty')).rejects.toBeInstanceOf(DeviceFsError);
+  });
+});
+
+describe('DeviceFs error pass-through', () => {
+  it('re-throws the original runRaw rejection unchanged (e.g. ReplDisconnectedError)', async () => {
+    class FakeDisconnect extends Error {
+      readonly name = 'ReplDisconnectedError';
+    }
+    const cause = new FakeDisconnect('disconnected');
+    const runRaw = vi.fn(async () => {
+      throw cause;
+    });
+    const fs = new DeviceFs(runRaw);
+    await expect(fs.list('/')).rejects.toBe(cause);
+  });
+});

--- a/src/DeviceFs.ts
+++ b/src/DeviceFs.ts
@@ -1,0 +1,232 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { escapePythonStr } from './lib/devicePath';
+import type { RunResult } from './ReplInterface';
+
+export interface DeviceDirEntry {
+  name: string;
+  isDir: boolean;
+}
+
+export interface DeviceStat {
+  isDir: boolean;
+  size: number;
+}
+
+/**
+ * Thrown when the device-side helper reported an error (an `ERR:` line in
+ * stdout). The message carries the device's exception text so the UI can
+ * surface it to the user without further translation.
+ */
+export class DeviceFsError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'DeviceFsError';
+  }
+}
+
+const ERR_PREFIX = 'ERR:';
+
+/**
+ * Typed device-filesystem API. Each operation builds a small MicroPython
+ * snippet, runs it via the injected `runRaw`, and parses the response.
+ *
+ * Errors propagate as:
+ *   - `DeviceFsError` for device-reported errors (`ERR:` lines).
+ *   - The original `runRaw` rejection (e.g. `ReplDisconnectedError`) for
+ *     connection loss; these are re-thrown unchanged.
+ *   - `Error` for protocol violations (unparseable output, oversized file).
+ */
+export class DeviceFs {
+  /** Maximum file size accepted by `readBytes`. */
+  static readonly MAX_READ_BYTES = 256 * 1024;
+  /** Maximum payload size accepted by `writeBytes`, enforced host-side. */
+  static readonly MAX_WRITE_BYTES = 256 * 1024;
+
+  constructor(private runRaw: (code: string) => Promise<RunResult>) {}
+
+  async list(path: string): Promise<DeviceDirEntry[]> {
+    const p = escapePythonStr(path);
+    const code = [
+      'try:',
+      '    import os, json',
+      `    _p = '${p}'`,
+      "    _base = _p if _p == '/' else _p + '/'",
+      "    _r = [{'name': n, 'isDir': (os.stat(_base + n)[0] & 0x4000) != 0} for n in os.listdir(_p)]",
+      '    print(json.dumps(_r))',
+      'except Exception as e:',
+      "    print('ERR:' + str(e))",
+    ].join('\n');
+    const line = await this.runAndExtract(code);
+    return parseJson<DeviceDirEntry[]>(line);
+  }
+
+  async stat(path: string): Promise<DeviceStat> {
+    const p = escapePythonStr(path);
+    const code = [
+      'try:',
+      '    import os, json',
+      `    _s = os.stat('${p}')`,
+      "    print(json.dumps({'isDir': (_s[0] & 0x4000) != 0, 'size': _s[6]}))",
+      'except Exception as e:',
+      "    print('ERR:' + str(e))",
+    ].join('\n');
+    const line = await this.runAndExtract(code);
+    return parseJson<DeviceStat>(line);
+  }
+
+  async readBytes(path: string): Promise<Uint8Array> {
+    const p = escapePythonStr(path);
+    const code = [
+      'try:',
+      '    import os, binascii',
+      `    _s = os.stat('${p}')`,
+      `    if _s[6] > ${DeviceFs.MAX_READ_BYTES}:`,
+      "        print('ERR:File too large to open')",
+      '    else:',
+      `        _f = open('${p}', 'rb')`,
+      '        print(binascii.b2a_base64(_f.read()).decode().strip())',
+      '        _f.close()',
+      'except Exception as e:',
+      "    print('ERR:' + str(e))",
+    ].join('\n');
+    const result = await this.runRaw(code);
+    assertNoStderr(result);
+    // Empty stdout means an empty file: b2a_base64(b'').decode().strip() is ''.
+    const line = firstNonEmptyLine(result.stdout) ?? '';
+    if (line.startsWith(ERR_PREFIX)) {
+      throw new DeviceFsError(line.slice(ERR_PREFIX.length));
+    }
+    return decodeBase64(line);
+  }
+
+  async readText(path: string): Promise<string> {
+    const bytes = await this.readBytes(path);
+    try {
+      return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch (err) {
+      throw new Error('File is not valid UTF-8', { cause: err });
+    }
+  }
+
+  async writeBytes(path: string, bytes: Uint8Array): Promise<void> {
+    if (bytes.byteLength > DeviceFs.MAX_WRITE_BYTES) {
+      throw new Error(
+        `File too large to write (${bytes.byteLength} bytes; limit ${DeviceFs.MAX_WRITE_BYTES})`,
+      );
+    }
+    const p = escapePythonStr(path);
+    const b64 = encodeBase64(bytes);
+    const code = [
+      'try:',
+      '    import binascii',
+      `    _f = open('${p}', 'wb')`,
+      `    _f.write(binascii.a2b_base64(b'${b64}'))`,
+      '    _f.close()',
+      'except Exception as e:',
+      "    print('ERR:' + str(e))",
+    ].join('\n');
+    await this.runAndExpectAck(code);
+  }
+
+  async writeText(path: string, text: string): Promise<void> {
+    const bytes = new TextEncoder().encode(text);
+    return this.writeBytes(path, bytes);
+  }
+
+  async mkdir(path: string): Promise<void> {
+    await this.runAndExpectAck(buildMutationSnippet('os', `os.mkdir('${escapePythonStr(path)}')`));
+  }
+
+  async rename(from: string, to: string): Promise<void> {
+    const f = escapePythonStr(from);
+    const t = escapePythonStr(to);
+    await this.runAndExpectAck(buildMutationSnippet('os', `os.rename('${f}', '${t}')`));
+  }
+
+  async removeFile(path: string): Promise<void> {
+    await this.runAndExpectAck(buildMutationSnippet('os', `os.remove('${escapePythonStr(path)}')`));
+  }
+
+  async removeDir(path: string): Promise<void> {
+    await this.runAndExpectAck(buildMutationSnippet('os', `os.rmdir('${escapePythonStr(path)}')`));
+  }
+
+  /** Run `code` and return the first non-empty stdout line (or throw). */
+  private async runAndExtract(code: string): Promise<string> {
+    const result = await this.runRaw(code);
+    assertNoStderr(result);
+    const line = firstNonEmptyLine(result.stdout);
+    if (line === null) {
+      throw new Error('DeviceFs: device returned no output');
+    }
+    if (line.startsWith(ERR_PREFIX)) {
+      throw new DeviceFsError(line.slice(ERR_PREFIX.length));
+    }
+    return line;
+  }
+
+  /** Run `code` and require empty stdout; surface `ERR:` lines as DeviceFsError. */
+  private async runAndExpectAck(code: string): Promise<void> {
+    const result = await this.runRaw(code);
+    assertNoStderr(result);
+    const line = firstNonEmptyLine(result.stdout);
+    if (line === null) return;
+    if (line.startsWith(ERR_PREFIX)) {
+      throw new DeviceFsError(line.slice(ERR_PREFIX.length));
+    }
+    throw new Error(`DeviceFs: unexpected output: ${line}`);
+  }
+}
+
+function buildMutationSnippet(modules: string, statement: string): string {
+  return [
+    'try:',
+    `    import ${modules}`,
+    `    ${statement}`,
+    'except Exception as e:',
+    "    print('ERR:' + str(e))",
+  ].join('\n');
+}
+
+function firstNonEmptyLine(stdout: string): string | null {
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (trimmed !== '') return trimmed;
+  }
+  return null;
+}
+
+function assertNoStderr(result: RunResult): void {
+  const stderr = result.stderr.trim();
+  if (stderr !== '') {
+    throw new Error(`DeviceFs: device reported stderr: ${stderr}`);
+  }
+}
+
+function parseJson<T>(line: string): T {
+  try {
+    return JSON.parse(line) as T;
+  } catch (err) {
+    throw new Error(`DeviceFs: failed to parse JSON response: ${line}`, { cause: err });
+  }
+}
+
+function decodeBase64(line: string): Uint8Array {
+  let binary: string;
+  try {
+    binary = atob(line);
+  } catch (err) {
+    throw new Error('DeviceFs: failed to decode base64 response', { cause: err });
+  }
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
+}
+
+function encodeBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}

--- a/src/lib/devicePath.test.ts
+++ b/src/lib/devicePath.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect } from 'vitest';
-import { basename, dirname, join, normalise, validateName } from './devicePath';
+import { basename, dirname, escapePythonStr, join, normalise, validateName } from './devicePath';
 
 describe('normalise', () => {
   it('preserves a simple absolute path', () => {
@@ -106,6 +106,28 @@ describe('basename', () => {
 
   it('returns top-level entry', () => {
     expect(basename('/foo')).toBe('foo');
+  });
+});
+
+describe('escapePythonStr', () => {
+  it('passes plain ASCII through unchanged', () => {
+    expect(escapePythonStr('/foo/bar.py')).toBe('/foo/bar.py');
+  });
+
+  it('escapes backslashes', () => {
+    expect(escapePythonStr('a\\b')).toBe('a\\\\b');
+  });
+
+  it('escapes single quotes', () => {
+    expect(escapePythonStr("a'b")).toBe("a\\'b");
+  });
+
+  it('escapes both in the same string', () => {
+    expect(escapePythonStr("a\\b'c")).toBe("a\\\\b\\'c");
+  });
+
+  it('does not escape double quotes', () => {
+    expect(escapePythonStr('a"b')).toBe('a"b');
   });
 });
 

--- a/src/lib/devicePath.ts
+++ b/src/lib/devicePath.ts
@@ -52,6 +52,16 @@ export function basename(path: string): string {
 }
 
 /**
+ * Escape a string so it can be embedded inside a single-quoted Python string
+ * literal. Only backslash and single quote are escaped — callers must validate
+ * their inputs (paths come from validated names; payloads cross the wire as
+ * base64). No expression interpolation is performed.
+ */
+export function escapePythonStr(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+/**
  * Validate a single path component (no slashes) for use in create / rename UI.
  * The returned `reason` is a short, user-facing string suitable for inline display.
  */


### PR DESCRIPTION
## Summary
- Adds `src/DeviceFs.ts` implementing the typed device-filesystem API per `docs/device-files/SPEC.md` § "Models — DeviceFs", § "Device-side Protocol — Operations", § "Result parsing", and § "Size limits".
- Each operation builds the snippet documented in the SPEC, calls the injected `runRaw`, and parses the response: `JSON.parse` for `list` / `stat`, base64 for `readBytes`, empty stdout for mutations.
- `readBytes` rejects files > 256 KiB device-side (so the size check rides one round-trip with the read); `writeBytes` rejects payloads > 256 KiB host-side without sending anything.
- `ERR:` lines surface as `DeviceFsError`; non-empty stderr or otherwise unparseable output surfaces as `Error`. `runRaw` rejections (e.g. `ReplDisconnectedError`) pass through unchanged.
- `MAX_READ_BYTES` / `MAX_WRITE_BYTES` live as named static fields on `DeviceFs`.
- Adds `escapePythonStr` helper to `src/lib/devicePath.ts` (referenced by the SPEC; needed here to safely embed paths in Python string literals).
- Empty files round-trip correctly: `b2a_base64(b'').decode().strip()` is `''`, which `readBytes` interprets as a successful zero-byte read.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (Vitest covers each operation's snippet shape, JSON / base64 parsing, ERR-line handling, size-limit rejection, empty-file read, and runRaw rejection pass-through)
- [x] `npm run build`
- [x] Manual regression test in browser: existing Run / REPL / local file open still work (no UI wiring in this PR)

Closes #64