### PR TITLE
feat(device-files): local-to-device upload via drag-and-drop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ export function App() {
     list: deviceList,
     readBytes: deviceReadBytes,
     writeText: deviceWriteText,
+    writeBytes: deviceWriteBytes,
     mkdir: deviceMkdir,
     rename: deviceRename,
     removeFile: deviceRemoveFile,
@@ -100,6 +101,45 @@ export function App() {
     | { kind: 'pending-switch'; origin: EditorOrigin; content: string }
     | { kind: 'message'; message: string };
   const [banner, setBanner] = useState<BannerState | null>(null);
+
+  const handleUploadToDevice = useCallback(
+    async (parentPath: string, files: File[]): Promise<void> => {
+      // List once per drop and reuse — multi-file drops to the same folder
+      // are the common case and we want one round-trip, not N. Re-listing
+      // after each successful write would catch self-collisions if the user
+      // dropped two copies of the same name, but that's a degenerate case
+      // and the user can resolve via the second confirm.
+      let existingNames: Set<string>;
+      try {
+        existingNames = new Set((await deviceList(parentPath)).map((e) => e.name));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        setBanner({ kind: 'message', message: `Upload failed: ${message}` });
+        return;
+      }
+      for (const file of files) {
+        if (existingNames.has(file.name)) {
+          if (!window.confirm(`${file.name} already exists in ${parentPath}. Overwrite?`)) {
+            continue;
+          }
+        }
+        try {
+          const bytes = new Uint8Array(await file.arrayBuffer());
+          await deviceWriteBytes(join(parentPath, file.name), bytes);
+          existingNames.add(file.name);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          setBanner({ kind: 'message', message: `Upload failed: ${message}` });
+          return;
+        }
+      }
+    },
+    [deviceList, deviceWriteBytes],
+  );
+
+  const handleShowDeviceMessage = useCallback((message: string) => {
+    setBanner({ kind: 'message', message });
+  }, []);
 
   const handleSave = useCallback(async (): Promise<'saved' | 'cancelled' | 'noop'> => {
     return saveEditor(origin, getContent(), setOriginAndContent, deviceWriteText);
@@ -294,6 +334,8 @@ export function App() {
                     onDeleteFile={handleDeleteDeviceFile}
                     onDeleteDir={handleDeleteDeviceDir}
                     onCountChildren={handleCountDeviceChildren}
+                    onUpload={handleUploadToDevice}
+                    onShowMessage={handleShowDeviceMessage}
                   />,
                 ]}
               </SplitPane>,

--- a/src/components/DeviceFileNavigator.tsx
+++ b/src/components/DeviceFileNavigator.tsx
@@ -14,9 +14,14 @@ import {
   Trash2,
 } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
-import type { MouseEvent as ReactMouseEvent, KeyboardEvent as ReactKeyboardEvent } from 'react';
+import type {
+  DragEvent as ReactDragEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+  MouseEvent as ReactMouseEvent,
+} from 'react';
 import type { DeviceTreeEntry, DeviceTreeNode } from '../hooks/useDeviceFs';
-import { validateName } from '../lib/devicePath';
+import { dirname, validateName } from '../lib/devicePath';
+import { LOCAL_PATH_MIME, consumeLocalDragSource } from '../lib/localDragSource';
 
 type CreateKind = 'file' | 'dir';
 
@@ -34,6 +39,8 @@ interface DeviceFileNavigatorProps {
   onDeleteFile: (path: string) => Promise<void>;
   onDeleteDir: (path: string, recursive: boolean) => Promise<void>;
   onCountChildren: (path: string) => Promise<number>;
+  onUpload: (parentPath: string, files: File[]) => Promise<void>;
+  onShowMessage: (message: string) => void;
 }
 
 export function DeviceFileNavigator({
@@ -50,6 +57,8 @@ export function DeviceFileNavigator({
   onDeleteFile,
   onDeleteDir,
   onCountChildren,
+  onUpload,
+  onShowMessage,
 }: DeviceFileNavigatorProps) {
   const [creating, setCreating] = useState<{ path: string; kind: CreateKind } | null>(null);
   const [renaming, setRenaming] = useState<{ path: string } | null>(null);
@@ -59,6 +68,7 @@ export function DeviceFileNavigator({
     y: number;
     entry: DeviceTreeEntry;
   } | null>(null);
+  const [dragOverPath, setDragOverPath] = useState<string | null>(null);
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -87,6 +97,7 @@ export function DeviceFileNavigator({
       if (creating !== null) setCreating(null);
       if (renaming !== null) setRenaming(null);
       if (deleting !== null) setDeleting(null);
+      if (dragOverPath !== null) setDragOverPath(null);
     }
   }
 
@@ -147,6 +158,83 @@ export function DeviceFileNavigator({
     setContextMenu({ x: e.clientX, y: e.clientY, entry });
   };
 
+  const startUploadHere = (parentPath: string) => {
+    setContextMenu(null);
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.multiple = true;
+    input.style.display = 'none';
+    input.onchange = () => {
+      const files = input.files ? Array.from(input.files) : [];
+      if (files.length > 0) {
+        void onUpload(parentPath, files).catch((err) => {
+          onShowMessage(
+            `Upload failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
+      }
+    };
+    input.click();
+  };
+
+  const handleDragOverRow = (e: ReactDragEvent<HTMLElement>, effectiveTarget: string) => {
+    if (!isAcceptableDrop(e.dataTransfer)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    if (dragOverPath !== effectiveTarget) setDragOverPath(effectiveTarget);
+  };
+
+  const handleDropRow = async (
+    e: ReactDragEvent<HTMLElement>,
+    effectiveTarget: string,
+  ) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverPath(null);
+    const dt = e.dataTransfer;
+
+    if (hasFolderItem(dt)) {
+      onShowMessage(
+        'Folder upload/download is not supported yet — drag individual files for now.',
+      );
+      return;
+    }
+
+    const localId = dt.getData(LOCAL_PATH_MIME);
+    if (localId) {
+      const source = consumeLocalDragSource(localId);
+      if (source) {
+        try {
+          const file = await source.handle.getFile();
+          await onUpload(effectiveTarget, [file]);
+        } catch (err) {
+          onShowMessage(
+            `Upload failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+        return;
+      }
+    }
+
+    if (dt.files.length > 0) {
+      try {
+        await onUpload(effectiveTarget, Array.from(dt.files));
+      } catch (err) {
+        onShowMessage(
+          `Upload failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  };
+
+  const handleContainerDragLeave = (e: ReactDragEvent<HTMLDivElement>) => {
+    // dragleave fires when transitioning between children too. Only clear
+    // when the pointer truly leaves the container.
+    const next = e.relatedTarget;
+    if (next instanceof Node && e.currentTarget.contains(next)) return;
+    setDragOverPath(null);
+  };
+
   return (
     <div className="flex flex-col h-full bg-muted/30">
       <div className="flex items-center gap-1 px-2 py-1 border-b border-border">
@@ -168,7 +256,10 @@ export function DeviceFileNavigator({
           <RefreshCw size={14} />
         </button>
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div
+        className="flex-1 overflow-y-auto"
+        onDragLeave={handleContainerDragLeave}
+      >
         {!isAvailable || !tree ? (
           <div className="px-3 py-2 text-sm text-muted-foreground">
             Connect a device to browse its files.
@@ -194,6 +285,9 @@ export function DeviceFileNavigator({
             onSubmitDelete={submitDelete}
             onCountChildren={onCountChildren}
             onContextMenu={openContextMenu}
+            dragOverPath={dragOverPath}
+            onDragOverRow={handleDragOverRow}
+            onDropRow={handleDropRow}
           />
         )}
       </div>
@@ -201,7 +295,13 @@ export function DeviceFileNavigator({
         <ContextMenu
           x={contextMenu.x}
           y={contextMenu.y}
-          items={buildContextMenuItems(contextMenu.entry, startCreate, startRename, startDelete)}
+          items={buildContextMenuItems(
+            contextMenu.entry,
+            startCreate,
+            startRename,
+            startDelete,
+            startUploadHere,
+          )}
         />
       )}
     </div>
@@ -228,6 +328,9 @@ interface TreeRowProps {
   onSubmitDelete: (entry: DeviceTreeEntry, recursive: boolean) => Promise<void>;
   onCountChildren: (path: string) => Promise<number>;
   onContextMenu: (e: ReactMouseEvent, entry: DeviceTreeEntry) => void;
+  dragOverPath: string | null;
+  onDragOverRow: (e: ReactDragEvent<HTMLElement>, effectiveTarget: string) => void;
+  onDropRow: (e: ReactDragEvent<HTMLElement>, effectiveTarget: string) => void;
 }
 
 function TreeRow({
@@ -250,11 +353,16 @@ function TreeRow({
   onSubmitDelete,
   onCountChildren,
   onContextMenu,
+  dragOverPath,
+  onDragOverRow,
+  onDropRow,
 }: TreeRowProps) {
   const indent = 8 + depth * 12;
   const isRenaming = renaming?.path === entry.path;
   const isDeleting = deleting?.path === entry.path;
   const isRoot = entry.path === '/';
+  const effectiveTarget = entry.isDir ? entry.path : dirname(entry.path);
+  const isDropHighlighted = entry.isDir && dragOverPath === entry.path;
   if (entry.isDir) {
     const toggle = () => (entry.expanded ? onCollapse(entry.path) : onExpand(entry.path));
     return (
@@ -276,8 +384,14 @@ function TreeRow({
           />
         ) : (
           <div
-            className="group flex items-center hover:bg-accent transition-colors"
+            className={`group flex items-center transition-colors ${
+              isDropHighlighted
+                ? 'bg-primary/15 outline outline-1 outline-primary/40'
+                : 'hover:bg-accent'
+            }`}
             onContextMenu={(e) => onContextMenu(e, entry)}
+            onDragOver={(e) => onDragOverRow(e, effectiveTarget)}
+            onDrop={(e) => onDropRow(e, effectiveTarget)}
           >
             <button
               onClick={toggle}
@@ -375,6 +489,9 @@ function TreeRow({
                 onSubmitDelete={onSubmitDelete}
                 onCountChildren={onCountChildren}
                 onContextMenu={onContextMenu}
+                dragOverPath={dragOverPath}
+                onDragOverRow={onDragOverRow}
+                onDropRow={onDropRow}
               />
             ))}
           </>
@@ -407,6 +524,8 @@ function TreeRow({
     <div
       className="group flex items-center hover:bg-accent transition-colors"
       onContextMenu={(e) => onContextMenu(e, entry)}
+      onDragOver={(e) => onDragOverRow(e, effectiveTarget)}
+      onDrop={(e) => onDropRow(e, effectiveTarget)}
     >
       <button
         onClick={() => onOpenFile(entry.path)}
@@ -761,6 +880,7 @@ function buildContextMenuItems(
   startCreate: (parentPath: string, kind: CreateKind, expanded: boolean) => void,
   startRename: (path: string) => void,
   startDelete: (path: string) => void,
+  startUploadHere: (parentPath: string) => void,
 ): ContextMenuItem[] {
   const items: ContextMenuItem[] = [];
   if (entry.isDir) {
@@ -772,12 +892,26 @@ function buildContextMenuItems(
       label: 'New folder',
       onClick: () => startCreate(entry.path, 'dir', entry.expanded),
     });
+    items.push({ label: 'Upload here', onClick: () => startUploadHere(entry.path) });
   }
   if (entry.path !== '/') {
     items.push({ label: 'Rename', onClick: () => startRename(entry.path) });
     items.push({ label: 'Delete', onClick: () => startDelete(entry.path) });
   }
   return items;
+}
+
+function isAcceptableDrop(dt: DataTransfer): boolean {
+  return dt.types.includes(LOCAL_PATH_MIME) || dt.types.includes('Files');
+}
+
+function hasFolderItem(dt: DataTransfer): boolean {
+  for (let i = 0; i < dt.items.length; i++) {
+    const item = dt.items[i];
+    const entry = item.webkitGetAsEntry?.();
+    if (entry?.isDirectory) return true;
+  }
+  return false;
 }
 
 function ContextMenu({ x, y, items }: { x: number; y: number; items: ContextMenuItem[] }) {

--- a/src/components/FileNavigator.tsx
+++ b/src/components/FileNavigator.tsx
@@ -3,6 +3,12 @@
 
 import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from 'lucide-react';
 import { useState } from 'react';
+import type { DragEvent as ReactDragEvent } from 'react';
+import {
+  LOCAL_PATH_MIME,
+  clearLocalDragSource,
+  registerLocalDragSource,
+} from '../lib/localDragSource';
 
 interface LocalTreeNode {
   handle: FileSystemDirectoryHandle;
@@ -126,8 +132,39 @@ function TreeRow({ entry, path, depth, onToggle, onOpenFile }: TreeRowProps) {
       </>
     );
   }
+  return <FileTreeRow entry={entry} indent={indent} onOpenFile={onOpenFile} />;
+}
+
+interface FileTreeRowProps {
+  entry: LocalTreeFile;
+  indent: number;
+  onOpenFile: (handle: FileSystemFileHandle) => void;
+}
+
+function FileTreeRow({ entry, indent, onOpenFile }: FileTreeRowProps) {
+  const [dragId, setDragId] = useState<string | null>(null);
+
+  const onDragStart = (e: ReactDragEvent<HTMLButtonElement>) => {
+    const id = registerLocalDragSource(entry.handle, entry.name);
+    e.dataTransfer.setData(LOCAL_PATH_MIME, id);
+    e.dataTransfer.effectAllowed = 'copy';
+    setDragId(id);
+  };
+
+  const onDragEnd = () => {
+    if (dragId) {
+      // Drop targets `consume` the source on success; `clear` is a no-op
+      // there. On a cancelled drag the entry would otherwise leak.
+      clearLocalDragSource(dragId);
+      setDragId(null);
+    }
+  };
+
   return (
     <button
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
       onClick={() => onOpenFile(entry.handle)}
       style={{ paddingLeft: indent + 12 }}
       className="flex items-center gap-1.5 w-full text-left pr-2 py-1 text-sm hover:bg-accent transition-colors truncate"

--- a/src/lib/localDragSource.test.ts
+++ b/src/lib/localDragSource.test.ts
@@ -1,0 +1,48 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import {
+  LOCAL_PATH_MIME,
+  clearLocalDragSource,
+  consumeLocalDragSource,
+  registerLocalDragSource,
+} from './localDragSource';
+
+const fakeHandle = {} as FileSystemFileHandle;
+
+describe('localDragSource', () => {
+  it('exposes the agreed MIME type', () => {
+    expect(LOCAL_PATH_MIME).toBe('application/x-cobweb-local-path');
+  });
+
+  it('roundtrips handle and name through register → consume', () => {
+    const id = registerLocalDragSource(fakeHandle, 'app.py');
+    const value = consumeLocalDragSource(id);
+    expect(value).toEqual({ handle: fakeHandle, name: 'app.py' });
+  });
+
+  it('returns undefined for unknown ids', () => {
+    expect(consumeLocalDragSource('does-not-exist')).toBeUndefined();
+  });
+
+  it('consume removes the entry so a second consume sees nothing', () => {
+    const id = registerLocalDragSource(fakeHandle, 'a.py');
+    expect(consumeLocalDragSource(id)).toBeDefined();
+    expect(consumeLocalDragSource(id)).toBeUndefined();
+  });
+
+  it('issues distinct ids for distinct registrations', () => {
+    const id1 = registerLocalDragSource(fakeHandle, 'a.py');
+    const id2 = registerLocalDragSource(fakeHandle, 'b.py');
+    expect(id1).not.toBe(id2);
+    clearLocalDragSource(id1);
+    clearLocalDragSource(id2);
+  });
+
+  it('clearLocalDragSource removes the entry', () => {
+    const id = registerLocalDragSource(fakeHandle, 'a.py');
+    clearLocalDragSource(id);
+    expect(consumeLocalDragSource(id)).toBeUndefined();
+  });
+});

--- a/src/lib/localDragSource.ts
+++ b/src/lib/localDragSource.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Coordination map for cross-component drag of local-FS file handles.
+ *
+ * `dataTransfer.setData` only accepts strings, so a `FileSystemFileHandle`
+ * cannot ride along with the drag payload directly. The drag source registers
+ * its handle here under a generated ID and embeds that ID in the payload; the
+ * drop target consumes the entry by ID at drop time. HTML5 only supports one
+ * drag operation at a time so a single module-scoped Map is safe.
+ */
+
+export const LOCAL_PATH_MIME = 'application/x-cobweb-local-path';
+
+interface LocalDragSource {
+  handle: FileSystemFileHandle;
+  name: string;
+}
+
+const sources = new Map<string, LocalDragSource>();
+let counter = 0;
+
+export function registerLocalDragSource(
+  handle: FileSystemFileHandle,
+  name: string,
+): string {
+  const id = `local-${++counter}`;
+  sources.set(id, { handle, name });
+  return id;
+}
+
+export function consumeLocalDragSource(id: string): LocalDragSource | undefined {
+  const value = sources.get(id);
+  sources.delete(id);
+  return value;
+}
+
+export function clearLocalDragSource(id: string): void {
+  sources.delete(id);
+}


### PR DESCRIPTION
## Summary

Adds Local → Device upload to `<DeviceFileNavigator>` via drag-and-drop and right-click "Upload here", per SPEC § "Drag-and-drop semantics" (Local → Device folder) and § "UI - `<DeviceFileNavigator>`" (Upload here).

- Local file rows in `<FileNavigator>` are now `draggable` and ship `application/x-cobweb-local-path` with a generated ID. Because `dataTransfer.setData` can only carry strings, a new `src/lib/localDragSource.ts` module brokers the actual `FileSystemFileHandle` through a small Map keyed by that ID; the device pane `consume`s the entry at drop time. Drag end clears any leftover entry from cancelled drags so the map doesn't leak.
- Device folder rows accept drops of `application/x-cobweb-local-path` and `dataTransfer.files` from the OS. Drop-onto-file falls through to its parent: file rows compute their effective target as `dirname(path)` and the parent folder row picks up the highlight, so the destination is unambiguous before release.
- Folder drags are refused. Local folder rows aren't `draggable`, so the device pane never sees one from us; OS folder drops are detected via `webkitGetAsEntry().isDirectory` at drop time and surface the SPEC-mandated toast through the existing message banner.
- App's `handleUploadToDevice` lists the target directory once per drop and prompts (`window.confirm`) for each existing-name collision before calling `deviceFs.writeBytes`. Multi-file drops to the same folder thus pay one round-trip for collision detection rather than N. Errors propagate to the same banner.
- Right-click → "Upload here" on a folder spawns a hidden `<input type=\"file\" multiple>` and routes the picked files through the same upload handler.

Closes #78

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (346/346)
- [x] Manual: drag local file onto device folder uploads; drag onto device file falls through to parent (parent row highlights); drag a local folder doesn't initiate; drag an OS folder onto the pane refuses with the toast banner; existing-name collision prompts and skip/overwrite both behave; right-click "Upload here" on a folder opens the OS picker and uploads; multi-file OS drop prompts per collision.