### PR TITLE
feat(device-files): open device file in editor; Save writes back

### DIFF
--- a/docs/device-files/SPEC.md
+++ b/docs/device-files/SPEC.md
@@ -384,6 +384,7 @@ Rename is omitted from agent tools for v1 (it's rarely a useful agent action and
 - `src/lib/devicePath.ts`
 - `src/hooks/useDeviceFs.ts`
 - `src/components/DeviceFileNavigator.tsx`
+- `src/components/EditorBanner.tsx` — inline strip for unsaved-changes confirmation and device-open errors.
 - `src/agent/tools/ListDeviceFilesTool.ts`
 - `src/agent/tools/ReadDeviceFileTool.ts`
 - `src/agent/tools/WriteDeviceFileTool.ts`

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,11 @@ import { ReplShell } from './components/ReplShell';
 import { CodeEditor } from './components/CodeEditor';
 import { FileNavigator } from './components/FileNavigator';
 import { DeviceFileNavigator } from './components/DeviceFileNavigator';
+import { EditorBanner } from './components/EditorBanner';
 import { SettingsPanel } from './components/SettingsPanel';
 import { AgentPanel } from './components/AgentPanel';
 import { useReplConnection } from './hooks/useReplConnection';
-import { useEditor } from './hooks/useEditor';
+import { useEditor, type EditorOrigin } from './hooks/useEditor';
 import { useDeviceFs } from './hooks/useDeviceFs';
 import { useProviderConfig } from './hooks/useProviderConfig';
 import { useTheme } from './hooks/useTheme';
@@ -32,31 +33,104 @@ export function App() {
     useReplConnection();
   const { config, save: saveConfig, clear: clearConfig } = useProviderConfig();
   const { theme, preference: themePreference, cycle: cycleTheme } = useTheme();
-  const { editorRef, getContent, setContent, origin, setOriginAndContent } = useEditor(theme);
+  const { editorRef, getContent, setContent, origin, setOriginAndContent, isModified } =
+    useEditor(theme);
 
   const deviceFsHook = useDeviceFs({ connectionState, sendRaw });
+  const { readBytes: deviceReadBytes, writeText: deviceWriteText } = deviceFsHook;
 
   const deviceFs = useMemo(
     () => (connectionState === 'connected' ? new DeviceFs(runCode) : null),
     [connectionState, runCode],
   );
 
-  const handleSave = useCallback(() => {
-    saveEditor(origin, getContent(), setOriginAndContent).catch((err) => {
-      console.error('Save failed:', err);
-    });
-  }, [origin, getContent, setOriginAndContent]);
+  type BannerState =
+    | { kind: 'pending-switch'; origin: EditorOrigin; content: string }
+    | { kind: 'message'; message: string };
+  const [banner, setBanner] = useState<BannerState | null>(null);
+
+  const handleSave = useCallback(async (): Promise<'saved' | 'cancelled' | 'noop'> => {
+    return saveEditor(origin, getContent(), setOriginAndContent, deviceWriteText);
+  }, [origin, getContent, setOriginAndContent, deviceWriteText]);
+
+  const handleSaveClick = useCallback(() => {
+    handleSave().catch((err) => console.error('Save failed:', err));
+  }, [handleSave]);
+
+  const handleOpenDeviceFile = useCallback(
+    async (path: string) => {
+      // Drop any stale banner from a previous open attempt; later branches
+      // raise a new banner when needed (binary file, error, pending switch).
+      setBanner(null);
+      try {
+        const bytes = await deviceReadBytes(path);
+        let text: string;
+        try {
+          text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+        } catch (err) {
+          if (err instanceof TypeError) {
+            setBanner({ kind: 'message', message: 'Binary file — cannot open in editor.' });
+            return;
+          }
+          throw err;
+        }
+        const newOrigin: EditorOrigin = { kind: 'device', path };
+        if (isModified) {
+          setBanner({ kind: 'pending-switch', origin: newOrigin, content: text });
+          return;
+        }
+        setOriginAndContent(newOrigin, text);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setBanner({ kind: 'message', message: `Failed to open: ${message}` });
+      }
+    },
+    [deviceReadBytes, isModified, setOriginAndContent],
+  );
+
+  const dismissBanner = useCallback(() => setBanner(null), []);
+
+  const acceptPendingSwitch = useCallback(() => {
+    if (banner?.kind !== 'pending-switch') return;
+    setOriginAndContent(banner.origin, banner.content);
+    setBanner(null);
+  }, [banner, setOriginAndContent]);
+
+  const saveAndAcceptPendingSwitch = useCallback(() => {
+    if (banner?.kind !== 'pending-switch') return;
+    const target = banner;
+    handleSave()
+      .then((result) => {
+        if (result === 'cancelled') return;
+        setOriginAndContent(target.origin, target.content);
+        setBanner(null);
+      })
+      .catch((err) => {
+        const message = err instanceof Error ? err.message : String(err);
+        setBanner({ kind: 'message', message: `Save failed: ${message}` });
+      });
+  }, [banner, handleSave, setOriginAndContent]);
+
+  // Banners reflect in-flight device-fs interactions (pending switch to a
+  // device file, binary-file warning, open errors). On disconnect those
+  // become stale — the target path is unreachable — so dismiss using the
+  // documented "adjust state during render" pattern.
+  const [prevIsAvailable, setPrevIsAvailable] = useState(deviceFsHook.isAvailable);
+  if (prevIsAvailable !== deviceFsHook.isAvailable) {
+    setPrevIsAvailable(deviceFsHook.isAvailable);
+    if (!deviceFsHook.isAvailable && banner !== null) setBanner(null);
+  }
 
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if ((e.ctrlKey || e.metaKey) && !e.altKey && !e.shiftKey && e.key.toLowerCase() === 's') {
         e.preventDefault();
-        handleSave();
+        handleSaveClick();
       }
     };
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [handleSave]);
+  }, [handleSaveClick]);
 
   useEffect(() => {
     wireTools(models.tools, {
@@ -118,8 +192,8 @@ export function App() {
             // promise rejection.
             runCode(getContent()).catch((err) => console.error('Run failed:', err));
           }}
-          onSave={handleSave}
-          saveEnabled={origin.kind !== 'device'}
+          onSave={handleSaveClick}
+          saveEnabled={origin.kind !== 'device' || deviceFsHook.isAvailable}
           onOpenSettings={() => setIsSettingsOpen(true)}
           isAgentConfigured={config !== null}
           themePreference={themePreference}
@@ -157,6 +231,11 @@ export function App() {
                         console.error('Refresh failed:', err),
                       );
                     }}
+                    onOpenFile={(p) => {
+                      handleOpenDeviceFile(p).catch((err) =>
+                        console.error('Open device file failed:', err),
+                      );
+                    }}
                   />,
                 ]}
               </SplitPane>,
@@ -178,7 +257,34 @@ export function App() {
                     collapsed={!replOpen}
                   >
                     {[
-                      <CodeEditor key="editor" editorRef={editorRef} />,
+                      <div
+                        key="editor"
+                        style={{
+                          display: 'flex',
+                          flexDirection: 'column',
+                          width: '100%',
+                          height: '100%',
+                        }}
+                      >
+                        {banner?.kind === 'pending-switch' && (
+                          <EditorBanner
+                            kind="pending-switch"
+                            onSave={saveAndAcceptPendingSwitch}
+                            onDiscard={acceptPendingSwitch}
+                            onCancel={dismissBanner}
+                          />
+                        )}
+                        {banner?.kind === 'message' && (
+                          <EditorBanner
+                            kind="message"
+                            message={banner.message}
+                            onDismiss={dismissBanner}
+                          />
+                        )}
+                        <div style={{ flex: 1, minHeight: 0 }}>
+                          <CodeEditor editorRef={editorRef} />
+                        </div>
+                      </div>,
                       <ReplShell key="repl" onData={onData} onInput={send} theme={theme} />,
                     ]}
                   </SplitPane>,

--- a/src/components/DeviceFileNavigator.tsx
+++ b/src/components/DeviceFileNavigator.tsx
@@ -11,6 +11,7 @@ interface DeviceFileNavigatorProps {
   onExpand: (path: string) => void;
   onCollapse: (path: string) => void;
   onRefreshAll: () => void;
+  onOpenFile: (path: string) => void;
 }
 
 export function DeviceFileNavigator({
@@ -20,6 +21,7 @@ export function DeviceFileNavigator({
   onExpand,
   onCollapse,
   onRefreshAll,
+  onOpenFile,
 }: DeviceFileNavigatorProps) {
   return (
     <div className="flex flex-col h-full bg-muted/30">
@@ -48,7 +50,13 @@ export function DeviceFileNavigator({
             Connect a device to browse its files.
           </div>
         ) : (
-          <TreeRow entry={tree} depth={0} onExpand={onExpand} onCollapse={onCollapse} />
+          <TreeRow
+            entry={tree}
+            depth={0}
+            onExpand={onExpand}
+            onCollapse={onCollapse}
+            onOpenFile={onOpenFile}
+          />
         )}
       </div>
     </div>
@@ -60,9 +68,10 @@ interface TreeRowProps {
   depth: number;
   onExpand: (path: string) => void;
   onCollapse: (path: string) => void;
+  onOpenFile: (path: string) => void;
 }
 
-function TreeRow({ entry, depth, onExpand, onCollapse }: TreeRowProps) {
+function TreeRow({ entry, depth, onExpand, onCollapse, onOpenFile }: TreeRowProps) {
   const indent = 8 + depth * 12;
   if (entry.isDir) {
     const toggle = () => (entry.expanded ? onCollapse(entry.path) : onExpand(entry.path));
@@ -89,18 +98,20 @@ function TreeRow({ entry, depth, onExpand, onCollapse }: TreeRowProps) {
               depth={depth + 1}
               onExpand={onExpand}
               onCollapse={onCollapse}
+              onOpenFile={onOpenFile}
             />
           ))}
       </>
     );
   }
   return (
-    <div
+    <button
+      onClick={() => onOpenFile(entry.path)}
       style={{ paddingLeft: indent + 12 }}
-      className="flex items-center gap-1.5 w-full pr-2 py-1 text-sm text-muted-foreground truncate cursor-default"
+      className="flex items-center gap-1.5 w-full text-left pr-2 py-1 text-sm hover:bg-accent transition-colors truncate"
     >
       <File size={14} className="shrink-0" />
       <span className="truncate">{entry.name}</span>
-    </div>
+    </button>
   );
 }

--- a/src/components/EditorBanner.tsx
+++ b/src/components/EditorBanner.tsx
@@ -1,0 +1,60 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { X } from 'lucide-react';
+
+interface PendingSwitchBannerProps {
+  kind: 'pending-switch';
+  onSave: () => void;
+  onDiscard: () => void;
+  onCancel: () => void;
+}
+
+interface MessageBannerProps {
+  kind: 'message';
+  message: string;
+  onDismiss: () => void;
+}
+
+type EditorBannerProps = PendingSwitchBannerProps | MessageBannerProps;
+
+export function EditorBanner(props: EditorBannerProps) {
+  if (props.kind === 'pending-switch') {
+    return (
+      <div className="flex items-center gap-2 px-3 py-1.5 text-sm bg-amber-100 dark:bg-amber-950 border-b border-amber-300 dark:border-amber-800 text-amber-900 dark:text-amber-100 shrink-0">
+        <span className="flex-1">Unsaved changes — what do you want to do?</span>
+        <button
+          onClick={props.onSave}
+          className="px-2 py-0.5 rounded text-xs bg-amber-700 text-white hover:bg-amber-800 transition-colors"
+        >
+          Save
+        </button>
+        <button
+          onClick={props.onDiscard}
+          className="px-2 py-0.5 rounded text-xs bg-amber-200 dark:bg-amber-900 hover:bg-amber-300 dark:hover:bg-amber-800 transition-colors"
+        >
+          Discard
+        </button>
+        <button
+          onClick={props.onCancel}
+          className="px-2 py-0.5 rounded text-xs hover:bg-amber-200 dark:hover:bg-amber-900 transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    );
+  }
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 text-sm bg-destructive/10 border-b border-destructive/30 text-destructive shrink-0">
+      <span className="flex-1">{props.message}</span>
+      <button
+        onClick={props.onDismiss}
+        title="Dismiss"
+        aria-label="Dismiss"
+        className="p-0.5 rounded hover:bg-destructive/20 transition-colors"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/src/hooks/useEditor.test.ts
+++ b/src/hooks/useEditor.test.ts
@@ -57,6 +57,7 @@ vi.mock('codemirror', () => {
       return [];
     },
   };
+  (EditorViewMock as unknown as { theme: (spec: unknown) => unknown[] }).theme = () => [];
   return { EditorView: EditorViewMock, basicSetup: [] };
 });
 

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -32,12 +32,18 @@ export function useEditor(theme: 'light' | 'dark') {
       setIsModified(current !== snapshotRef.current);
     });
 
+    const fillHeight = EditorView.theme({
+      '&': { height: '100%' },
+      '.cm-scroller': { overflow: 'auto' },
+    });
+
     const view = new EditorView({
       state: EditorState.create({
         extensions: [
           basicSetup,
           python(),
           themeCompartment.current.of(themeExtension(theme)),
+          fillHeight,
           modifiedListener,
         ],
       }),

--- a/src/lib/saveEditor.test.ts
+++ b/src/lib/saveEditor.test.ts
@@ -35,7 +35,7 @@ afterEach(() => {
 
 describe('saveEditor', () => {
   describe('origin: device', () => {
-    it('is a no-op', async () => {
+    it('is a no-op when no writeDevice is provided', async () => {
       const setOriginAndContent = vi.fn();
       const result = await saveEditor(
         { kind: 'device', path: '/main.py' },
@@ -43,6 +43,34 @@ describe('saveEditor', () => {
         setOriginAndContent
       );
       expect(result).toBe('noop');
+      expect(setOriginAndContent).not.toHaveBeenCalled();
+    });
+
+    it('writes through writeDevice and re-snapshots', async () => {
+      const setOriginAndContent = vi.fn();
+      const writeDevice = vi.fn().mockResolvedValue(undefined);
+      const origin: EditorOrigin = { kind: 'device', path: '/main.py' };
+
+      const result = await saveEditor(origin, 'print("hi")', setOriginAndContent, writeDevice);
+
+      expect(result).toBe('saved');
+      expect(writeDevice).toHaveBeenCalledWith('/main.py', 'print("hi")');
+      expect(setOriginAndContent).toHaveBeenCalledWith(origin, 'print("hi")');
+    });
+
+    it('does not re-snapshot when writeDevice rejects', async () => {
+      const setOriginAndContent = vi.fn();
+      const writeDevice = vi.fn().mockRejectedValue(new Error('device offline'));
+
+      await expect(
+        saveEditor(
+          { kind: 'device', path: '/main.py' },
+          'print("hi")',
+          setOriginAndContent,
+          writeDevice
+        )
+      ).rejects.toThrow('device offline');
+
       expect(setOriginAndContent).not.toHaveBeenCalled();
     });
   });

--- a/src/lib/saveEditor.ts
+++ b/src/lib/saveEditor.ts
@@ -8,10 +8,14 @@ export type SaveEditorResult = 'saved' | 'cancelled' | 'noop';
 export async function saveEditor(
   origin: EditorOrigin,
   content: string,
-  setOriginAndContent: (origin: EditorOrigin, content: string) => void
+  setOriginAndContent: (origin: EditorOrigin, content: string) => void,
+  writeDevice?: (path: string, text: string) => Promise<void>
 ): Promise<SaveEditorResult> {
   if (origin.kind === 'device') {
-    return 'noop';
+    if (!writeDevice) return 'noop';
+    await writeDevice(origin.path, content);
+    setOriginAndContent(origin, content);
+    return 'saved';
   }
 
   if (origin.kind === 'local') {


### PR DESCRIPTION
## Summary

- Clicking a device file row reads bytes via `useDeviceFs.readBytes`, decodes UTF-8 with fatal mode, and loads the editor with `origin.kind === 'device'`. Binary files surface "Binary file — cannot open in editor." in an inline banner above the editor without changing the editor content.
- Save with device origin now writes through `useDeviceFs.writeText` (the previous "device save = no-op" stub is gone). The Save button enables whenever the device is connected; `Ctrl+S` / `Cmd+S` triggers it.
- Switching files with `isModified === true` shows a Save / Discard / Cancel inline strip pinned above the editor. Save commits the current buffer then loads the new file; Discard loads without saving; Cancel keeps the editor as-is.
- Constrains CodeMirror to fill its container with internal scrolling (`EditorView.theme({ '&': { height: '100%' }, '.cm-scroller': { overflow: 'auto' } })`). Without this, long files made the SplitPane scroll and dragged the inline banner offscreen.
- Banner is dismissed on disconnect (target device path is unreachable) and reset at the start of each open so a leftover error doesn't linger across a successful click.

Implements `docs/device-files/SPEC.md` § "Editor origin tracking" (device-Save behaviour), § "Binary safety for editor opens", and § "Unsaved-changes confirmation".

Closes #72.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test` — 338 passing, including new device-origin save cases in `saveEditor.test.ts`
- [x] Manual: Pico connected, open `main.py` → edit → `Ctrl+S` → reset → re-open → changes persisted
- [x] Manual: open binary file → "Binary file" banner appears, editor unchanged
- [x] Manual: edit a file then click another → Save / Discard / Cancel banner; all three buttons behave correctly
- [x] Manual: trigger banner, then disconnect → banner clears
- [x] Manual: trigger binary error, then click a Python file → banner clears, file loads
- [x] Manual: scroll deep into a long device file then trigger the banner → banner stays at top of editor area