### PR TITLE
feat(device-files): device-to-device move via drag-and-drop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,13 @@ export function App() {
     [],
   );
 
+  const handleMoveOnDevice = useCallback(
+    async (from: string, to: string): Promise<void> => {
+      await deviceRename(from, to);
+    },
+    [deviceRename],
+  );
+
   const handleSave = useCallback(async (): Promise<'saved' | 'cancelled' | 'noop'> => {
     return saveEditor(origin, getContent(), setOriginAndContent, deviceWriteText);
   }, [origin, getContent, setOriginAndContent, deviceWriteText]);
@@ -358,6 +365,7 @@ export function App() {
                     onCountChildren={handleCountDeviceChildren}
                     onUpload={handleUploadToDevice}
                     onDownloadRequest={handleDownloadFromDevice}
+                    onMoveOnDevice={handleMoveOnDevice}
                     onShowMessage={handleShowDeviceMessage}
                   />,
                 ]}

--- a/src/components/DeviceFileNavigator.tsx
+++ b/src/components/DeviceFileNavigator.tsx
@@ -20,7 +20,7 @@ import type {
   MouseEvent as ReactMouseEvent,
 } from 'react';
 import type { DeviceTreeEntry, DeviceTreeNode } from '../hooks/useDeviceFs';
-import { dirname, validateName } from '../lib/devicePath';
+import { basename, dirname, join, validateName } from '../lib/devicePath';
 import {
   DEVICE_PATH_MIME,
   LOCAL_PATH_MIME,
@@ -45,6 +45,7 @@ interface DeviceFileNavigatorProps {
   onCountChildren: (path: string) => Promise<number>;
   onUpload: (parentPath: string, files: File[]) => Promise<void>;
   onDownloadRequest: (path: string) => Promise<void>;
+  onMoveOnDevice: (from: string, to: string) => Promise<void>;
   onShowMessage: (message: string) => void;
 }
 
@@ -64,6 +65,7 @@ export function DeviceFileNavigator({
   onCountChildren,
   onUpload,
   onDownloadRequest,
+  onMoveOnDevice,
   onShowMessage,
 }: DeviceFileNavigatorProps) {
   const [creating, setCreating] = useState<{ path: string; kind: CreateKind } | null>(null);
@@ -195,7 +197,11 @@ export function DeviceFileNavigator({
   const handleDragOverRow = (e: ReactDragEvent<HTMLElement>, effectiveTarget: string) => {
     if (!isAcceptableDrop(e.dataTransfer)) return;
     e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
+    // Device-path drags are moves within the device; everything else is a
+    // copy from the local pane / OS.
+    e.dataTransfer.dropEffect = e.dataTransfer.types.includes(DEVICE_PATH_MIME)
+      ? 'move'
+      : 'copy';
     if (dragOverPath !== effectiveTarget) setDragOverPath(effectiveTarget);
   };
 
@@ -207,6 +213,22 @@ export function DeviceFileNavigator({
     e.stopPropagation();
     setDragOverPath(null);
     const dt = e.dataTransfer;
+
+    const devicePath = dt.getData(DEVICE_PATH_MIME);
+    if (devicePath) {
+      // No-op when the user drops onto the same parent — `rename` to the
+      // same path would round-trip to the device for nothing.
+      if (dirname(devicePath) === effectiveTarget) return;
+      const to = join(effectiveTarget, basename(devicePath));
+      try {
+        await onMoveOnDevice(devicePath, to);
+      } catch (err) {
+        onShowMessage(
+          `Move failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      return;
+    }
 
     if (hasFolderItem(dt)) {
       onShowMessage(
@@ -547,7 +569,10 @@ function TreeRow({
         draggable
         onDragStart={(e) => {
           e.dataTransfer.setData(DEVICE_PATH_MIME, entry.path);
-          e.dataTransfer.effectAllowed = 'copy';
+          // Copy → drop on local pane (download); move → drop on a device
+          // folder (rename). The destination's `dropEffect` selects between
+          // them at drop time.
+          e.dataTransfer.effectAllowed = 'copyMove';
         }}
         onClick={() => onOpenFile(entry.path)}
         style={{ paddingLeft: indent + 12 }}
@@ -926,7 +951,11 @@ function buildContextMenuItems(
 }
 
 function isAcceptableDrop(dt: DataTransfer): boolean {
-  return dt.types.includes(LOCAL_PATH_MIME) || dt.types.includes('Files');
+  return (
+    dt.types.includes(LOCAL_PATH_MIME) ||
+    dt.types.includes(DEVICE_PATH_MIME) ||
+    dt.types.includes('Files')
+  );
 }
 
 function hasFolderItem(dt: DataTransfer): boolean {


### PR DESCRIPTION
## Summary

Adds Device → Device move to `<DeviceFileNavigator>` via drag-and-drop, per SPEC § "Drag-and-drop semantics" (Device → Device folder).

- Device file rows already ship `application/x-cobweb-device-path` for the device→local download path. Their `effectAllowed` becomes `copyMove` so the same drag can resolve as a move when the destination is a device folder, and as a copy when it's the local pane.
- Folder drop targets in `<DeviceFileNavigator>` now accept `DEVICE_PATH_MIME`. `dragover` sets `dropEffect = 'move'` for device-source drags (and `'copy'` for everything else) so the cursor reflects the action. Drop-onto-file falls through to the file's parent — same effective-target logic as upload.
- On drop, the device-path branch runs first: if `dirname(from) === effectiveTarget` we skip (no point round-tripping a same-parent rename); otherwise the component computes `to = join(effectiveTarget, basename(from))` and calls `onMoveOnDevice`. App's handler delegates to `useDeviceFs.rename`, so device errors (e.g. destination already exists) flow through `lastError` and the existing message banner with a "Move failed: …" prefix. The hook's mutation-driven refresh re-lists both source and destination directories where they're expanded.

Closes #80

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (346/346)
- [x] Manual: drag a device file across folders moves it; drag onto its own row or a sibling in the same parent is a silent no-op; drag onto a folder containing a same-named file surfaces the device error in the banner; existing device→local download, local→device upload, and OS-folder refusal still work.