### PR TITLE
feat(device-files): add Toolbar Save button + Ctrl+S shortcut

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AgentProvider, INLINE_APPROVAL } from '@mast-ai/react-ui';
 import { AgentRunner } from '@mast-ai/core';
 import { SplitPane } from './components/SplitPane';
@@ -21,6 +21,7 @@ import { createAdapter } from './providers/factory';
 import { CODING_AGENT } from './agent/config';
 import { wireTools } from './agent/wireTools';
 import { DeviceFs } from './DeviceFs';
+import { saveEditor } from './lib/saveEditor';
 
 const models = createModels();
 
@@ -29,12 +30,29 @@ export function App() {
     useReplConnection();
   const { config, save: saveConfig, clear: clearConfig } = useProviderConfig();
   const { theme, preference: themePreference, cycle: cycleTheme } = useTheme();
-  const { editorRef, getContent, setContent } = useEditor(theme);
+  const { editorRef, getContent, setContent, origin, setOriginAndContent } = useEditor(theme);
 
   const deviceFs = useMemo(
     () => (connectionState === 'connected' ? new DeviceFs(runCode) : null),
     [connectionState, runCode],
   );
+
+  const handleSave = useCallback(() => {
+    saveEditor(origin, getContent(), setOriginAndContent).catch((err) => {
+      console.error('Save failed:', err);
+    });
+  }, [origin, getContent, setOriginAndContent]);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 's') {
+        e.preventDefault();
+        handleSave();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [handleSave]);
 
   useEffect(() => {
     wireTools(models.tools, {
@@ -95,6 +113,8 @@ export function App() {
             // promise rejection.
             runCode(getContent()).catch((err) => console.error('Run failed:', err));
           }}
+          onSave={handleSave}
+          saveEnabled={origin.kind !== 'device'}
           onOpenSettings={() => setIsSettingsOpen(true)}
           isAgentConfigured={config !== null}
           themePreference={themePreference}

--- a/src/components/Toolbar.test.tsx
+++ b/src/components/Toolbar.test.tsx
@@ -12,6 +12,8 @@ const defaults = {
   onDisconnect: vi.fn(),
   onReset: vi.fn(),
   onRun: vi.fn(),
+  onSave: vi.fn(),
+  saveEnabled: true,
   onOpenSettings: vi.fn(),
   isAgentConfigured: false,
   themePreference: 'light' as const,
@@ -69,6 +71,20 @@ describe('Toolbar', () => {
     render(<Toolbar {...defaults} onCycleTheme={onCycleTheme} />);
     await userEvent.click(screen.getByTitle(/Theme:/));
     expect(onCycleTheme).toHaveBeenCalledOnce();
+  });
+
+  it('renders the Save button and calls onSave when clicked', async () => {
+    const onSave = vi.fn();
+    render(<Toolbar {...defaults} onSave={onSave} />);
+    const saveButton = screen.getByRole('button', { name: /Save/ });
+    expect(saveButton).not.toBeDisabled();
+    await userEvent.click(saveButton);
+    expect(onSave).toHaveBeenCalledOnce();
+  });
+
+  it('disables Save when saveEnabled is false', () => {
+    render(<Toolbar {...defaults} saveEnabled={false} />);
+    expect(screen.getByRole('button', { name: /Save/ })).toBeDisabled();
   });
 
   it('reflects each theme preference in the button title', () => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { Monitor, Moon, Play, Plug, RotateCcw, Settings, Sun, Unplug } from 'lucide-react';
+import { Monitor, Moon, Play, Plug, RotateCcw, Save, Settings, Sun, Unplug } from 'lucide-react';
 
 type ConnectionState = 'disconnected' | 'connected';
 type ThemePreference = 'light' | 'dark' | 'system';
@@ -12,11 +12,18 @@ interface ToolbarProps {
   onDisconnect: () => void;
   onReset: () => void;
   onRun: () => void;
+  onSave: () => void;
+  saveEnabled: boolean;
   onOpenSettings: () => void;
   isAgentConfigured: boolean;
   themePreference: ThemePreference;
   onCycleTheme: () => void;
 }
+
+const SAVE_SHORTCUT_LABEL =
+  typeof navigator !== 'undefined' && /Mac|iP(hone|ad|od)/i.test(navigator.platform)
+    ? '⌘S'
+    : 'Ctrl+S';
 
 const THEME_LABEL: Record<ThemePreference, string> = {
   light: 'Theme: light (click for dark)',
@@ -30,13 +37,14 @@ export function Toolbar({
   onDisconnect,
   onReset,
   onRun,
+  onSave,
+  saveEnabled,
   onOpenSettings,
   themePreference,
   onCycleTheme,
 }: ToolbarProps) {
   const connected = connectionState === 'connected';
-  const ThemeIcon =
-    themePreference === 'light' ? Sun : themePreference === 'dark' ? Moon : Monitor;
+  const ThemeIcon = themePreference === 'light' ? Sun : themePreference === 'dark' ? Moon : Monitor;
 
   return (
     <div className="flex items-center gap-2 h-10 px-3 bg-muted border-b border-border shrink-0">
@@ -81,6 +89,16 @@ export function Toolbar({
         >
           <Play size={14} />
           Run
+        </button>
+
+        <button
+          onClick={onSave}
+          disabled={!saveEnabled}
+          title={`Save (${SAVE_SHORTCUT_LABEL})`}
+          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <Save size={14} />
+          Save
         </button>
       </div>
 

--- a/src/lib/saveEditor.test.ts
+++ b/src/lib/saveEditor.test.ts
@@ -1,0 +1,144 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { saveEditor } from './saveEditor';
+import type { EditorOrigin } from '../hooks/useEditor';
+
+interface FakeWritable {
+  write: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+}
+
+interface FakeFileHandle {
+  name: string;
+  createWritable: ReturnType<typeof vi.fn>;
+  __writable: FakeWritable;
+}
+
+function makeFakeHandle(name: string): FakeFileHandle {
+  const writable: FakeWritable = {
+    write: vi.fn().mockResolvedValue(undefined),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  return {
+    name,
+    createWritable: vi.fn().mockResolvedValue(writable),
+    __writable: writable,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('saveEditor', () => {
+  describe('origin: device', () => {
+    it('is a no-op', async () => {
+      const setOriginAndContent = vi.fn();
+      const result = await saveEditor(
+        { kind: 'device', path: '/main.py' },
+        'print("hi")',
+        setOriginAndContent
+      );
+      expect(result).toBe('noop');
+      expect(setOriginAndContent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('origin: local', () => {
+    it('writes through createWritable() and re-snapshots', async () => {
+      const handle = makeFakeHandle('main.py');
+      const origin: EditorOrigin = {
+        kind: 'local',
+        handle: handle as unknown as FileSystemFileHandle,
+        name: 'main.py',
+      };
+      const setOriginAndContent = vi.fn();
+
+      const result = await saveEditor(origin, 'edited', setOriginAndContent);
+
+      expect(result).toBe('saved');
+      expect(handle.createWritable).toHaveBeenCalledOnce();
+      expect(handle.__writable.write).toHaveBeenCalledWith('edited');
+      expect(handle.__writable.close).toHaveBeenCalledOnce();
+      expect(setOriginAndContent).toHaveBeenCalledWith(origin, 'edited');
+    });
+
+    it('closes the writable even if write fails', async () => {
+      const handle = makeFakeHandle('main.py');
+      handle.__writable.write.mockRejectedValueOnce(new Error('disk full'));
+      const setOriginAndContent = vi.fn();
+
+      await expect(
+        saveEditor(
+          {
+            kind: 'local',
+            handle: handle as unknown as FileSystemFileHandle,
+            name: 'main.py',
+          },
+          'edited',
+          setOriginAndContent
+        )
+      ).rejects.toThrow('disk full');
+
+      expect(handle.__writable.close).toHaveBeenCalledOnce();
+      expect(setOriginAndContent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('origin: untitled', () => {
+    let pickerHandle: FakeFileHandle;
+    let showSaveFilePicker: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      pickerHandle = makeFakeHandle('chosen.py');
+      showSaveFilePicker = vi.fn().mockResolvedValue(pickerHandle);
+      vi.stubGlobal('showSaveFilePicker', showSaveFilePicker);
+    });
+
+    it('opens the save picker, writes content, and transitions origin to local', async () => {
+      const setOriginAndContent = vi.fn();
+
+      const result = await saveEditor({ kind: 'untitled' }, 'print("hello")', setOriginAndContent);
+
+      expect(result).toBe('saved');
+      expect(showSaveFilePicker).toHaveBeenCalledOnce();
+      const args = showSaveFilePicker.mock.calls[0][0];
+      expect(args.suggestedName).toBe('untitled.py');
+      expect(args.types[0].accept['text/x-python']).toContain('.py');
+
+      expect(pickerHandle.__writable.write).toHaveBeenCalledWith('print("hello")');
+      expect(pickerHandle.__writable.close).toHaveBeenCalledOnce();
+      expect(setOriginAndContent).toHaveBeenCalledWith(
+        {
+          kind: 'local',
+          handle: pickerHandle,
+          name: 'chosen.py',
+        },
+        'print("hello")'
+      );
+    });
+
+    it('returns "cancelled" and does nothing when the user dismisses the picker', async () => {
+      showSaveFilePicker.mockRejectedValueOnce(new DOMException('cancelled', 'AbortError'));
+      const setOriginAndContent = vi.fn();
+
+      const result = await saveEditor({ kind: 'untitled' }, 'unsaved', setOriginAndContent);
+
+      expect(result).toBe('cancelled');
+      expect(setOriginAndContent).not.toHaveBeenCalled();
+    });
+
+    it('rethrows non-Abort errors from the picker', async () => {
+      showSaveFilePicker.mockRejectedValueOnce(new Error('boom'));
+      const setOriginAndContent = vi.fn();
+
+      await expect(
+        saveEditor({ kind: 'untitled' }, 'unsaved', setOriginAndContent)
+      ).rejects.toThrow('boom');
+      expect(setOriginAndContent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/saveEditor.ts
+++ b/src/lib/saveEditor.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { EditorOrigin } from '../hooks/useEditor';
+
+export type SaveEditorResult = 'saved' | 'cancelled' | 'noop';
+
+export async function saveEditor(
+  origin: EditorOrigin,
+  content: string,
+  setOriginAndContent: (origin: EditorOrigin, content: string) => void
+): Promise<SaveEditorResult> {
+  if (origin.kind === 'device') {
+    return 'noop';
+  }
+
+  if (origin.kind === 'local') {
+    await writeToHandle(origin.handle, content);
+    setOriginAndContent(origin, content);
+    return 'saved';
+  }
+
+  let handle: FileSystemFileHandle;
+  try {
+    handle = await window.showSaveFilePicker({
+      suggestedName: 'untitled.py',
+      types: [
+        {
+          description: 'Python source',
+          accept: { 'text/x-python': ['.py'] },
+        },
+      ],
+    });
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'AbortError') return 'cancelled';
+    throw err;
+  }
+
+  await writeToHandle(handle, content);
+  setOriginAndContent({ kind: 'local', handle, name: handle.name }, content);
+  return 'saved';
+}
+
+async function writeToHandle(handle: FileSystemFileHandle, content: string): Promise<void> {
+  const writable = await handle.createWritable();
+  try {
+    await writable.write(content);
+  } finally {
+    await writable.close();
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a Save button to the Toolbar (with platform-aware ⌘S / Ctrl+S label) and a window-level Ctrl+S/Cmd+S shortcut that calls `preventDefault` so the browser's save-page dialog never appears.
- New `saveEditor` helper handles the three editor origins:
  - `untitled` → `showSaveFilePicker()`, write content, transition origin to `local` (AbortError on cancel is swallowed).
  - `local` → `FileSystemFileHandle.createWritable()`, write, re-snapshot via `setOriginAndContent` so `isModified` resets.
  - `device` → no-op for now; the Save button is disabled in that state. Device save lands with the open-in-editor PR (#72).

Implements SPEC § "Editor origin tracking" (Save behaviour for local/untitled).

Closes #69

## Test plan
- [x] `npm run lint`, `npm run test` (336 passing), `npm run build`
- [x] Manual: untitled → Ctrl+S opens picker → save as foo.py → file written, isModified clears
- [x] Manual: edit saved file → Ctrl+S overwrites in place, no picker
- [x] Manual: Toolbar Save button mirrors the shortcut
- [x] Manual: Ctrl+S does not trigger the browser save-page dialog