### PR TITLE
feat(device-files): add read_device_file agent tool

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -11,7 +11,7 @@ Help the user write, debug, and understand MicroPython code.
 When asked to write code, use write_editor then offer to run it.
 To run the editor's contents (typically a full program that may run for a long time), use run_editor. It returns as soon as the program starts; the user watches output directly in the REPL. After run_editor, simply tell the user the program started — do NOT follow up with read_repl_history or run_editor again unless the user asks.
 For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
-To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files.`,
+To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.`,
   tools: [
     'read_editor',
     'write_editor',
@@ -19,5 +19,6 @@ To inspect the device's filesystem (e.g. to confirm what's on the board before w
     'run_snippet',
     'read_repl_history',
     'list_device_files',
+    'read_device_file',
   ],
 });

--- a/src/agent/tools/ReadDeviceFileTool.test.ts
+++ b/src/agent/tools/ReadDeviceFileTool.test.ts
@@ -1,0 +1,87 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { ReadDeviceFileTool } from './ReadDeviceFileTool';
+import type { ToolBindings } from '../wireTools';
+import { DeviceFs, DeviceFsError } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => ({stdout: '', stderr: ''}),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    ...overrides,
+  };
+}
+
+function makeDeviceFs(readText: (path: string) => Promise<string>): DeviceFs {
+  return { readText } as unknown as DeviceFs;
+}
+
+describe('ReadDeviceFileTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new ReadDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('read_device_file');
+    expect(def.scope).toBe('read');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('definition makes path required', () => {
+    const tool = new ReadDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual(['path']);
+  });
+
+  it('returns a clear message when deviceFs is null', async () => {
+    const tool = new ReadDeviceFileTool(() => makeBindings({ deviceFs: null }));
+    await expect(tool.call({ path: '/main.py' })).resolves.toBe('Device is not connected.');
+  });
+
+  it('forwards the requested path to DeviceFs.readText', async () => {
+    const readText = vi.fn().mockResolvedValue('print("hi")\n');
+    const tool = new ReadDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readText) }),
+    );
+    await tool.call({ path: '/lib/foo.py' });
+    expect(readText).toHaveBeenCalledWith('/lib/foo.py');
+  });
+
+  it('returns the file contents from DeviceFs.readText', async () => {
+    const readText = vi.fn().mockResolvedValue('hello world');
+    const tool = new ReadDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readText) }),
+    );
+    await expect(tool.call({ path: '/note.txt' })).resolves.toBe('hello world');
+  });
+
+  it('returns "binary file — cannot read" on UTF-8 decode failure', async () => {
+    const decodeErr = new TypeError('The encoded data was not valid for encoding utf-8');
+    const wrapped = new Error('File is not valid UTF-8', { cause: decodeErr });
+    const readText = vi.fn().mockRejectedValue(wrapped);
+    const tool = new ReadDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readText) }),
+    );
+    await expect(tool.call({ path: '/blob.bin' })).resolves.toBe('binary file — cannot read');
+  });
+
+  it('propagates DeviceFsError (e.g. ENOENT) to the caller', async () => {
+    const readText = vi.fn().mockRejectedValue(new DeviceFsError('ENOENT: /nope'));
+    const tool = new ReadDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readText) }),
+    );
+    await expect(tool.call({ path: '/nope' })).rejects.toBeInstanceOf(DeviceFsError);
+  });
+
+  it('propagates non-decode errors from DeviceFs.readText', async () => {
+    const readText = vi.fn().mockRejectedValue(new Error('disconnected'));
+    const tool = new ReadDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readText) }),
+    );
+    await expect(tool.call({ path: '/main.py' })).rejects.toThrow('disconnected');
+  });
+});

--- a/src/agent/tools/ReadDeviceFileTool.ts
+++ b/src/agent/tools/ReadDeviceFileTool.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface ReadDeviceFileArgs {
+  path: string;
+}
+
+export class ReadDeviceFileTool implements Tool<ReadDeviceFileArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'read_device_file',
+      description:
+        'Reads a UTF-8 text file at the given absolute device path on the connected ' +
+        'microcontroller. Returns "binary file — cannot read" if the file is not valid UTF-8.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style).',
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+      scope: 'read',
+      requiresApproval: false,
+    };
+  }
+
+  async call(args: ReadDeviceFileArgs): Promise<string> {
+    const { deviceFs } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+    try {
+      return await deviceFs.readText(args.path);
+    } catch (err) {
+      // DeviceFs.readText wraps TextDecoder TypeErrors as Error with the
+      // TypeError attached as `cause`. Translate that to a tool-level message;
+      // let every other error (DeviceFsError, ReplDisconnectedError, …) pass.
+      if (err instanceof Error && err.cause instanceof TypeError) {
+        return 'binary file — cannot read';
+      }
+      throw err;
+    }
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -24,6 +24,7 @@ describe('wireTools', () => {
     const names = tools.getTools().map((t) => t.name).sort();
     expect(names).toEqual([
       'list_device_files',
+      'read_device_file',
       'read_editor',
       'read_repl_history',
       'run_editor',
@@ -36,7 +37,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(6);
+    expect(tools.getTools()).toHaveLength(7);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -10,6 +10,7 @@ import { RunEditorTool } from './tools/RunEditorTool';
 import { RunSnippetTool } from './tools/RunSnippetTool';
 import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
 import { ListDeviceFilesTool } from './tools/ListDeviceFilesTool';
+import { ReadDeviceFileTool } from './tools/ReadDeviceFileTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -40,4 +41,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new RunSnippetTool(get));
   tools.register(new ReadReplHistoryTool(get));
   tools.register(new ListDeviceFilesTool(get));
+  tools.register(new ReadDeviceFileTool(get));
 }


### PR DESCRIPTION
## Summary
- New `read_device_file` agent tool: reads a UTF-8 text file at an absolute device path via `DeviceFs.readText`.
- Returns `"binary file — cannot read"` when the file is not valid UTF-8 (detected via `err.cause instanceof TypeError`, the wrapping that `DeviceFs.readText` applies to `TextDecoder` failures). Other errors (`DeviceFsError`, disconnects) propagate.
- No-ops with `"Device is not connected."` when `deviceFs` is null.
- Wired into `wireTools` and added to `CODING_AGENT.tools`; instructions updated with one sentence.

Closes #82.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (290 passing, includes 8 new cases for `ReadDeviceFileTool`)
- [x] `npm run build`
- [x] Manual browser test: agent reads a text file and a binary file on a connected device