### PR TITLE
feat(device-files): add list_device_files agent tool

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import { createModels } from './models';
 import { createAdapter } from './providers/factory';
 import { CODING_AGENT } from './agent/config';
 import { wireTools } from './agent/wireTools';
+import { DeviceFs } from './DeviceFs';
 
 const models = createModels();
 
@@ -30,6 +31,11 @@ export function App() {
   const { theme, preference: themePreference, cycle: cycleTheme } = useTheme();
   const { editorRef, getContent, setContent } = useEditor(theme);
 
+  const deviceFs = useMemo(
+    () => (connectionState === 'connected' ? new DeviceFs(runCode) : null),
+    [connectionState, runCode],
+  );
+
   useEffect(() => {
     wireTools(models.tools, {
       getEditorContent: getContent,
@@ -37,8 +43,9 @@ export function App() {
       runCode,
       getReplHistory: () => replHistory,
       onData,
+      deviceFs,
     });
-  }, [getContent, setContent, runCode, replHistory, onData]);
+  }, [getContent, setContent, runCode, replHistory, onData, deviceFs]);
 
   const runner = useMemo(() => {
     if (!config) return null;

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -10,6 +10,14 @@ You have access to the user's code editor and a live MicroPython REPL connected 
 Help the user write, debug, and understand MicroPython code.
 When asked to write code, use write_editor then offer to run it.
 To run the editor's contents (typically a full program that may run for a long time), use run_editor. It returns as soon as the program starts; the user watches output directly in the REPL. After run_editor, simply tell the user the program started — do NOT follow up with read_repl_history or run_editor again unless the user asks.
-For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.`,
-  tools: ['read_editor', 'write_editor', 'run_editor', 'run_snippet', 'read_repl_history'],
+For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
+To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files.`,
+  tools: [
+    'read_editor',
+    'write_editor',
+    'run_editor',
+    'run_snippet',
+    'read_repl_history',
+    'list_device_files',
+  ],
 });

--- a/src/agent/tools/ListDeviceFilesTool.test.ts
+++ b/src/agent/tools/ListDeviceFilesTool.test.ts
@@ -1,0 +1,80 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { ListDeviceFilesTool } from './ListDeviceFilesTool';
+import type { ToolBindings } from '../wireTools';
+import type { DeviceFs, DeviceDirEntry } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => ({stdout: '', stderr: ''}),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    ...overrides,
+  };
+}
+
+function makeDeviceFs(list: (path: string) => Promise<DeviceDirEntry[]>): DeviceFs {
+  return { list } as unknown as DeviceFs;
+}
+
+describe('ListDeviceFilesTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new ListDeviceFilesTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('list_device_files');
+    expect(def.scope).toBe('read');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('definition makes path optional', () => {
+    const tool = new ListDeviceFilesTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual([]);
+  });
+
+  it('returns a clear message when deviceFs is null', async () => {
+    const tool = new ListDeviceFilesTool(() => makeBindings({ deviceFs: null }));
+    await expect(tool.call({})).resolves.toBe('Device is not connected.');
+  });
+
+  it('defaults path to "/" when args omit it', async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    const tool = new ListDeviceFilesTool(() => makeBindings({ deviceFs: makeDeviceFs(list) }));
+    await tool.call({});
+    expect(list).toHaveBeenCalledWith('/');
+  });
+
+  it('forwards the requested path to DeviceFs.list', async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    const tool = new ListDeviceFilesTool(() => makeBindings({ deviceFs: makeDeviceFs(list) }));
+    await tool.call({ path: '/lib' });
+    expect(list).toHaveBeenCalledWith('/lib');
+  });
+
+  it('joins entries with newlines and suffixes directories with "/"', async () => {
+    const list = vi.fn().mockResolvedValue([
+      { name: 'lib', isDir: true },
+      { name: 'main.py', isDir: false },
+      { name: 'boot.py', isDir: false },
+    ] satisfies DeviceDirEntry[]);
+    const tool = new ListDeviceFilesTool(() => makeBindings({ deviceFs: makeDeviceFs(list) }));
+    await expect(tool.call({ path: '/' })).resolves.toBe('lib/\nmain.py\nboot.py');
+  });
+
+  it('returns "(empty directory)" for empty listings', async () => {
+    const list = vi.fn().mockResolvedValue([]);
+    const tool = new ListDeviceFilesTool(() => makeBindings({ deviceFs: makeDeviceFs(list) }));
+    await expect(tool.call({ path: '/empty' })).resolves.toBe('(empty directory)');
+  });
+
+  it('propagates errors from DeviceFs.list', async () => {
+    const list = vi.fn().mockRejectedValue(new Error('ENOENT: /nope'));
+    const tool = new ListDeviceFilesTool(() => makeBindings({ deviceFs: makeDeviceFs(list) }));
+    await expect(tool.call({ path: '/nope' })).rejects.toThrow('ENOENT: /nope');
+  });
+});

--- a/src/agent/tools/ListDeviceFilesTool.ts
+++ b/src/agent/tools/ListDeviceFilesTool.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface ListDeviceFilesArgs {
+  path?: string;
+}
+
+export class ListDeviceFilesTool implements Tool<ListDeviceFilesArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'list_device_files',
+      description:
+        'Lists files and directories at the given absolute device path on the connected ' +
+        'microcontroller. Path defaults to "/". Directory entries are suffixed with "/" in ' +
+        'the output.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style). Defaults to "/".',
+          },
+        },
+        required: [],
+        additionalProperties: false,
+      },
+      scope: 'read',
+      requiresApproval: false,
+    };
+  }
+
+  async call(args: ListDeviceFilesArgs): Promise<string> {
+    const { deviceFs } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+    const path = args.path ?? '/';
+    const entries = await deviceFs.list(path);
+    if (entries.length === 0) return '(empty directory)';
+    return entries.map((e) => (e.isDir ? `${e.name}/` : e.name)).join('\n');
+  }
+}

--- a/src/agent/tools/ReadEditorTool.test.ts
+++ b/src/agent/tools/ReadEditorTool.test.ts
@@ -12,6 +12,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
+    deviceFs: null,
     ...overrides,
   };
 }

--- a/src/agent/tools/ReadReplHistoryTool.test.ts
+++ b/src/agent/tools/ReadReplHistoryTool.test.ts
@@ -12,6 +12,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
+    deviceFs: null,
     ...overrides,
   };
 }

--- a/src/agent/tools/RunEditorTool.test.ts
+++ b/src/agent/tools/RunEditorTool.test.ts
@@ -12,6 +12,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
+    deviceFs: null,
     ...overrides,
   };
 }

--- a/src/agent/tools/RunSnippetTool.test.ts
+++ b/src/agent/tools/RunSnippetTool.test.ts
@@ -12,6 +12,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
+    deviceFs: null,
     ...overrides,
   };
 }

--- a/src/agent/tools/WriteEditorTool.test.ts
+++ b/src/agent/tools/WriteEditorTool.test.ts
@@ -12,6 +12,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
+    deviceFs: null,
     ...overrides,
   };
 }

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -12,16 +12,18 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
+    deviceFs: null,
     ...overrides,
   };
 }
 
 describe('wireTools', () => {
-  it('registers the five agent tools on first call', () => {
+  it('registers the agent tools on first call', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     const names = tools.getTools().map((t) => t.name).sort();
     expect(names).toEqual([
+      'list_device_files',
       'read_editor',
       'read_repl_history',
       'run_editor',
@@ -34,7 +36,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(5);
+    expect(tools.getTools()).toHaveLength(6);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -3,11 +3,13 @@
 
 import type { ToolRegistry } from '@mast-ai/core';
 import type { RunResult } from '../ReplInterface';
+import type { DeviceFs } from '../DeviceFs';
 import { ReadEditorTool } from './tools/ReadEditorTool';
 import { WriteEditorTool } from './tools/WriteEditorTool';
 import { RunEditorTool } from './tools/RunEditorTool';
 import { RunSnippetTool } from './tools/RunSnippetTool';
 import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
+import { ListDeviceFilesTool } from './tools/ListDeviceFilesTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -15,6 +17,7 @@ export interface ToolBindings {
   runCode(code: string): Promise<RunResult>;
   getReplHistory(): string[];
   onData(handler: (data: Uint8Array) => void): () => void;
+  deviceFs: DeviceFs | null;
 }
 
 const REGISTERED = new WeakSet<ToolRegistry>();
@@ -36,4 +39,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new RunEditorTool(get));
   tools.register(new RunSnippetTool(get));
   tools.register(new ReadReplHistoryTool(get));
+  tools.register(new ListDeviceFilesTool(get));
 }


### PR DESCRIPTION
## Summary
- Adds `src/agent/tools/ListDeviceFilesTool.ts` per `docs/device-files/SPEC.md` § "Agent Tools": `scope: 'read'`, `requiresApproval: false`, args `{ path?: string }` defaulting to `/`, returns newline-joined entries with `/` suffix on directories.
- `ToolBindings` (in `src/agent/wireTools.ts`) gains `deviceFs: DeviceFs | null`. Tool no-ops with "Device is not connected." when null.
- `App.tsx` constructs `new DeviceFs(runCode)` while `connectionState === 'connected'` and passes `null` otherwise. (`runCode` already wraps `ReplInterface.sendRaw`; the dedicated `sendRaw` alias on `useReplConnection` is still pending in #65 but isn't required for this tool to function.)
- `CODING_AGENT.tools` includes `list_device_files`; instructions get a one-line note pointing the agent at it.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (8 new Vitest cases mocking `DeviceFs`: definition shape, optional path, null-deviceFs message, default `/`, path forwarding, dir-suffix formatting, empty-listing message, error propagation)
- [x] `npm run build`
- [x] Manual browser test confirmed by user: agent successfully lists device files when connected.

Closes #81