### PR TITLE
feat(device-files): add make_device_dir agent tool

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -13,7 +13,8 @@ To run the editor's contents (typically a full program that may run for a long t
 For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
 To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.
 To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
-To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.`,
+To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.
+To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.`,
   tools: [
     'read_editor',
     'write_editor',
@@ -24,5 +25,6 @@ To delete a file on the device, use delete_device_file. It does not delete direc
     'read_device_file',
     'write_device_file',
     'delete_device_file',
+    'make_device_dir',
   ],
 });

--- a/src/agent/tools/MakeDeviceDirTool.test.ts
+++ b/src/agent/tools/MakeDeviceDirTool.test.ts
@@ -1,0 +1,76 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { MakeDeviceDirTool } from './MakeDeviceDirTool';
+import type { ToolBindings } from '../wireTools';
+import { DeviceFs, DeviceFsError } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    ...overrides,
+  };
+}
+
+function makeDeviceFs(mkdir: (path: string) => Promise<void>): DeviceFs {
+  return { mkdir } as unknown as DeviceFs;
+}
+
+describe('MakeDeviceDirTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new MakeDeviceDirTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('make_device_dir');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('definition makes path required', () => {
+    const tool = new MakeDeviceDirTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual(['path']);
+  });
+
+  it('returns a clear message when deviceFs is null', async () => {
+    const tool = new MakeDeviceDirTool(() => makeBindings({ deviceFs: null }));
+    await expect(tool.call({ path: '/lib' })).resolves.toBe('Device is not connected.');
+  });
+
+  it('forwards path to DeviceFs.mkdir', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined);
+    const tool = new MakeDeviceDirTool(() => makeBindings({ deviceFs: makeDeviceFs(mkdir) }));
+    await tool.call({ path: '/lib/foo' });
+    expect(mkdir).toHaveBeenCalledWith('/lib/foo');
+  });
+
+  it('returns "ok" on success', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined);
+    const tool = new MakeDeviceDirTool(() => makeBindings({ deviceFs: makeDeviceFs(mkdir) }));
+    await expect(tool.call({ path: '/lib' })).resolves.toBe('ok');
+  });
+
+  it('does not call DeviceFs.mkdir when device is not connected', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined);
+    const tool = new MakeDeviceDirTool(() => makeBindings({ deviceFs: null }));
+    await tool.call({ path: '/lib' });
+    expect(mkdir).not.toHaveBeenCalled();
+  });
+
+  it('propagates DeviceFsError from DeviceFs.mkdir', async () => {
+    const mkdir = vi.fn().mockRejectedValue(new DeviceFsError('EEXIST: directory exists'));
+    const tool = new MakeDeviceDirTool(() => makeBindings({ deviceFs: makeDeviceFs(mkdir) }));
+    await expect(tool.call({ path: '/lib' })).rejects.toBeInstanceOf(DeviceFsError);
+  });
+
+  it('propagates non-device errors from DeviceFs.mkdir', async () => {
+    const mkdir = vi.fn().mockRejectedValue(new Error('disconnected'));
+    const tool = new MakeDeviceDirTool(() => makeBindings({ deviceFs: makeDeviceFs(mkdir) }));
+    await expect(tool.call({ path: '/lib' })).rejects.toThrow('disconnected');
+  });
+});

--- a/src/agent/tools/MakeDeviceDirTool.ts
+++ b/src/agent/tools/MakeDeviceDirTool.ts
@@ -1,0 +1,42 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export interface MakeDeviceDirArgs {
+  path: string;
+}
+
+export class MakeDeviceDirTool implements Tool<MakeDeviceDirArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'make_device_dir',
+      description:
+        'Creates a directory at the given absolute device path on the connected microcontroller. ' +
+        'The parent directory must already exist. Requires user approval.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style) of the directory to create.',
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: MakeDeviceDirArgs): Promise<string> {
+    const { deviceFs } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+    await deviceFs.mkdir(args.path);
+    return 'ok';
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -25,6 +25,7 @@ describe('wireTools', () => {
     expect(names).toEqual([
       'delete_device_file',
       'list_device_files',
+      'make_device_dir',
       'read_device_file',
       'read_editor',
       'read_repl_history',
@@ -39,7 +40,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(9);
+    expect(tools.getTools()).toHaveLength(10);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -13,6 +13,7 @@ import { ListDeviceFilesTool } from './tools/ListDeviceFilesTool';
 import { ReadDeviceFileTool } from './tools/ReadDeviceFileTool';
 import { WriteDeviceFileTool } from './tools/WriteDeviceFileTool';
 import { DeleteDeviceFileTool } from './tools/DeleteDeviceFileTool';
+import { MakeDeviceDirTool } from './tools/MakeDeviceDirTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -46,4 +47,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new ReadDeviceFileTool(get));
   tools.register(new WriteDeviceFileTool(get));
   tools.register(new DeleteDeviceFileTool(get));
+  tools.register(new MakeDeviceDirTool(get));
 }


### PR DESCRIPTION
## Summary
- New `make_device_dir` agent tool wrapping `DeviceFs.mkdir`. Args `{ path: string }`, `requiresApproval: true`, returns `'ok'` on success.
- Registered in `wireTools.ts` and added to the coding-agent prompt + tool list in `agent/config.ts`.
- Vitest coverage in `MakeDeviceDirTool.test.ts`.

Closes #85.

## Test plan
- [x] `npm run lint`
- [x] `npm run test` (370 pass)
- [x] `npm run build`
- [x] Manual: agent successfully creates a directory on the device after user approval; tree refreshes