### PR TITLE
feat(device-files): add write_device_file agent tool

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -11,7 +11,8 @@ Help the user write, debug, and understand MicroPython code.
 When asked to write code, use write_editor then offer to run it.
 To run the editor's contents (typically a full program that may run for a long time), use run_editor. It returns as soon as the program starts; the user watches output directly in the REPL. After run_editor, simply tell the user the program started — do NOT follow up with read_repl_history or run_editor again unless the user asks.
 For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
-To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.`,
+To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.
+To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).`,
   tools: [
     'read_editor',
     'write_editor',
@@ -20,5 +21,6 @@ To inspect the device's filesystem (e.g. to confirm what's on the board before w
     'read_repl_history',
     'list_device_files',
     'read_device_file',
+    'write_device_file',
   ],
 });

--- a/src/agent/tools/WriteDeviceFileTool.test.ts
+++ b/src/agent/tools/WriteDeviceFileTool.test.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { WriteDeviceFileTool } from './WriteDeviceFileTool';
+import type { ToolBindings } from '../wireTools';
+import { DeviceFs, DeviceFsError } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    ...overrides,
+  };
+}
+
+function makeDeviceFs(writeText: (path: string, text: string) => Promise<void>): DeviceFs {
+  return { writeText } as unknown as DeviceFs;
+}
+
+describe('WriteDeviceFileTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new WriteDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('write_device_file');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('definition makes path and content required', () => {
+    const tool = new WriteDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual([
+      'path',
+      'content',
+    ]);
+  });
+
+  it('returns a clear message when deviceFs is null', async () => {
+    const tool = new WriteDeviceFileTool(() => makeBindings({ deviceFs: null }));
+    await expect(tool.call({ path: '/main.py', content: 'x' })).resolves.toBe(
+      'Device is not connected.',
+    );
+  });
+
+  it('forwards path and content to DeviceFs.writeText', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const tool = new WriteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(writeText) }),
+    );
+    await tool.call({ path: '/lib/foo.py', content: 'print("hi")\n' });
+    expect(writeText).toHaveBeenCalledWith('/lib/foo.py', 'print("hi")\n');
+  });
+
+  it('returns "ok" on success', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const tool = new WriteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(writeText) }),
+    );
+    await expect(tool.call({ path: '/main.py', content: 'x = 1' })).resolves.toBe('ok');
+  });
+
+  it('does not call DeviceFs.writeText when device is not connected', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const tool = new WriteDeviceFileTool(() => makeBindings({ deviceFs: null }));
+    await tool.call({ path: '/main.py', content: 'x' });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('propagates DeviceFsError from DeviceFs.writeText', async () => {
+    const writeText = vi.fn().mockRejectedValue(new DeviceFsError('ENOSPC: no space left'));
+    const tool = new WriteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(writeText) }),
+    );
+    await expect(tool.call({ path: '/big.bin', content: 'x' })).rejects.toBeInstanceOf(
+      DeviceFsError,
+    );
+  });
+
+  it('propagates non-device errors from DeviceFs.writeText', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('disconnected'));
+    const tool = new WriteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(writeText) }),
+    );
+    await expect(tool.call({ path: '/main.py', content: 'x' })).rejects.toThrow('disconnected');
+  });
+});

--- a/src/agent/tools/WriteDeviceFileTool.ts
+++ b/src/agent/tools/WriteDeviceFileTool.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface WriteDeviceFileArgs {
+  path: string;
+  content: string;
+}
+
+export class WriteDeviceFileTool implements Tool<WriteDeviceFileArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'write_device_file',
+      description:
+        'Writes UTF-8 text to a file at the given absolute device path on the connected ' +
+        'microcontroller. Overwrites any existing file. Requires user approval.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style).',
+          },
+          content: {
+            type: 'string',
+            description: 'UTF-8 text to write to the file.',
+          },
+        },
+        required: ['path', 'content'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: WriteDeviceFileArgs): Promise<string> {
+    const { deviceFs } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+    await deviceFs.writeText(args.path, args.content);
+    return 'ok';
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -29,6 +29,7 @@ describe('wireTools', () => {
       'read_repl_history',
       'run_editor',
       'run_snippet',
+      'write_device_file',
       'write_editor',
     ]);
   });
@@ -37,7 +38,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(7);
+    expect(tools.getTools()).toHaveLength(8);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -11,6 +11,7 @@ import { RunSnippetTool } from './tools/RunSnippetTool';
 import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
 import { ListDeviceFilesTool } from './tools/ListDeviceFilesTool';
 import { ReadDeviceFileTool } from './tools/ReadDeviceFileTool';
+import { WriteDeviceFileTool } from './tools/WriteDeviceFileTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -42,4 +43,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new ReadReplHistoryTool(get));
   tools.register(new ListDeviceFilesTool(get));
   tools.register(new ReadDeviceFileTool(get));
+  tools.register(new WriteDeviceFileTool(get));
 }


### PR DESCRIPTION
## Summary
- New `write_device_file` agent tool: writes UTF-8 text to an absolute device path via `DeviceFs.writeText`. `scope: 'write'`, `requiresApproval: true`, args `{ path, content }`, returns `'ok'` on success.
- No-ops with `'Device is not connected.'` when `deviceFs` is null. `DeviceFsError` and other errors from `DeviceFs.writeText` (disconnects, host-side size cap) propagate.
- Wired into `wireTools` and added to `CODING_AGENT.tools`; instructions get one sentence noting the approval requirement and steering the agent to prefer `write_editor` for in-flight buffers.

Closes #83.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (354 passing, includes 9 new cases for `WriteDeviceFileTool`)
- [x] `npm run build`
- [x] Manual browser test confirmed by user: agent writes a UTF-8 file to the connected device after the approval prompt.