### PR TITLE
feat(ui-state-persistence): persist untitled editor buffer

### DIFF
--- a/src/hooks/useEditor.test.ts
+++ b/src/hooks/useEditor.test.ts
@@ -88,6 +88,7 @@ beforeEach(() => {
   mockDocState.length = 0;
   mockDocState.content = '';
   capturedListeners.length = 0;
+  localStorage.clear();
 });
 
 function mountedHook() {
@@ -250,6 +251,138 @@ describe('useEditor — origin tracking', () => {
     act(() => handle.current.setContent('snapshot'));
     expect(handle.current.isModified).toBe(false);
 
+    handle.cleanup();
+  });
+});
+
+describe('useEditor — untitled buffer persistence', () => {
+  const KEY = 'cobweb:editor:untitled';
+
+  it('restores stored content on mount and keeps isModified false', () => {
+    localStorage.setItem(KEY, 'print("restored")');
+    const handle = mountedHook();
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      changes: { from: 0, to: 0, insert: 'print("restored")' },
+    });
+    expect(handle.current.getContent()).toBe('print("restored")');
+    expect(handle.current.origin).toEqual({ kind: 'untitled' });
+    expect(handle.current.isModified).toBe(false);
+
+    handle.cleanup();
+  });
+
+  it('does not dispatch a restore when the key is missing', () => {
+    const handle = mountedHook();
+
+    const restoreCalls = mockDispatch.mock.calls.filter(
+      ([t]) => (t as { changes?: unknown }).changes !== undefined,
+    );
+    expect(restoreCalls).toHaveLength(0);
+    expect(handle.current.getContent()).toBe('');
+
+    handle.cleanup();
+  });
+
+  it('skips restore when stored value is the empty string', () => {
+    localStorage.setItem(KEY, '');
+    const handle = mountedHook();
+
+    const restoreCalls = mockDispatch.mock.calls.filter(
+      ([t]) => (t as { changes?: unknown }).changes !== undefined,
+    );
+    expect(restoreCalls).toHaveLength(0);
+
+    handle.cleanup();
+  });
+
+  it('writes to localStorage on edits while origin is untitled', () => {
+    const handle = mountedHook();
+
+    act(() => handle.current.setContent('print("new")'));
+    expect(localStorage.getItem(KEY)).toBe('print("new")');
+
+    act(() => handle.current.setContent('print("again")'));
+    expect(localStorage.getItem(KEY)).toBe('print("again")');
+
+    handle.cleanup();
+  });
+
+  it('does not write to localStorage on edits while origin is local', () => {
+    const handle = mountedHook();
+    const fileHandle = {} as FileSystemFileHandle;
+    const localOrigin: EditorOrigin = { kind: 'local', handle: fileHandle, name: 'main.py' };
+
+    act(() => handle.current.setOriginAndContent(localOrigin, 'print("local")'));
+    expect(localStorage.getItem(KEY)).toBeNull();
+
+    act(() => handle.current.setContent('edited'));
+    expect(localStorage.getItem(KEY)).toBeNull();
+
+    handle.cleanup();
+  });
+
+  it('does not write to localStorage on edits while origin is device', () => {
+    const handle = mountedHook();
+    const deviceOrigin: EditorOrigin = { kind: 'device', path: '/main.py' };
+
+    act(() => handle.current.setOriginAndContent(deviceOrigin, 'print("device")'));
+    expect(localStorage.getItem(KEY)).toBeNull();
+
+    act(() => handle.current.setContent('edited'));
+    expect(localStorage.getItem(KEY)).toBeNull();
+
+    handle.cleanup();
+  });
+
+  it('clears localStorage when transitioning from untitled to local', () => {
+    localStorage.setItem(KEY, 'old draft');
+    const handle = mountedHook();
+    expect(localStorage.getItem(KEY)).toBe('old draft');
+
+    const fileHandle = {} as FileSystemFileHandle;
+    const localOrigin: EditorOrigin = { kind: 'local', handle: fileHandle, name: 'main.py' };
+    act(() => handle.current.setOriginAndContent(localOrigin, 'file content'));
+
+    expect(localStorage.getItem(KEY)).toBeNull();
+
+    handle.cleanup();
+  });
+
+  it('clears localStorage when transitioning from untitled to device', () => {
+    localStorage.setItem(KEY, 'old draft');
+    const handle = mountedHook();
+
+    const deviceOrigin: EditorOrigin = { kind: 'device', path: '/main.py' };
+    act(() => handle.current.setOriginAndContent(deviceOrigin, 'device content'));
+
+    expect(localStorage.getItem(KEY)).toBeNull();
+
+    handle.cleanup();
+  });
+
+  it('writes new content when setOriginAndContent moves back to untitled', () => {
+    const handle = mountedHook();
+    const deviceOrigin: EditorOrigin = { kind: 'device', path: '/main.py' };
+
+    act(() => handle.current.setOriginAndContent(deviceOrigin, 'device content'));
+    expect(localStorage.getItem(KEY)).toBeNull();
+
+    act(() => handle.current.setOriginAndContent({ kind: 'untitled' }, 'fresh draft'));
+    expect(localStorage.getItem(KEY)).toBe('fresh draft');
+
+    handle.cleanup();
+  });
+
+  it('swallows QuotaExceededError thrown by localStorage.setItem', () => {
+    const handle = mountedHook();
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('quota', 'QuotaExceededError');
+    });
+
+    expect(() => act(() => handle.current.setContent('overflow'))).not.toThrow();
+
+    setItemSpy.mockRestore();
     handle.cleanup();
   });
 });

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -12,11 +12,30 @@ export type EditorOrigin =
   | { kind: 'local'; handle: FileSystemFileHandle; name: string }
   | { kind: 'device'; path: string };
 
+const UNTITLED_KEY = 'cobweb:editor:untitled';
+
+function writeUntitled(content: string): void {
+  try {
+    localStorage.setItem(UNTITLED_KEY, content);
+  } catch {
+    // QuotaExceededError or similar — silently drop the in-flight save.
+  }
+}
+
+function clearUntitled(): void {
+  try {
+    localStorage.removeItem(UNTITLED_KEY);
+  } catch {
+    // ignore
+  }
+}
+
 export function useEditor(theme: 'light' | 'dark') {
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
   const themeCompartment = useRef(new Compartment());
   const snapshotRef = useRef<string>('');
+  const originRef = useRef<EditorOrigin>({ kind: 'untitled' });
   const [origin, setOrigin] = useState<EditorOrigin>({ kind: 'untitled' });
   const [isModified, setIsModified] = useState(false);
 
@@ -30,6 +49,9 @@ export function useEditor(theme: 'light' | 'dark') {
       if (!update.docChanged) return;
       const current = update.state.doc.sliceString(0);
       setIsModified(current !== snapshotRef.current);
+      if (originRef.current.kind === 'untitled') {
+        writeUntitled(current);
+      }
     });
 
     const fillHeight = EditorView.theme({
@@ -50,6 +72,14 @@ export function useEditor(theme: 'light' | 'dark') {
       parent: editorRef.current,
     });
     viewRef.current = view;
+
+    const stored = localStorage.getItem(UNTITLED_KEY);
+    if (stored !== null && stored !== '') {
+      snapshotRef.current = stored;
+      view.dispatch({
+        changes: { from: 0, to: view.state.doc.length, insert: stored },
+      });
+    }
 
     return () => {
       view.destroy();
@@ -82,6 +112,7 @@ export function useEditor(theme: 'light' | 'dark') {
 
   const setOriginAndContent = useCallback((newOrigin: EditorOrigin, content: string): void => {
     snapshotRef.current = content;
+    originRef.current = newOrigin;
     setOrigin(newOrigin);
     const view = viewRef.current;
     if (view) {
@@ -90,6 +121,11 @@ export function useEditor(theme: 'light' | 'dark') {
       });
     }
     setIsModified(false);
+    if (newOrigin.kind === 'untitled') {
+      writeUntitled(content);
+    } else {
+      clearUntitled();
+    }
   }, []);
 
   return { editorRef, getContent, setContent, origin, setOriginAndContent, isModified };


### PR DESCRIPTION
## Summary
- Persist the editor's content to `cobweb:editor:untitled` localStorage key only while `useEditor.origin.kind === 'untitled'`. Local- and device-file origins manage their own persistence (filesystem / device), so duplicating here would create stale-copy bugs.
- On mount, restore stored content (and seed `snapshotRef` so `isModified` stays `false`). Empty / missing values skip the no-op dispatch.
- `setOriginAndContent` writes the new content when staying in untitled and clears the key when transitioning to local/device. `QuotaExceededError` is swallowed.

Closes #113. See `docs/ui-state-persistence/SPEC.md` §2.

## Test plan
- [x] `npm run test` — 391 passing (10 new tests in `useEditor.test.ts` for restore/write/clear/quota).
- [x] `npm run lint`, `npm run build` clean.
- [x] Manual: type into untitled → reload → text restored.
- [x] Manual: open a local/device file → reload → no stale untitled draft.
- [x] Manual: type into untitled, then open a local file → reload → untitled is cleared.