### PR TITLE
feat(device-files): device-to-local download via drag-and-drop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AgentProvider, INLINE_APPROVAL } from '@mast-ai/react-ui';
 import { AgentRunner } from '@mast-ai/core';
 import { SplitPane } from './components/SplitPane';
@@ -9,7 +9,7 @@ import { StatusBar } from './components/StatusBar';
 import { Toolbar } from './components/Toolbar';
 import { ReplShell } from './components/ReplShell';
 import { CodeEditor } from './components/CodeEditor';
-import { FileNavigator } from './components/FileNavigator';
+import { FileNavigator, type FileNavigatorHandle } from './components/FileNavigator';
 import { DeviceFileNavigator } from './components/DeviceFileNavigator';
 import { EditorBanner } from './components/EditorBanner';
 import { SettingsPanel } from './components/SettingsPanel';
@@ -140,6 +140,22 @@ export function App() {
   const handleShowDeviceMessage = useCallback((message: string) => {
     setBanner({ kind: 'message', message });
   }, []);
+
+  const localNavRef = useRef<FileNavigatorHandle | null>(null);
+
+  const handleDownloadFromDevice = useCallback(
+    async (path: string): Promise<void> => {
+      const handle = localNavRef.current;
+      if (!handle) {
+        // FileNavigator is always mounted, so a missing ref means React
+        // hasn't attached yet — surface a clear toast rather than swallowing.
+        setBanner({ kind: 'message', message: 'Local pane is not ready yet.' });
+        return;
+      }
+      await handle.downloadFromDevice(path);
+    },
+    [],
+  );
 
   const handleSave = useCallback(async (): Promise<'saved' | 'cancelled' | 'noop'> => {
     return saveEditor(origin, getContent(), setOriginAndContent, deviceWriteText);
@@ -308,7 +324,13 @@ export function App() {
                 onSizeChange={setLeftSplitSize}
               >
                 {[
-                  <FileNavigator key="files" onFileSelected={setContent} />,
+                  <FileNavigator
+                    key="files"
+                    ref={localNavRef}
+                    onFileSelected={setContent}
+                    onDeviceReadBytes={deviceReadBytes}
+                    onShowMessage={handleShowDeviceMessage}
+                  />,
                   <DeviceFileNavigator
                     key="device-files"
                     isAvailable={deviceFsHook.isAvailable}
@@ -335,6 +357,7 @@ export function App() {
                     onDeleteDir={handleDeleteDeviceDir}
                     onCountChildren={handleCountDeviceChildren}
                     onUpload={handleUploadToDevice}
+                    onDownloadRequest={handleDownloadFromDevice}
                     onShowMessage={handleShowDeviceMessage}
                   />,
                 ]}

--- a/src/components/DeviceFileNavigator.tsx
+++ b/src/components/DeviceFileNavigator.tsx
@@ -21,7 +21,11 @@ import type {
 } from 'react';
 import type { DeviceTreeEntry, DeviceTreeNode } from '../hooks/useDeviceFs';
 import { dirname, validateName } from '../lib/devicePath';
-import { LOCAL_PATH_MIME, consumeLocalDragSource } from '../lib/localDragSource';
+import {
+  DEVICE_PATH_MIME,
+  LOCAL_PATH_MIME,
+  consumeLocalDragSource,
+} from '../lib/localDragSource';
 
 type CreateKind = 'file' | 'dir';
 
@@ -40,6 +44,7 @@ interface DeviceFileNavigatorProps {
   onDeleteDir: (path: string, recursive: boolean) => Promise<void>;
   onCountChildren: (path: string) => Promise<number>;
   onUpload: (parentPath: string, files: File[]) => Promise<void>;
+  onDownloadRequest: (path: string) => Promise<void>;
   onShowMessage: (message: string) => void;
 }
 
@@ -58,6 +63,7 @@ export function DeviceFileNavigator({
   onDeleteDir,
   onCountChildren,
   onUpload,
+  onDownloadRequest,
   onShowMessage,
 }: DeviceFileNavigatorProps) {
   const [creating, setCreating] = useState<{ path: string; kind: CreateKind } | null>(null);
@@ -156,6 +162,15 @@ export function DeviceFileNavigator({
     e.preventDefault();
     e.nativeEvent.stopImmediatePropagation();
     setContextMenu({ x: e.clientX, y: e.clientY, entry });
+  };
+
+  const startDownload = (path: string) => {
+    setContextMenu(null);
+    void onDownloadRequest(path).catch((err) => {
+      onShowMessage(
+        `Download failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   };
 
   const startUploadHere = (parentPath: string) => {
@@ -301,6 +316,7 @@ export function DeviceFileNavigator({
             startRename,
             startDelete,
             startUploadHere,
+            startDownload,
           )}
         />
       )}
@@ -528,6 +544,11 @@ function TreeRow({
       onDrop={(e) => onDropRow(e, effectiveTarget)}
     >
       <button
+        draggable
+        onDragStart={(e) => {
+          e.dataTransfer.setData(DEVICE_PATH_MIME, entry.path);
+          e.dataTransfer.effectAllowed = 'copy';
+        }}
         onClick={() => onOpenFile(entry.path)}
         style={{ paddingLeft: indent + 12 }}
         className="flex items-center gap-1.5 flex-1 min-w-0 text-left pr-1 py-1 text-sm truncate"
@@ -881,6 +902,7 @@ function buildContextMenuItems(
   startRename: (path: string) => void,
   startDelete: (path: string) => void,
   startUploadHere: (parentPath: string) => void,
+  startDownload: (path: string) => void,
 ): ContextMenuItem[] {
   const items: ContextMenuItem[] = [];
   if (entry.isDir) {
@@ -893,6 +915,8 @@ function buildContextMenuItems(
       onClick: () => startCreate(entry.path, 'dir', entry.expanded),
     });
     items.push({ label: 'Upload here', onClick: () => startUploadHere(entry.path) });
+  } else {
+    items.push({ label: 'Download', onClick: () => startDownload(entry.path) });
   }
   if (entry.path !== '/') {
     items.push({ label: 'Rename', onClick: () => startRename(entry.path) });

--- a/src/components/FileNavigator.tsx
+++ b/src/components/FileNavigator.tsx
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from 'lucide-react';
-import { useState } from 'react';
-import type { DragEvent as ReactDragEvent } from 'react';
+import { useCallback, useImperativeHandle, useState } from 'react';
+import type { DragEvent as ReactDragEvent, RefObject } from 'react';
+import { basename } from '../lib/devicePath';
 import {
+  DEVICE_PATH_MIME,
   LOCAL_PATH_MIME,
   clearLocalDragSource,
   registerLocalDragSource,
@@ -26,12 +28,30 @@ interface LocalTreeFile {
 
 type LocalTreeEntry = LocalTreeNode | LocalTreeFile;
 
-interface FileNavigatorProps {
-  onFileSelected: (content: string) => void;
+export interface FileNavigatorHandle {
+  /**
+   * Download a file from the device into the open local folder. Used by the
+   * device pane's right-click "Download" so the local pane stays the single
+   * owner of the local-FS handle and tree state.
+   */
+  downloadFromDevice(devicePath: string): Promise<void>;
 }
 
-export function FileNavigator({ onFileSelected }: FileNavigatorProps) {
+interface FileNavigatorProps {
+  onFileSelected: (content: string) => void;
+  onDeviceReadBytes: (path: string) => Promise<Uint8Array>;
+  onShowMessage: (message: string) => void;
+  ref?: RefObject<FileNavigatorHandle | null>;
+}
+
+export function FileNavigator({
+  onFileSelected,
+  onDeviceReadBytes,
+  onShowMessage,
+  ref,
+}: FileNavigatorProps) {
   const [root, setRoot] = useState<LocalTreeNode | null>(null);
+  const [isDeviceDragOver, setIsDeviceDragOver] = useState(false);
 
   const openDirectory = async () => {
     const dirHandle = await window.showDirectoryPicker();
@@ -65,8 +85,73 @@ export function FileNavigator({ onFileSelected }: FileNavigatorProps) {
     onFileSelected(content);
   };
 
+  const downloadFromDevice = useCallback(
+    async (devicePath: string): Promise<void> => {
+      if (!root) {
+        onShowMessage('Open a local folder first.');
+        return;
+      }
+      const name = basename(devicePath);
+      const bytes = await onDeviceReadBytes(devicePath);
+      const fileHandle = await root.handle.getFileHandle(name, { create: true });
+      const writable = await fileHandle.createWritable();
+      try {
+        await writable.write(bytes);
+      } finally {
+        await writable.close();
+      }
+      // Surface the new (or overwritten) file in the tree without losing the
+      // expansion state of unrelated subtrees: re-list root and merge.
+      const refreshed = await loadChildren(root.handle);
+      setRoot((r) => (r ? mergeRootChildren(r, refreshed) : r));
+    },
+    [root, onDeviceReadBytes, onShowMessage],
+  );
+
+  useImperativeHandle(ref, () => ({ downloadFromDevice }), [downloadFromDevice]);
+
+  const acceptsDeviceDrop = (dt: DataTransfer): boolean =>
+    dt.types.includes(DEVICE_PATH_MIME);
+
+  const handleDragOver = (e: ReactDragEvent<HTMLDivElement>) => {
+    if (!acceptsDeviceDrop(e.dataTransfer)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    if (!isDeviceDragOver) setIsDeviceDragOver(true);
+  };
+
+  const handleDragLeave = (e: ReactDragEvent<HTMLDivElement>) => {
+    const next = e.relatedTarget;
+    if (next instanceof Node && e.currentTarget.contains(next)) return;
+    setIsDeviceDragOver(false);
+  };
+
+  const handleDrop = async (e: ReactDragEvent<HTMLDivElement>) => {
+    if (!acceptsDeviceDrop(e.dataTransfer)) return;
+    e.preventDefault();
+    setIsDeviceDragOver(false);
+    const devicePath = e.dataTransfer.getData(DEVICE_PATH_MIME);
+    if (!devicePath) return;
+    try {
+      await downloadFromDevice(devicePath);
+    } catch (err) {
+      onShowMessage(
+        `Download failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+
   return (
-    <div className="flex flex-col h-full bg-muted/30">
+    <div
+      className={`flex flex-col h-full bg-muted/30 transition-colors ${
+        isDeviceDragOver ? 'outline outline-2 outline-primary/40 bg-primary/5' : ''
+      }`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={(e) => {
+        void handleDrop(e);
+      }}
+    >
       <div className="flex items-center gap-1 px-2 py-1 border-b border-border">
         <button
           onClick={openDirectory}
@@ -201,6 +286,26 @@ async function loadChildren(dirHandle: FileSystemDirectoryHandle): Promise<Local
 function compareEntries(a: LocalTreeEntry, b: LocalTreeEntry): number {
   if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
   return a.name.localeCompare(b.name);
+}
+
+// Re-list root preserves expansion state of unrelated folders by carrying
+// over the previous (expanded, children) for any directory child whose name
+// survived the re-list. New entries (e.g. the freshly downloaded file) appear
+// in their sorted position; deleted entries drop out.
+function mergeRootChildren(
+  root: LocalTreeNode,
+  refreshed: LocalTreeEntry[],
+): LocalTreeNode {
+  const oldByName = new Map<string, LocalTreeEntry>();
+  for (const c of root.children) oldByName.set(c.name, c);
+  const merged = refreshed.map((entry) => {
+    const old = oldByName.get(entry.name);
+    if (old && old.isDir && entry.isDir) {
+      return { ...entry, expanded: old.expanded, children: old.children };
+    }
+    return entry;
+  });
+  return { ...root, children: merged };
 }
 
 function findNode(root: LocalTreeNode, path: string[]): LocalTreeNode | null {

--- a/src/lib/localDragSource.ts
+++ b/src/lib/localDragSource.ts
@@ -2,16 +2,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Coordination map for cross-component drag of local-FS file handles.
+ * Coordination map for cross-component drag of local-FS file handles, plus
+ * the sibling device-path MIME constant used for device → local drags.
  *
  * `dataTransfer.setData` only accepts strings, so a `FileSystemFileHandle`
  * cannot ride along with the drag payload directly. The drag source registers
  * its handle here under a generated ID and embeds that ID in the payload; the
  * drop target consumes the entry by ID at drop time. HTML5 only supports one
  * drag operation at a time so a single module-scoped Map is safe.
+ *
+ * Device paths are plain strings, so they ride directly in the drag payload —
+ * `DEVICE_PATH_MIME` lives here next to the local one purely for proximity.
  */
 
 export const LOCAL_PATH_MIME = 'application/x-cobweb-local-path';
+export const DEVICE_PATH_MIME = 'application/x-cobweb-device-path';
 
 interface LocalDragSource {
   handle: FileSystemFileHandle;


### PR DESCRIPTION
## Summary

Adds Device → Local download to `<DeviceFileNavigator>` via drag-and-drop and right-click "Download", per SPEC § "Drag-and-drop semantics" (Device file → Local pane) and § "UI - `<DeviceFileNavigator>`" (Download).

- Device file rows now set `draggable` and ship `application/x-cobweb-device-path` with the path; folder rows stay non-draggable so device folder drags can't initiate (the SPEC-mandated "folder drags refused" rule). The new MIME constant lives next to `LOCAL_PATH_MIME` in `src/lib/localDragSource.ts` — paths are plain strings so no Map indirection is needed.
- `<FileNavigator>` exposes a `FileNavigatorHandle.downloadFromDevice(path)` via `useImperativeHandle` (React 19 ref-as-prop). The pane container is a drop zone that accepts `DEVICE_PATH_MIME`, fetches bytes via the new `onDeviceReadBytes` prop, writes through the open `dirHandle.getFileHandle(name, { create: true })` → `createWritable()`, then re-lists root and merges so subtree expansion state is preserved while the new (or overwritten) file appears in its sorted position. Drop highlight via an outline + tinted background while a device drag is over.
- Without an open local folder, the drop / right-click surfaces "Open a local folder first." through the existing message banner. The right-click "Download" item routes through `App.handleDownloadFromDevice` which delegates to the imperative handle, so it shares one path with drag-drop. Read errors from `deviceReadBytes` (oversize, disconnect, etc.) propagate to the same banner with a "Download failed: ..." message.
- The download follows SPEC literally: `getFileHandle({ create: true })` silently overwrites local files of the same name; collision prompting is asymmetric with upload but matches what the SPEC describes for this direction.

Closes #79

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (346/346)
- [x] Manual: drag device file onto local pane → file appears locally; right-click → Download produces same result; drag with no folder open shows "Open a local folder first." banner; device folder rows can't initiate a drag; existing local→device upload, tree expand/collapse, and editor open flows still work.