### PR TITLE
feat(device-files): add vertical split with DeviceFileNavigator placeholder

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Toolbar } from './components/Toolbar';
 import { ReplShell } from './components/ReplShell';
 import { CodeEditor } from './components/CodeEditor';
 import { FileNavigator } from './components/FileNavigator';
+import { DeviceFileNavigator } from './components/DeviceFileNavigator';
 import { SettingsPanel } from './components/SettingsPanel';
 import { AgentPanel } from './components/AgentPanel';
 import { useReplConnection } from './hooks/useReplConnection';
@@ -86,6 +87,7 @@ export function App() {
   const [rightSize, setRightSize] = useState(35);
   const [replOpen, setReplOpen] = useState(true);
   const [replSize, setReplSize] = useState(40);
+  const [leftSplitSize, setLeftSplitSize] = useState(50);
 
   return (
     <AgentProvider
@@ -129,7 +131,18 @@ export function App() {
             collapsed={!leftOpen}
           >
             {[
-              <FileNavigator key="files" onFileSelected={setContent} />,
+              <SplitPane
+                key="left"
+                orientation="vertical"
+                initialSize={leftSplitSize}
+                size={leftSplitSize}
+                onSizeChange={setLeftSplitSize}
+              >
+                {[
+                  <FileNavigator key="files" onFileSelected={setContent} />,
+                  <DeviceFileNavigator key="device-files" />,
+                ]}
+              </SplitPane>,
               <SplitPane
                 key="main"
                 orientation="horizontal"

--- a/src/components/DeviceFileNavigator.tsx
+++ b/src/components/DeviceFileNavigator.tsx
@@ -1,0 +1,15 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export function DeviceFileNavigator() {
+  return (
+    <div className="flex flex-col h-full bg-muted/30">
+      <div className="flex items-center px-2 py-1 border-b border-border">
+        <span className="px-2 py-1 text-sm font-medium">Device Files</span>
+      </div>
+      <div className="flex-1 overflow-y-auto px-3 py-2 text-sm text-muted-foreground">
+        Connect a device to browse its files.
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Splits the left pane into a vertical `<SplitPane>` (50/50 default, draggable) between the existing `<FileNavigator>` (top) and a new `<DeviceFileNavigator>` placeholder (bottom).
- Adds `src/components/DeviceFileNavigator.tsx` with the "Device Files" header and the empty-state message "Connect a device to browse its files." No props, no device API calls — purely layout, per [SPEC § "UI — Layout"](../blob/main/docs/device-files/SPEC.md#layout).
- Tree rendering arrives in the next phase (#71).

Closes #70

## Test plan
- [x] `npm run lint`, `npm run test`, `npm run build` all pass
- [x] Manually verified in the browser: header + empty-state render, divider drags, existing pane toggles still work