### PR TITLE
feat(device-files): upgrade FileNavigator to a lazy expandable tree

### DIFF
--- a/src/components/FileNavigator.test.tsx
+++ b/src/components/FileNavigator.test.tsx
@@ -6,20 +6,33 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileNavigator } from './FileNavigator';
 
-function makeDirectoryHandle(files: Record<string, string>) {
-  const entries = Object.entries(files).map(([name, content]) => {
-    const handle = {
-      kind: 'file' as const,
-      getFile: vi.fn().mockResolvedValue({ text: vi.fn().mockResolvedValue(content) }),
-    };
-    return [name, handle] as const;
+type FakeEntry =
+  | { kind: 'file'; content: string }
+  | { kind: 'directory'; entries: Record<string, FakeEntry> };
+
+function makeDirectoryHandle(name: string, entries: Record<string, FakeEntry>): unknown {
+  const childHandles: [string, unknown][] = Object.entries(entries).map(([childName, entry]) => {
+    if (entry.kind === 'file') {
+      const fileHandle = {
+        kind: 'file' as const,
+        name: childName,
+        getFile: vi
+          .fn()
+          .mockResolvedValue({ text: vi.fn().mockResolvedValue(entry.content) }),
+      };
+      return [childName, fileHandle];
+    }
+    return [childName, makeDirectoryHandle(childName, entry.entries)];
   });
 
   return {
-    entries: vi.fn().mockReturnValue(
-      (async function* () {
-        for (const entry of entries) yield entry;
-      })(),
+    kind: 'directory' as const,
+    name,
+    entries: vi.fn().mockImplementation(
+      () =>
+        (async function* () {
+          for (const entry of childHandles) yield entry;
+        })(),
     ),
   };
 }
@@ -28,7 +41,18 @@ describe('FileNavigator', () => {
   beforeEach(() => {
     vi.stubGlobal(
       'showDirectoryPicker',
-      vi.fn().mockResolvedValue(makeDirectoryHandle({ 'main.py': 'print("hello")', 'boot.py': '' })),
+      vi.fn().mockResolvedValue(
+        makeDirectoryHandle('project', {
+          'main.py': { kind: 'file', content: 'print("hello")' },
+          'boot.py': { kind: 'file', content: '' },
+          lib: {
+            kind: 'directory',
+            entries: {
+              'helper.py': { kind: 'file', content: 'def help(): pass' },
+            },
+          },
+        }),
+      ),
     );
   });
 
@@ -43,11 +67,24 @@ describe('FileNavigator', () => {
     expect(window.showDirectoryPicker).toHaveBeenCalledOnce();
   });
 
-  it('lists files from the directory after opening', async () => {
+  it('renders the picked root expanded with its children', async () => {
     render(<FileNavigator onFileSelected={vi.fn()} />);
     await userEvent.click(screen.getByTitle('Open folder'));
-    expect(await screen.findByText('main.py')).toBeInTheDocument();
+    expect(await screen.findByText('project')).toBeInTheDocument();
+    expect(screen.getByText('main.py')).toBeInTheDocument();
     expect(screen.getByText('boot.py')).toBeInTheDocument();
+    expect(screen.getByText('lib')).toBeInTheDocument();
+  });
+
+  it('lists directories before files, alphabetically', async () => {
+    render(<FileNavigator onFileSelected={vi.fn()} />);
+    await userEvent.click(screen.getByTitle('Open folder'));
+    await screen.findByText('project');
+    const names = screen
+      .getAllByRole('button')
+      .map((b) => b.textContent ?? '')
+      .filter((t) => t !== '' && t !== 'Open Folder');
+    expect(names).toEqual(['project', 'lib', 'boot.py', 'main.py']);
   });
 
   it('calls onFileSelected with content when a file is clicked', async () => {
@@ -56,5 +93,33 @@ describe('FileNavigator', () => {
     await userEvent.click(screen.getByTitle('Open folder'));
     await userEvent.click(await screen.findByText('main.py'));
     expect(onFileSelected).toHaveBeenCalledWith('print("hello")');
+  });
+
+  it('lazily loads subfolder children when expanded', async () => {
+    render(<FileNavigator onFileSelected={vi.fn()} />);
+    await userEvent.click(screen.getByTitle('Open folder'));
+    await screen.findByText('lib');
+    expect(screen.queryByText('helper.py')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByText('lib'));
+    expect(await screen.findByText('helper.py')).toBeInTheDocument();
+  });
+
+  it('collapses an expanded folder, hiding its children', async () => {
+    render(<FileNavigator onFileSelected={vi.fn()} />);
+    await userEvent.click(screen.getByTitle('Open folder'));
+    await userEvent.click(await screen.findByText('lib'));
+    await screen.findByText('helper.py');
+    await userEvent.click(screen.getByText('lib'));
+    expect(screen.queryByText('helper.py')).not.toBeInTheDocument();
+  });
+
+  it('reuses cached children when re-expanding a previously loaded folder', async () => {
+    render(<FileNavigator onFileSelected={vi.fn()} />);
+    await userEvent.click(screen.getByTitle('Open folder'));
+    await userEvent.click(await screen.findByText('lib'));
+    await screen.findByText('helper.py');
+    await userEvent.click(screen.getByText('lib'));
+    await userEvent.click(screen.getByText('lib'));
+    expect(await screen.findByText('helper.py')).toBeInTheDocument();
   });
 });

--- a/src/components/FileNavigator.tsx
+++ b/src/components/FileNavigator.tsx
@@ -1,25 +1,56 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { FolderOpen } from 'lucide-react';
+import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from 'lucide-react';
 import { useState } from 'react';
+
+interface LocalTreeNode {
+  handle: FileSystemDirectoryHandle;
+  name: string;
+  isDir: true;
+  expanded: boolean;
+  children: LocalTreeEntry[];
+}
+
+interface LocalTreeFile {
+  handle: FileSystemFileHandle;
+  name: string;
+  isDir: false;
+}
+
+type LocalTreeEntry = LocalTreeNode | LocalTreeFile;
 
 interface FileNavigatorProps {
   onFileSelected: (content: string) => void;
 }
 
 export function FileNavigator({ onFileSelected }: FileNavigatorProps) {
-  const [files, setFiles] = useState<Map<string, FileSystemFileHandle>>(new Map());
+  const [root, setRoot] = useState<LocalTreeNode | null>(null);
 
   const openDirectory = async () => {
     const dirHandle = await window.showDirectoryPicker();
-    const newFiles = new Map<string, FileSystemFileHandle>();
-    for await (const [name, handle] of dirHandle.entries()) {
-      if (handle.kind === 'file') {
-        newFiles.set(name, handle as FileSystemFileHandle);
-      }
+    const children = await loadChildren(dirHandle);
+    setRoot({
+      handle: dirHandle,
+      name: dirHandle.name,
+      isDir: true,
+      expanded: true,
+      children,
+    });
+  };
+
+  const toggleFolder = async (path: string[]) => {
+    if (!root) return;
+    const node = findNode(root, path);
+    if (!node) return;
+    if (node.expanded) {
+      setRoot((r) => (r ? updateNode(r, path, (n) => ({ ...n, expanded: false })) : r));
+      return;
     }
-    setFiles(newFiles);
+    const children = node.children.length === 0 ? await loadChildren(node.handle) : node.children;
+    setRoot((r) =>
+      r ? updateNode(r, path, (n) => ({ ...n, expanded: true, children })) : r,
+    );
   };
 
   const openFile = async (handle: FileSystemFileHandle) => {
@@ -40,18 +71,127 @@ export function FileNavigator({ onFileSelected }: FileNavigatorProps) {
           Open Folder
         </button>
       </div>
-      <ul className="flex-1 overflow-y-auto">
-        {[...files.entries()].map(([name, handle]) => (
-          <li key={name}>
-            <button
-              onClick={() => openFile(handle)}
-              className="w-full text-left px-3 py-1 text-sm hover:bg-accent transition-colors truncate"
-            >
-              {name}
-            </button>
-          </li>
-        ))}
-      </ul>
+      <div className="flex-1 overflow-y-auto">
+        {root && (
+          <TreeRow
+            entry={root}
+            path={[]}
+            depth={0}
+            onToggle={toggleFolder}
+            onOpenFile={openFile}
+          />
+        )}
+      </div>
     </div>
   );
+}
+
+interface TreeRowProps {
+  entry: LocalTreeEntry;
+  path: string[];
+  depth: number;
+  onToggle: (path: string[]) => void;
+  onOpenFile: (handle: FileSystemFileHandle) => void;
+}
+
+function TreeRow({ entry, path, depth, onToggle, onOpenFile }: TreeRowProps) {
+  const indent = 8 + depth * 12;
+  if (entry.isDir) {
+    return (
+      <>
+        <button
+          onClick={() => onToggle(path)}
+          style={{ paddingLeft: indent }}
+          className="flex items-center gap-1.5 w-full text-left pr-2 py-1 text-sm hover:bg-accent transition-colors truncate"
+        >
+          {entry.expanded ? (
+            <ChevronDown size={12} className="shrink-0" />
+          ) : (
+            <ChevronRight size={12} className="shrink-0" />
+          )}
+          <Folder size={14} className="shrink-0" />
+          <span className="truncate">{entry.name}</span>
+        </button>
+        {entry.expanded &&
+          entry.children.map((child) => (
+            <TreeRow
+              key={child.name}
+              entry={child}
+              path={[...path, child.name]}
+              depth={depth + 1}
+              onToggle={onToggle}
+              onOpenFile={onOpenFile}
+            />
+          ))}
+      </>
+    );
+  }
+  return (
+    <button
+      onClick={() => onOpenFile(entry.handle)}
+      style={{ paddingLeft: indent + 12 }}
+      className="flex items-center gap-1.5 w-full text-left pr-2 py-1 text-sm hover:bg-accent transition-colors truncate"
+    >
+      <File size={14} className="shrink-0" />
+      <span className="truncate">{entry.name}</span>
+    </button>
+  );
+}
+
+async function loadChildren(dirHandle: FileSystemDirectoryHandle): Promise<LocalTreeEntry[]> {
+  const entries: LocalTreeEntry[] = [];
+  for await (const [name, handle] of dirHandle.entries()) {
+    if (handle.kind === 'directory') {
+      entries.push({
+        handle: handle as FileSystemDirectoryHandle,
+        name,
+        isDir: true,
+        expanded: false,
+        children: [],
+      });
+    } else {
+      entries.push({
+        handle: handle as FileSystemFileHandle,
+        name,
+        isDir: false,
+      });
+    }
+  }
+  entries.sort(compareEntries);
+  return entries;
+}
+
+function compareEntries(a: LocalTreeEntry, b: LocalTreeEntry): number {
+  if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+  return a.name.localeCompare(b.name);
+}
+
+function findNode(root: LocalTreeNode, path: string[]): LocalTreeNode | null {
+  let node: LocalTreeNode = root;
+  for (const segment of path) {
+    const next = node.children.find((c) => c.isDir && c.name === segment);
+    if (!next || !next.isDir) return null;
+    node = next;
+  }
+  return node;
+}
+
+function updateNode(
+  root: LocalTreeNode,
+  path: string[],
+  updater: (node: LocalTreeNode) => LocalTreeNode,
+): LocalTreeNode {
+  if (path.length === 0) return updater(root);
+  const [head, ...rest] = path;
+  let changed = false;
+  const newChildren = root.children.map((c) => {
+    if (c.isDir && c.name === head) {
+      const updated = updateNode(c, rest, updater);
+      if (updated !== c) changed = true;
+      return updated;
+    }
+    return c;
+  });
+  if (!changed) return root;
+  return { ...root, children: newChildren };
 }


### PR DESCRIPTION
## Summary
- `<FileNavigator>` now holds a `LocalTreeNode | null` root after the user picks a directory. Folders click-to-toggle-expand; children load lazily via `dirHandle.entries()`. Files click-to-open via the existing `onFileSelected` callback.
- First expand of a subfolder iterates entries and caches them on the node; subsequent collapses keep the cached subtree so re-expand is instant. Sorting matches the device-side tree (directories first, then alphabetical).
- Rendering uses `ChevronRight`/`ChevronDown` + `Folder`/`File` icons (lucide), indented by depth — visually parallel to the upcoming `<DeviceFileNavigator>` so navigation feels symmetric.
- 4 new Vitest cases for expand/collapse/sort/re-expand caching; existing open-flow assertions retained. Lint, build, and full test suite (322/322) pass.
- Drag-and-drop, rename, create, and delete are intentionally out of scope here — they ship in #78 / #79 / etc.

Implements `docs/device-files/SPEC.md` § "<FileNavigator> updates".

Closes #67

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (322/322)
- [x] `npm run build`
- [x] Manual browser smoke — Open Folder picks a directory; nested folders expand/collapse lazily; clicking a file loads its contents into the editor.