### PR TITLE
feat(device-files): expose sendRaw from useReplConnection

### DIFF
--- a/src/hooks/useReplConnection.test.ts
+++ b/src/hooks/useReplConnection.test.ts
@@ -82,6 +82,32 @@ describe('useReplConnection', () => {
     await expect(result.current.runCode('print("hi")')).rejects.toThrow(/not connected/i);
   });
 
+  it('sendRaw() calls repl.sendRaw() with the given code', async () => {
+    const { result } = renderHook(() => useReplConnection());
+    await act(() => result.current.connect());
+    await act(() => result.current.sendRaw('import os'));
+    expect(mockRepl.sendRaw).toHaveBeenCalledWith('import os');
+  });
+
+  it("sendRaw() resolves with the device's stdout/stderr", async () => {
+    (mockRepl.sendRaw as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      stdout: '["main.py"]',
+      stderr: '',
+    });
+    const { result } = renderHook(() => useReplConnection());
+    await act(() => result.current.connect());
+    let runResult: {stdout: string; stderr: string} | undefined;
+    await act(async () => {
+      runResult = await result.current.sendRaw('import os; print(os.listdir("/"))');
+    });
+    expect(runResult).toEqual({stdout: '["main.py"]', stderr: ''});
+  });
+
+  it('sendRaw() rejects when not connected', async () => {
+    const { result } = renderHook(() => useReplConnection());
+    await expect(result.current.sendRaw('import os')).rejects.toThrow(/not connected/i);
+  });
+
   it('onData handler receives data dispatched by repl', async () => {
     const { result } = renderHook(() => useReplConnection());
     await act(() => result.current.connect());

--- a/src/hooks/useReplConnection.ts
+++ b/src/hooks/useReplConnection.ts
@@ -98,6 +98,13 @@ export function useReplConnection() {
     return replRef.current.sendRaw(code);
   }, []);
 
+  const sendRaw = useCallback(async (code: string): Promise<RunResult> => {
+    if (!replRef.current) {
+      throw new Error('Not connected');
+    }
+    return replRef.current.sendRaw(code);
+  }, []);
+
   const send = useCallback(async (data: string) => {
     if (replRef.current) {
       try {
@@ -113,5 +120,15 @@ export function useReplConnection() {
     return () => handlersRef.current.delete(handler);
   }, []);
 
-  return { connectionState, connect, disconnect, reset, runCode, send, replHistory, onData };
+  return {
+    connectionState,
+    connect,
+    disconnect,
+    reset,
+    runCode,
+    sendRaw,
+    send,
+    replHistory,
+    onData,
+  };
 }


### PR DESCRIPTION
## Summary
- Adds a sibling `sendRaw(code)` callback to `useReplConnection` so device-fs callers don't share the "run user code" semantics of `runCode`. Both delegate to `replRef.current.sendRaw`, so the existing `ReplInterface` write-chain mutex continues to serialise concurrent user-Run and device-fs ops automatically.
- Hook tests extended with symmetric coverage for `sendRaw` (happy path, stdout/stderr passthrough, not-connected rejection).

Implements `docs/device-files/SPEC.md` § "Hook integration".

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (293/293)
- [x] `npm run build`
- [x] Manual browser smoke — Run still works, no regression on existing REPL connect/disconnect/reset.

Closes #65