### PR TITLE
feat(device-files): add delete_device_file agent tool

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,9 +286,7 @@ export function App() {
       runner={runner}
       agent={CODING_AGENT}
       disableRoot={true}
-      onApprovalRequired={async (call) =>
-        call.name === 'run_editor' || call.name === 'run_snippet' ? INLINE_APPROVAL : true
-      }
+      onApprovalRequired={async () => INLINE_APPROVAL}
       onConversationChange={(history, entries) => {
         localStorage.setItem('cobweb:conversation', JSON.stringify({ history, entries }));
       }}

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -12,7 +12,8 @@ When asked to write code, use write_editor then offer to run it.
 To run the editor's contents (typically a full program that may run for a long time), use run_editor. It returns as soon as the program starts; the user watches output directly in the REPL. After run_editor, simply tell the user the program started — do NOT follow up with read_repl_history or run_editor again unless the user asks.
 For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
 To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.
-To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).`,
+To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
+To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.`,
   tools: [
     'read_editor',
     'write_editor',
@@ -22,5 +23,6 @@ To save UTF-8 text to a file on the device, use write_device_file. It overwrites
     'list_device_files',
     'read_device_file',
     'write_device_file',
+    'delete_device_file',
   ],
 });

--- a/src/agent/tools/DeleteDeviceFileTool.test.ts
+++ b/src/agent/tools/DeleteDeviceFileTool.test.ts
@@ -1,0 +1,84 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { DeleteDeviceFileTool } from './DeleteDeviceFileTool';
+import type { ToolBindings } from '../wireTools';
+import { DeviceFs, DeviceFsError } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    ...overrides,
+  };
+}
+
+function makeDeviceFs(removeFile: (path: string) => Promise<void>): DeviceFs {
+  return { removeFile } as unknown as DeviceFs;
+}
+
+describe('DeleteDeviceFileTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new DeleteDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('delete_device_file');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('definition makes path required', () => {
+    const tool = new DeleteDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual(['path']);
+  });
+
+  it('returns a clear message when deviceFs is null', async () => {
+    const tool = new DeleteDeviceFileTool(() => makeBindings({ deviceFs: null }));
+    await expect(tool.call({ path: '/main.py' })).resolves.toBe('Device is not connected.');
+  });
+
+  it('forwards path to DeviceFs.removeFile', async () => {
+    const removeFile = vi.fn().mockResolvedValue(undefined);
+    const tool = new DeleteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(removeFile) }),
+    );
+    await tool.call({ path: '/lib/foo.py' });
+    expect(removeFile).toHaveBeenCalledWith('/lib/foo.py');
+  });
+
+  it('returns "ok" on success', async () => {
+    const removeFile = vi.fn().mockResolvedValue(undefined);
+    const tool = new DeleteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(removeFile) }),
+    );
+    await expect(tool.call({ path: '/main.py' })).resolves.toBe('ok');
+  });
+
+  it('does not call DeviceFs.removeFile when device is not connected', async () => {
+    const removeFile = vi.fn().mockResolvedValue(undefined);
+    const tool = new DeleteDeviceFileTool(() => makeBindings({ deviceFs: null }));
+    await tool.call({ path: '/main.py' });
+    expect(removeFile).not.toHaveBeenCalled();
+  });
+
+  it('propagates DeviceFsError from DeviceFs.removeFile', async () => {
+    const removeFile = vi.fn().mockRejectedValue(new DeviceFsError('ENOENT: no such file'));
+    const tool = new DeleteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(removeFile) }),
+    );
+    await expect(tool.call({ path: '/missing.py' })).rejects.toBeInstanceOf(DeviceFsError);
+  });
+
+  it('propagates non-device errors from DeviceFs.removeFile', async () => {
+    const removeFile = vi.fn().mockRejectedValue(new Error('disconnected'));
+    const tool = new DeleteDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(removeFile) }),
+    );
+    await expect(tool.call({ path: '/main.py' })).rejects.toThrow('disconnected');
+  });
+});

--- a/src/agent/tools/DeleteDeviceFileTool.ts
+++ b/src/agent/tools/DeleteDeviceFileTool.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface DeleteDeviceFileArgs {
+  path: string;
+}
+
+export class DeleteDeviceFileTool implements Tool<DeleteDeviceFileArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'delete_device_file',
+      description:
+        'Deletes a file at the given absolute device path on the connected microcontroller. ' +
+        'Does not delete directories. Requires user approval.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style) of the file to delete.',
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: DeleteDeviceFileArgs): Promise<string> {
+    const { deviceFs } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+    await deviceFs.removeFile(args.path);
+    return 'ok';
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -23,6 +23,7 @@ describe('wireTools', () => {
     wireTools(tools, makeBindings());
     const names = tools.getTools().map((t) => t.name).sort();
     expect(names).toEqual([
+      'delete_device_file',
       'list_device_files',
       'read_device_file',
       'read_editor',
@@ -38,7 +39,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(8);
+    expect(tools.getTools()).toHaveLength(9);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -12,6 +12,7 @@ import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
 import { ListDeviceFilesTool } from './tools/ListDeviceFilesTool';
 import { ReadDeviceFileTool } from './tools/ReadDeviceFileTool';
 import { WriteDeviceFileTool } from './tools/WriteDeviceFileTool';
+import { DeleteDeviceFileTool } from './tools/DeleteDeviceFileTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -44,4 +45,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new ListDeviceFilesTool(get));
   tools.register(new ReadDeviceFileTool(get));
   tools.register(new WriteDeviceFileTool(get));
+  tools.register(new DeleteDeviceFileTool(get));
 }


### PR DESCRIPTION
## Summary

- New `DeleteDeviceFileTool` (`src/agent/tools/DeleteDeviceFileTool.ts`) — args `{ path: string }`, `requiresApproval: true`, calls `DeviceFs.removeFile`. Recursive directory delete is intentionally not exposed to the agent for v1.
- Vitest coverage in `DeleteDeviceFileTool.test.ts`.
- Wired through `wireTools` and `CODING_AGENT.tools`; instructions get a one-line note about the new tool.
- Fix `AgentProvider.onApprovalRequired` in `App.tsx` so every tool with `requiresApproval: true` routes through the inline approval queue. Previously the handler returned `true` (auto-approve) for any tool name not in a hardcoded `run_editor`/`run_snippet` allowlist, which silently auto-approved `write_device_file` and `delete_device_file`. Filed mast-ai/mast-ai#97 to default to `INLINE_APPROVAL` when the prop is omitted.

Closes #84

## Test plan

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` — 362 passing
- [x] Manual: ask the agent to delete a device file → inline approval prompt appears.
- [x] Manual: ask the agent to write a device file → inline approval prompt appears (previously skipped).
- [x] Manual: `run_editor` / `run_snippet` still prompt as before.