### PR TITLE
feat(device-files): render device tree (read-only)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { SettingsPanel } from './components/SettingsPanel';
 import { AgentPanel } from './components/AgentPanel';
 import { useReplConnection } from './hooks/useReplConnection';
 import { useEditor } from './hooks/useEditor';
+import { useDeviceFs } from './hooks/useDeviceFs';
 import { useProviderConfig } from './hooks/useProviderConfig';
 import { useTheme } from './hooks/useTheme';
 import { createModels } from './models';
@@ -27,11 +28,13 @@ import { saveEditor } from './lib/saveEditor';
 const models = createModels();
 
 export function App() {
-  const { connectionState, connect, disconnect, reset, runCode, send, onData, replHistory } =
+  const { connectionState, connect, disconnect, reset, runCode, sendRaw, send, onData, replHistory } =
     useReplConnection();
   const { config, save: saveConfig, clear: clearConfig } = useProviderConfig();
   const { theme, preference: themePreference, cycle: cycleTheme } = useTheme();
   const { editorRef, getContent, setContent, origin, setOriginAndContent } = useEditor(theme);
+
+  const deviceFsHook = useDeviceFs({ connectionState, sendRaw });
 
   const deviceFs = useMemo(
     () => (connectionState === 'connected' ? new DeviceFs(runCode) : null),
@@ -140,7 +143,21 @@ export function App() {
               >
                 {[
                   <FileNavigator key="files" onFileSelected={setContent} />,
-                  <DeviceFileNavigator key="device-files" />,
+                  <DeviceFileNavigator
+                    key="device-files"
+                    isAvailable={deviceFsHook.isAvailable}
+                    tree={deviceFsHook.tree}
+                    busy={deviceFsHook.busy}
+                    onExpand={(p) => {
+                      deviceFsHook.expand(p).catch((err) => console.error('Expand failed:', err));
+                    }}
+                    onCollapse={deviceFsHook.collapse}
+                    onRefreshAll={() => {
+                      deviceFsHook.refreshAll().catch((err) =>
+                        console.error('Refresh failed:', err),
+                      );
+                    }}
+                  />,
                 ]}
               </SplitPane>,
               <SplitPane

--- a/src/components/DeviceFileNavigator.tsx
+++ b/src/components/DeviceFileNavigator.tsx
@@ -1,15 +1,106 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-export function DeviceFileNavigator() {
+import { ChevronDown, ChevronRight, File, Folder, Loader2, RefreshCw } from 'lucide-react';
+import type { DeviceTreeEntry, DeviceTreeNode } from '../hooks/useDeviceFs';
+
+interface DeviceFileNavigatorProps {
+  isAvailable: boolean;
+  tree: DeviceTreeNode | null;
+  busy: boolean;
+  onExpand: (path: string) => void;
+  onCollapse: (path: string) => void;
+  onRefreshAll: () => void;
+}
+
+export function DeviceFileNavigator({
+  isAvailable,
+  tree,
+  busy,
+  onExpand,
+  onCollapse,
+  onRefreshAll,
+}: DeviceFileNavigatorProps) {
   return (
     <div className="flex flex-col h-full bg-muted/30">
-      <div className="flex items-center px-2 py-1 border-b border-border">
-        <span className="px-2 py-1 text-sm font-medium">Device Files</span>
+      <div className="flex items-center gap-1 px-2 py-1 border-b border-border">
+        <span className="px-2 py-1 text-sm font-medium flex-1">Device Files</span>
+        {busy && (
+          <Loader2
+            size={14}
+            className="animate-spin text-muted-foreground shrink-0"
+            aria-label="Working"
+          />
+        )}
+        <button
+          onClick={onRefreshAll}
+          disabled={!isAvailable || busy}
+          title="Refresh"
+          aria-label="Refresh"
+          className="p-1 rounded hover:bg-accent transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <RefreshCw size={14} />
+        </button>
       </div>
-      <div className="flex-1 overflow-y-auto px-3 py-2 text-sm text-muted-foreground">
-        Connect a device to browse its files.
+      <div className="flex-1 overflow-y-auto">
+        {!isAvailable || !tree ? (
+          <div className="px-3 py-2 text-sm text-muted-foreground">
+            Connect a device to browse its files.
+          </div>
+        ) : (
+          <TreeRow entry={tree} depth={0} onExpand={onExpand} onCollapse={onCollapse} />
+        )}
       </div>
+    </div>
+  );
+}
+
+interface TreeRowProps {
+  entry: DeviceTreeEntry;
+  depth: number;
+  onExpand: (path: string) => void;
+  onCollapse: (path: string) => void;
+}
+
+function TreeRow({ entry, depth, onExpand, onCollapse }: TreeRowProps) {
+  const indent = 8 + depth * 12;
+  if (entry.isDir) {
+    const toggle = () => (entry.expanded ? onCollapse(entry.path) : onExpand(entry.path));
+    return (
+      <>
+        <button
+          onClick={toggle}
+          style={{ paddingLeft: indent }}
+          className="flex items-center gap-1.5 w-full text-left pr-2 py-1 text-sm hover:bg-accent transition-colors truncate"
+        >
+          {entry.expanded ? (
+            <ChevronDown size={12} className="shrink-0" />
+          ) : (
+            <ChevronRight size={12} className="shrink-0" />
+          )}
+          <Folder size={14} className="shrink-0" />
+          <span className="truncate">{entry.name}</span>
+        </button>
+        {entry.expanded &&
+          entry.children.map((child) => (
+            <TreeRow
+              key={child.path}
+              entry={child}
+              depth={depth + 1}
+              onExpand={onExpand}
+              onCollapse={onCollapse}
+            />
+          ))}
+      </>
+    );
+  }
+  return (
+    <div
+      style={{ paddingLeft: indent + 12 }}
+      className="flex items-center gap-1.5 w-full pr-2 py-1 text-sm text-muted-foreground truncate cursor-default"
+    >
+      <File size={14} className="shrink-0" />
+      <span className="truncate">{entry.name}</span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Wires `useDeviceFs` into `<App>` and replaces the `<DeviceFileNavigator>` placeholder with a real tree renderer.

- Header: title + busy spinner (`Loader2`) + Refresh button bound to `useDeviceFs.refreshAll`.
- Folder rows toggle expand/collapse via `useDeviceFs.expand` / `collapse`. Children load lazily.
- File rows are visually styled (icon + name) but not interactive yet — click-to-open lands in #67.
- When disconnected, the existing "Connect a device to browse its files." empty state remains.

The agent-tools `DeviceFs` instance in `<App>` is left in place; switching the agent over to the hook is out of scope for #71.

Implements SPEC § "UI — `<DeviceFileNavigator>`" (read-only behaviours).

Closes #71

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test`
- [x] Manual: connect device → root expands; nested folders expand/collapse on click; Refresh re-lists root + expanded subtrees; spinner appears during ops; file rows non-interactive; disconnect returns to empty state.