### PR TITLE
feat(ui-state-persistence): persist layout sizes and panel visibility

### DIFF
--- a/docs/ui-state-persistence/PRD.md
+++ b/docs/ui-state-persistence/PRD.md
@@ -1,0 +1,39 @@
+# UI State Persistence — Product Requirements Document
+
+## Problem Statement
+
+Cobweb resets to a blank state on every page reload. The agent conversation, theme preference, and provider config already persist (see `cobweb:conversation`, `cobweb:theme`, `cobweb:provider-config` in localStorage), but everything else — split-pane sizes, panel visibility, the untitled editor buffer, the connected device, and the open local folder — is in-memory only.
+
+Each reload forces the user to: re-arrange the panes, re-open their folder via `showDirectoryPicker`, re-click "Connect" and re-pick the same serial port from the browser chooser, and lose any work-in-progress in an untitled buffer. For a tool people leave open across many short sessions (workshop, classroom, hobby tinkering), that friction is the difference between "still where I left off" and "start from scratch every time."
+
+## Target Users
+
+Same as the parent PRD — educators, hobbyists, beginners. The persistence behaviour matters most for:
+
+- **Hobbyist** opens Cobweb, wires a script for their Pico, gets pulled away, closes the tab. Returns hours later: their layout, last folder, last device, and unsaved scratch buffer should all still be there.
+- **Educator** sets up a workshop environment (panel layout, default folder), then duplicates the tab on each student's machine. Reload should not undo that setup.
+
+## Goals
+
+1. **Layout persists.** Split-pane sizes and the open/closed state of the left, REPL, and right panels survive reload.
+2. **Untitled buffer persists.** Text the user has typed into a buffer with no file origin is restored on reload.
+3. **Last device auto-reconnects.** If the browser still has permission for the previously-connected serial port (matched by USB vendor + product ID), reconnect silently on load.
+4. **Last local folder reopens.** The handle to the previously-opened local folder is remembered. On load, attempt to reopen silently; if the browser requires a permission re-grant, surface a one-click "Reopen <foldername>" button.
+
+## Out of Scope
+
+- **Editor cursor / scroll position.** Restoring cursor or viewport state across reloads. Buffer content is enough for v1.
+- **Editor origin restore for local / device files.** Local-file handles that live inside the open folder are not individually re-opened. Device-file origins are not restored (the device may have changed). Only `untitled` is persisted.
+- **REPL scrollback.** Terminal output is tied to the live device session; we do not replay it.
+- **File-navigator expansion state.** Folder paths may be stale; users re-expand on demand.
+- **Multi-device memory.** Only the last connected device is remembered; we do not maintain a list.
+- **Cross-browser sync.** Persisted state lives in this browser's localStorage / IndexedDB; we do not sync across devices or profiles.
+
+## Success Criteria
+
+- Resize a split, toggle the right panel closed, reload — split size and panel state are restored.
+- Type into an untitled buffer, reload — text is back.
+- Connect to a Pico, reload — connection state shows "connected" within ~1s without the user clicking Connect or seeing a serial-port chooser.
+- Open a local folder, reload — the folder's contents appear in the file navigator without a click. If the browser requires re-grant, a "Reopen <foldername>" button appears in the navigator header and one click restores it.
+- A reload with no previously-connected device and no previously-opened folder behaves identically to a first-time visit (no errors in console, no spurious UI).
+- Existing persisted state (`cobweb:conversation`, `cobweb:theme`, `cobweb:provider-config`) is unaffected.

--- a/docs/ui-state-persistence/SPEC.md
+++ b/docs/ui-state-persistence/SPEC.md
@@ -1,0 +1,204 @@
+# UI State Persistence — Technical Specification
+
+## Overview
+
+Four independent persistence mechanisms, each scoped to one concern and one storage key. Layout and editor buffer use localStorage (small, synchronous, JSON). Device port identity uses localStorage (USB IDs are integers). Local folder handle uses IndexedDB because `FileSystemDirectoryHandle` is structured-cloneable but not JSON-serialisable.
+
+Existing persisted state in the app:
+
+| Concern | Storage | Key |
+|---------|---------|-----|
+| Agent conversation | localStorage | `cobweb:conversation` |
+| Theme preference | localStorage | `cobweb:theme` |
+| Provider config | localStorage | `cobweb:provider-config` |
+
+New keys added by this feature follow the same `cobweb:` prefix.
+
+---
+
+## 1. Layout (split sizes + panel visibility)
+
+### State to persist
+
+From `src/App.tsx:276-282`:
+
+```ts
+leftOpen, leftSize, rightOpen, rightSize, replOpen, replSize, leftSplitSize
+```
+
+### Storage
+
+**Key:** `cobweb:layout`
+**Shape:**
+```ts
+interface PersistedLayout {
+  leftOpen: boolean;
+  leftSize: number;
+  rightOpen: boolean;
+  rightSize: number;
+  replOpen: boolean;
+  replSize: number;
+  leftSplitSize: number;
+}
+```
+
+### Implementation
+
+- A new `useLayout` hook in `src/hooks/useLayout.ts` owns the seven values, exposing the same setters `App.tsx` uses today.
+- On mount, read `cobweb:layout`; fall back to current defaults (20 / 35 / 40 / 50 / all open) on missing or malformed JSON.
+- On any setter call, write the full object back to localStorage. No debouncing — split-drag setters fire on `mousemove`, but localStorage writes of a ~100-byte JSON object are well under 1 ms; profile only if the browser flags jank.
+- Numeric ranges are clamped on read to `[0, 100]` to defend against corrupted entries.
+- `App.tsx` replaces its seven `useState` calls with `const layout = useLayout();` and threads `layout.leftSize`, `layout.setLeftSize`, etc.
+
+### Tests
+
+`src/hooks/useLayout.test.ts` — round-trips defaults, restores stored values, ignores malformed JSON, clamps out-of-range numbers.
+
+---
+
+## 2. Editor untitled buffer
+
+### State to persist
+
+The editor's text content, but **only when** `useEditor.origin.kind === 'untitled'`. Local-file and device-file origins manage their own persistence via the file system and the device respectively; persisting them here would either duplicate the source of truth or get out of sync.
+
+### Storage
+
+**Key:** `cobweb:editor:untitled`
+**Shape:** the raw string (no JSON wrap).
+
+### Implementation
+
+In `src/hooks/useEditor.ts`:
+
+- On editor mount, after the `EditorView` is created, read `cobweb:editor:untitled`. If non-empty, set the document content and the `snapshotRef` to that value. Origin remains `{ kind: 'untitled' }`. `isModified` stays `false` (the snapshot matches the content).
+- Extend the existing `modifiedListener` (line 29): on each `docChanged`, if `origin.kind === 'untitled'`, write the current content to localStorage. If `origin.kind !== 'untitled'`, leave the stored value alone — it'll be cleared by the next untitled open or remain available if the user returns to untitled.
+- In `setOriginAndContent`: if the new origin is `untitled`, write the new content to localStorage. If the new origin is `local` or `device`, **clear** `cobweb:editor:untitled` (the user has moved on; the orphan untitled buffer would otherwise reappear next reload).
+- The current `useEffect` that creates the editor (line 26) reads `origin` indirectly via the ref state; the restoration step must run inside that effect after `viewRef.current` is set, before returning.
+
+### Edge cases
+
+- Restored content is large (>1 MB): localStorage will throw `QuotaExceededError`. Wrap writes in try/catch and silently no-op on quota failure — losing the in-flight save is preferable to an unhandled exception.
+- The buffer at restore time is empty string: skip the restore (no point dispatching a no-op change).
+
+### Tests
+
+`src/hooks/useEditor.test.ts` — restore on mount when key is set, no restore when missing, write on edit while untitled, no write while local/device, clear on transition away from untitled.
+
+---
+
+## 3. Auto-reconnect last device
+
+### State to persist
+
+USB vendor ID + product ID of the last successfully-connected serial port.
+
+### Storage
+
+**Key:** `cobweb:lastDevice`
+**Shape:**
+```ts
+interface PersistedDevice {
+  usbVendorId: number;
+  usbProductId: number;
+}
+```
+
+### Implementation
+
+In `src/hooks/useReplConnection.ts`:
+
+- After a successful `connect()` call (line 55, immediately before `setConnectionState('connected')`), call `port.getInfo()` on the underlying `SerialPort` and store `{ usbVendorId, usbProductId }` to localStorage. (`ReplInterface` currently hides the port; expose it via a getter `getPortInfo(): { usbVendorId?: number; usbProductId?: number } | null` on `ReplInterface`.)
+- On `useReplConnection` mount (new `useEffect` with empty deps), call `navigator.serial.getPorts()`. For each granted port, call `getInfo()` and look for one whose `usbVendorId` and `usbProductId` match the persisted entry.
+  - **Exactly one match:** call a new `ReplInterface.connectToPort(port)` static method that mirrors `connect()` but skips the `requestPort()` chooser. Then run the same wiring as `connect()`.
+  - **Zero matches or multiple matches:** do nothing. (Multiple matches means the user has more than one identical board plugged in; auto-picking would be wrong, and silently doing nothing is consistent with first-time-visit behaviour.)
+- On user-initiated `disconnect()`, leave the persisted entry alone — disconnect is a transient action; the user likely wants the same device back next session. Only overwrite on a *successful new connect*.
+- If auto-reconnect throws (port stale, device removed mid-load), swallow the error and stay disconnected. The user can click Connect manually.
+
+### `ReplInterface` changes
+
+- Expose `getPortInfo(): { usbVendorId?: number; usbProductId?: number } | null` (returns `null` if no port).
+- Add `static connectToPort(port: SerialPort): Promise<ReplInterface>` — same as the body of `connect()` but takes the port as an argument instead of calling `navigator.serial.requestPort()`.
+
+### Tests
+
+`src/hooks/useReplConnection.test.ts` — mock `navigator.serial.getPorts` to return zero / one / two matching ports, verify auto-reconnect happens only on the one-match case, verify localStorage is written after a successful connect.
+
+`src/ReplInterface.test.ts` — `connectToPort` opens the given port and produces an interface equivalent to `connect()`.
+
+---
+
+## 4. Reopen last local folder
+
+### State to persist
+
+`FileSystemDirectoryHandle` for the most recently opened local folder.
+
+### Storage
+
+**Database:** `cobweb` (IndexedDB)
+**Object store:** `handles`
+**Key:** `lastFolder`
+**Value:** the `FileSystemDirectoryHandle` instance (structured-cloneable).
+
+A small helper module `src/lib/handleStore.ts` wraps the IndexedDB calls:
+
+```ts
+export async function saveFolderHandle(handle: FileSystemDirectoryHandle): Promise<void>;
+export async function loadFolderHandle(): Promise<FileSystemDirectoryHandle | null>;
+export async function clearFolderHandle(): Promise<void>;
+```
+
+Implemented with the raw `indexedDB` API (no library dependency) — the surface is tiny and adding `idb-keyval` for one key isn't worth it.
+
+### Implementation
+
+In `src/components/FileNavigator.tsx`:
+
+- On mount (new `useEffect`), call `loadFolderHandle()`. If a handle is returned:
+  - Call `handle.queryPermission({ mode: 'readwrite' })`.
+  - If `'granted'`: load children and set root, identical to `openDirectory`'s success path.
+  - If `'prompt'` or `'denied'`: set the handle into a new `pendingHandle` state and render a "Reopen *<folder name>*" button in the header (replacing the existing "Open Folder" button when `pendingHandle` is set).
+  - Clicking "Reopen": call `handle.requestPermission({ mode: 'readwrite' })` (must be in user-gesture stack). On `'granted'`, load children and set root; clear `pendingHandle`. On denial, fall back to the regular "Open Folder" button.
+- In `openDirectory` (the existing path), after a successful pick, call `saveFolderHandle(dirHandle)`.
+- Do not clear the handle on tab close or unmount — the user would lose the auto-reopen they just earned. Clear only when a *new* folder is picked (overwrite via `saveFolderHandle`).
+
+### Edge cases
+
+- The folder no longer exists at restore time: `queryPermission` returns `'granted'` but `entries()` throws. Catch in the load path, fall back to the empty / "Open Folder" UI, and call `clearFolderHandle()`.
+- IndexedDB unavailable (private browsing in some configurations): catch on `loadFolderHandle` / `saveFolderHandle` and behave as if no handle were stored.
+- Browser lacks File System Access API: the existing code path already calls `window.showDirectoryPicker()` unconditionally; this feature does not change that, since the persisted handle is only relevant where the API exists.
+
+### Tests
+
+`src/lib/handleStore.test.ts` — round-trip a fake handle through the store, return null when empty, clear works.
+
+`FileNavigator` is a UI component; per project convention it is not unit-tested. Manual browser test is the gate.
+
+---
+
+## File Map
+
+**Add:**
+- `src/hooks/useLayout.ts` + test
+- `src/lib/handleStore.ts` + test
+
+**Modify:**
+- `src/App.tsx` — replace seven layout `useState` calls with `useLayout`.
+- `src/hooks/useEditor.ts` + test — read/write `cobweb:editor:untitled`.
+- `src/hooks/useReplConnection.ts` + test — auto-reconnect on mount, write `cobweb:lastDevice` on successful connect.
+- `src/ReplInterface.ts` + test — add `getPortInfo()` and `static connectToPort(port)`.
+- `src/components/FileNavigator.tsx` — load handle on mount, "Reopen" button when permission needs re-grant, save handle on pick.
+
+---
+
+## Phasing / Issue Breakdown
+
+This feature ships behind the GitHub label `ui-state-persistence`. Each item below becomes a separate issue / PR.
+
+1. **Layout persistence** — `useLayout` hook, wire into `App.tsx`. (independent)
+2. **Untitled-buffer persistence** — read/write in `useEditor`. (independent)
+3. **Auto-reconnect last device** — `ReplInterface.connectToPort`, `getPortInfo`, mount-time auto-reconnect in `useReplConnection`. (independent)
+4. **Reopen last local folder** — `handleStore` IndexedDB module, mount-time load + "Reopen" button in `FileNavigator`. (independent)
+
+All four are technically independent and can ship in any order.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { AgentPanel } from './components/AgentPanel';
 import { useReplConnection } from './hooks/useReplConnection';
 import { useEditor, type EditorOrigin } from './hooks/useEditor';
 import { useDeviceFs } from './hooks/useDeviceFs';
+import { useLayout } from './hooks/useLayout';
 import { useProviderConfig } from './hooks/useProviderConfig';
 import { useTheme } from './hooks/useTheme';
 import { createModels } from './models';
@@ -273,13 +274,22 @@ export function App() {
   );
 
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const [leftOpen, setLeftOpen] = useState(true);
-  const [leftSize, setLeftSize] = useState(20);
-  const [rightOpen, setRightOpen] = useState(true);
-  const [rightSize, setRightSize] = useState(35);
-  const [replOpen, setReplOpen] = useState(true);
-  const [replSize, setReplSize] = useState(40);
-  const [leftSplitSize, setLeftSplitSize] = useState(50);
+  const {
+    leftOpen,
+    setLeftOpen,
+    leftSize,
+    setLeftSize,
+    rightOpen,
+    setRightOpen,
+    rightSize,
+    setRightSize,
+    replOpen,
+    setReplOpen,
+    replSize,
+    setReplSize,
+    leftSplitSize,
+    setLeftSplitSize,
+  } = useLayout();
 
   return (
     <AgentProvider

--- a/src/hooks/useLayout.test.ts
+++ b/src/hooks/useLayout.test.ts
@@ -1,0 +1,135 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLayout } from './useLayout';
+
+const KEY = 'cobweb:layout';
+
+describe('useLayout', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns documented defaults when nothing is stored', () => {
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.leftOpen).toBe(true);
+    expect(result.current.leftSize).toBe(20);
+    expect(result.current.rightOpen).toBe(true);
+    expect(result.current.rightSize).toBe(35);
+    expect(result.current.replOpen).toBe(true);
+    expect(result.current.replSize).toBe(40);
+    expect(result.current.leftSplitSize).toBe(50);
+  });
+
+  it('restores stored values on mount', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        leftOpen: false,
+        leftSize: 12,
+        rightOpen: false,
+        rightSize: 27,
+        replOpen: false,
+        replSize: 33,
+        leftSplitSize: 66,
+      }),
+    );
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.leftOpen).toBe(false);
+    expect(result.current.leftSize).toBe(12);
+    expect(result.current.rightOpen).toBe(false);
+    expect(result.current.rightSize).toBe(27);
+    expect(result.current.replOpen).toBe(false);
+    expect(result.current.replSize).toBe(33);
+    expect(result.current.leftSplitSize).toBe(66);
+  });
+
+  it('falls back to defaults when stored JSON is malformed', () => {
+    localStorage.setItem(KEY, '{not valid json');
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.leftSize).toBe(20);
+    expect(result.current.leftOpen).toBe(true);
+  });
+
+  it('falls back to defaults when stored value is not an object', () => {
+    localStorage.setItem(KEY, '"a string"');
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.leftSize).toBe(20);
+  });
+
+  it('falls back to defaults for individual missing or wrongly-typed keys', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({ leftSize: 'twenty', rightSize: 25, replOpen: 'yes' }),
+    );
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.leftSize).toBe(20);
+    expect(result.current.rightSize).toBe(25);
+    expect(result.current.replOpen).toBe(true);
+  });
+
+  it('clamps out-of-range numbers on read', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        leftSize: -50,
+        rightSize: 250,
+        replSize: 40,
+        leftSplitSize: 1000,
+      }),
+    );
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.leftSize).toBe(0);
+    expect(result.current.rightSize).toBe(100);
+    expect(result.current.leftSplitSize).toBe(100);
+  });
+
+  it('clamps values written through setters', () => {
+    const { result } = renderHook(() => useLayout());
+    act(() => result.current.setLeftSize(-10));
+    expect(result.current.leftSize).toBe(0);
+    act(() => result.current.setRightSize(150));
+    expect(result.current.rightSize).toBe(100);
+  });
+
+  it('persists numeric updates to localStorage', () => {
+    const { result } = renderHook(() => useLayout());
+    act(() => result.current.setLeftSize(42));
+    const stored = JSON.parse(localStorage.getItem(KEY) ?? '{}');
+    expect(stored.leftSize).toBe(42);
+    expect(stored.rightSize).toBe(35);
+  });
+
+  it('persists boolean toggles via direct value', () => {
+    const { result } = renderHook(() => useLayout());
+    act(() => result.current.setLeftOpen(false));
+    expect(result.current.leftOpen).toBe(false);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? '{}').leftOpen).toBe(false);
+  });
+
+  it('persists boolean toggles via functional updater', () => {
+    const { result } = renderHook(() => useLayout());
+    act(() => result.current.setReplOpen((o) => !o));
+    expect(result.current.replOpen).toBe(false);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? '{}').replOpen).toBe(false);
+    act(() => result.current.setReplOpen((o) => !o));
+    expect(result.current.replOpen).toBe(true);
+  });
+
+  it('round-trips a full session: change values, remount, observe restore', () => {
+    const first = renderHook(() => useLayout());
+    act(() => {
+      first.result.current.setLeftSize(15);
+      first.result.current.setRightOpen(false);
+      first.result.current.setLeftSplitSize(70);
+    });
+    first.unmount();
+
+    const second = renderHook(() => useLayout());
+    expect(second.result.current.leftSize).toBe(15);
+    expect(second.result.current.rightOpen).toBe(false);
+    expect(second.result.current.leftSplitSize).toBe(70);
+  });
+});

--- a/src/hooks/useLayout.ts
+++ b/src/hooks/useLayout.ts
@@ -1,0 +1,143 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useCallback, useState, type Dispatch, type SetStateAction } from 'react';
+
+const STORAGE_KEY = 'cobweb:layout';
+
+export interface PersistedLayout {
+  leftOpen: boolean;
+  leftSize: number;
+  rightOpen: boolean;
+  rightSize: number;
+  replOpen: boolean;
+  replSize: number;
+  leftSplitSize: number;
+}
+
+const DEFAULTS: PersistedLayout = {
+  leftOpen: true,
+  leftSize: 20,
+  rightOpen: true,
+  rightSize: 35,
+  replOpen: true,
+  replSize: 40,
+  leftSplitSize: 50,
+};
+
+function clamp(n: number): number {
+  if (n < 0) return 0;
+  if (n > 100) return 100;
+  return n;
+}
+
+function readLayout(): PersistedLayout {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw === null) return DEFAULTS;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return DEFAULTS;
+  }
+  if (parsed === null || typeof parsed !== 'object') return DEFAULTS;
+  const p = parsed as Partial<Record<keyof PersistedLayout, unknown>>;
+  const pickNumber = (key: keyof PersistedLayout, fallback: number): number => {
+    const v = p[key];
+    return typeof v === 'number' && Number.isFinite(v) ? clamp(v) : fallback;
+  };
+  const pickBool = (key: keyof PersistedLayout, fallback: boolean): boolean => {
+    const v = p[key];
+    return typeof v === 'boolean' ? v : fallback;
+  };
+  return {
+    leftOpen: pickBool('leftOpen', DEFAULTS.leftOpen),
+    leftSize: pickNumber('leftSize', DEFAULTS.leftSize),
+    rightOpen: pickBool('rightOpen', DEFAULTS.rightOpen),
+    rightSize: pickNumber('rightSize', DEFAULTS.rightSize),
+    replOpen: pickBool('replOpen', DEFAULTS.replOpen),
+    replSize: pickNumber('replSize', DEFAULTS.replSize),
+    leftSplitSize: pickNumber('leftSplitSize', DEFAULTS.leftSplitSize),
+  };
+}
+
+export interface UseLayoutResult {
+  leftOpen: boolean;
+  setLeftOpen: Dispatch<SetStateAction<boolean>>;
+  leftSize: number;
+  setLeftSize: (v: number) => void;
+  rightOpen: boolean;
+  setRightOpen: Dispatch<SetStateAction<boolean>>;
+  rightSize: number;
+  setRightSize: (v: number) => void;
+  replOpen: boolean;
+  setReplOpen: Dispatch<SetStateAction<boolean>>;
+  replSize: number;
+  setReplSize: (v: number) => void;
+  leftSplitSize: number;
+  setLeftSplitSize: (v: number) => void;
+}
+
+export function useLayout(): UseLayoutResult {
+  const [layout, setLayout] = useState<PersistedLayout>(readLayout);
+
+  const setBoolKey = useCallback(
+    (key: 'leftOpen' | 'rightOpen' | 'replOpen', value: SetStateAction<boolean>) => {
+      setLayout((prev) => {
+        const resolved = typeof value === 'function' ? value(prev[key]) : value;
+        const next = { ...prev, [key]: resolved };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setNumberKey = useCallback(
+    (key: 'leftSize' | 'rightSize' | 'replSize' | 'leftSplitSize', v: number) => {
+      setLayout((prev) => {
+        const next = { ...prev, [key]: clamp(v) };
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setLeftOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (v) => setBoolKey('leftOpen', v),
+    [setBoolKey],
+  );
+  const setRightOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (v) => setBoolKey('rightOpen', v),
+    [setBoolKey],
+  );
+  const setReplOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (v) => setBoolKey('replOpen', v),
+    [setBoolKey],
+  );
+  const setLeftSize = useCallback((v: number) => setNumberKey('leftSize', v), [setNumberKey]);
+  const setRightSize = useCallback((v: number) => setNumberKey('rightSize', v), [setNumberKey]);
+  const setReplSize = useCallback((v: number) => setNumberKey('replSize', v), [setNumberKey]);
+  const setLeftSplitSize = useCallback(
+    (v: number) => setNumberKey('leftSplitSize', v),
+    [setNumberKey],
+  );
+
+  return {
+    leftOpen: layout.leftOpen,
+    setLeftOpen,
+    leftSize: layout.leftSize,
+    setLeftSize,
+    rightOpen: layout.rightOpen,
+    setRightOpen,
+    rightSize: layout.rightSize,
+    setRightSize,
+    replOpen: layout.replOpen,
+    setReplOpen,
+    replSize: layout.replSize,
+    setReplSize,
+    leftSplitSize: layout.leftSplitSize,
+    setLeftSplitSize,
+  };
+}


### PR DESCRIPTION
## Summary
- New `useLayout` hook (`src/hooks/useLayout.ts`) owns the seven layout values (`leftOpen`, `leftSize`, `rightOpen`, `rightSize`, `replOpen`, `replSize`, `leftSplitSize`) and persists them to `localStorage['cobweb:layout']` on every change.
- `App.tsx` replaces its seven `useState` calls with one `useLayout()` destructure.
- Defaults (20 / 35 / 40 / 50, all open) apply on first load and whenever the stored JSON is missing or malformed; numbers are clamped to `[0, 100]` on read and on write to defend against corrupted entries.
- Lands `docs/ui-state-persistence/PRD.md` and `SPEC.md` covering all four phases of this feature (layout, untitled buffer, auto-reconnect, reopen folder).

## Test plan
- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm run test` — 381/381 pass, including 11 new `useLayout` tests (defaults, restore, malformed JSON, non-object payload, per-key validation, clamp on read, clamp on write, persistence via direct + functional updaters, full unmount-remount round-trip)
- [x] Manual browser test: drag splitters and toggle panels via the status-bar buttons, reload — all values restored. `cobweb:layout` updates live in DevTools.

Closes #112