### PR TITLE
feat(ui-state-persistence): auto-reconnect to last device on load

### DIFF
--- a/src/ReplInterface.test.ts
+++ b/src/ReplInterface.test.ts
@@ -13,6 +13,9 @@ class FakeSerialPort {
   closed = false;
   writableClosed = false;
   readableCancelled = false;
+  opened = false;
+  openOptions: SerialOptions | null = null;
+  info: SerialPortInfo = {usbVendorId: 0x2e8a, usbProductId: 0x0005};
 
   /**
    * Optional hook letting tests fail a specific write. Return an Error to
@@ -81,6 +84,15 @@ class FakeSerialPort {
 
   async close() {
     this.closed = true;
+  }
+
+  async open(options: SerialOptions) {
+    this.opened = true;
+    this.openOptions = options;
+  }
+
+  getInfo(): SerialPortInfo {
+    return this.info;
   }
 }
 
@@ -868,6 +880,62 @@ describe('ReplInterface', () => {
           });
         }
       }
+    });
+  });
+
+  describe('connectToPort', () => {
+    it('opens the supplied port and returns a wired ReplInterface', async () => {
+      // beforeEach already ran, but we want a fresh port we control.
+      port.endReadable();
+      const fresh = new FakeSerialPort();
+      const iface = await ReplInterface.connectToPort(fresh as unknown as SerialPort);
+      expect(fresh.opened).toBe(true);
+      expect(fresh.openOptions).toEqual({baudRate: 115200, dataBits: 8, stopBits: 1});
+      // The returned interface dispatches data events from the supplied port.
+      const seen: Uint8Array[] = [];
+      iface.addEventListener('data', (e) => {
+        seen.push((e as CustomEvent<Uint8Array>).detail);
+      });
+      fresh.inject([0x68, 0x69]);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(seen).toEqual([bytes(0x68, 0x69)]);
+      fresh.endReadable();
+    });
+
+    it('does not invoke navigator.serial.requestPort()', async () => {
+      // No need to set up navigator.serial — connectToPort skips the chooser.
+      port.endReadable();
+      const fresh = new FakeSerialPort();
+      const nav = navigator as unknown as { serial?: unknown };
+      const original = nav.serial;
+      delete nav.serial;
+      try {
+        await expect(
+          ReplInterface.connectToPort(fresh as unknown as SerialPort),
+        ).resolves.toBeInstanceOf(ReplInterface);
+      } finally {
+        if (original !== undefined) {
+          Object.defineProperty(navigator, 'serial', {
+            value: original,
+            configurable: true,
+          });
+        }
+        fresh.endReadable();
+      }
+    });
+  });
+
+  describe('getPortInfo', () => {
+    it('returns the underlying port USB IDs', () => {
+      port.info = {usbVendorId: 0x2e8a, usbProductId: 0x0005};
+      const info = repl.getPortInfo();
+      expect(info).toEqual({usbVendorId: 0x2e8a, usbProductId: 0x0005});
+    });
+
+    it('returns the IDs even when only one is set (non-USB transports)', () => {
+      port.info = {usbVendorId: 0x2e8a};
+      const info = repl.getPortInfo();
+      expect(info).toEqual({usbVendorId: 0x2e8a, usbProductId: undefined});
     });
   });
 });

--- a/src/ReplInterface.ts
+++ b/src/ReplInterface.ts
@@ -537,6 +537,17 @@ export class ReplInterface extends EventTarget {
     return exchange;
   }
 
+  /**
+   * USB vendor + product IDs of the underlying port, used to recognise the
+   * same physical device across reloads. Either field may be undefined for
+   * non-USB transports (Bluetooth serial, virtual ports).
+   */
+  getPortInfo(): { usbVendorId?: number; usbProductId?: number } | null {
+    if (!this.port) return null;
+    const info = this.port.getInfo();
+    return {usbVendorId: info.usbVendorId, usbProductId: info.usbProductId};
+  }
+
   static async connect(
         baudRate: number = 115200,
         dataBits: number = 8,
@@ -545,6 +556,20 @@ export class ReplInterface extends EventTarget {
       throw new Error('The Web Serial API is not supported');
     }
     const port = await navigator.serial!.requestPort();
+    return ReplInterface.connectToPort(port, baudRate, dataBits, stopBits);
+  }
+
+  /**
+   * Opens an explicitly-supplied port and returns a `ReplInterface` wired up
+   * to it. Mirrors `connect()` but skips the `requestPort()` chooser, so
+   * callers (e.g. auto-reconnect on load) can use ports already granted via
+   * `navigator.serial.getPorts()`.
+   */
+  static async connectToPort(
+        port: SerialPort,
+        baudRate: number = 115200,
+        dataBits: number = 8,
+        stopBits: number = 1): Promise<ReplInterface> {
     await port.open({
       baudRate: baudRate,
       dataBits: dataBits,

--- a/src/hooks/useReplConnection.test.ts
+++ b/src/hooks/useReplConnection.test.ts
@@ -1,27 +1,72 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import { useReplConnection } from './useReplConnection';
 import { ReplDisconnectedError, ReplInterface } from '../ReplInterface';
 
-function makeMockRepl(): ReplInterface {
+const LAST_DEVICE_KEY = 'cobweb:lastDevice';
+
+function makeMockRepl(
+  info: { usbVendorId?: number; usbProductId?: number } | null = {
+    usbVendorId: 0x2e8a,
+    usbProductId: 0x0005,
+  },
+): ReplInterface {
   const et = new EventTarget();
   return Object.assign(et, {
     disconnect: vi.fn().mockResolvedValue(undefined),
     reset: vi.fn().mockResolvedValue(undefined),
     sendRaw: vi.fn().mockResolvedValue({stdout: '', stderr: ''}),
     send: vi.fn().mockResolvedValue(undefined),
+    getPortInfo: vi.fn().mockReturnValue(info),
   }) as unknown as ReplInterface;
+}
+
+function fakePort(usbVendorId?: number, usbProductId?: number): SerialPort {
+  return {
+    getInfo: () => ({usbVendorId, usbProductId}),
+  } as unknown as SerialPort;
+}
+
+/**
+ * Installs a fake `navigator.serial` exposing only `getPorts`. Returns a
+ * teardown that restores the original.
+ */
+function installFakeSerial(ports: SerialPort[]): () => void {
+  const nav = navigator as unknown as { serial?: unknown };
+  const original = Object.prototype.hasOwnProperty.call(nav, 'serial')
+    ? nav.serial
+    : undefined;
+  Object.defineProperty(navigator, 'serial', {
+    value: { getPorts: vi.fn().mockResolvedValue(ports) },
+    configurable: true,
+  });
+  return () => {
+    if (original === undefined) {
+      delete nav.serial;
+    } else {
+      Object.defineProperty(navigator, 'serial', {
+        value: original,
+        configurable: true,
+      });
+    }
+  };
 }
 
 describe('useReplConnection', () => {
   let mockRepl: ReplInterface;
 
   beforeEach(() => {
+    localStorage.clear();
     mockRepl = makeMockRepl();
     vi.spyOn(ReplInterface, 'connect').mockResolvedValue(mockRepl);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
   });
 
   it('starts disconnected', () => {
@@ -190,6 +235,175 @@ describe('useReplConnection', () => {
       const { result } = renderHook(() => useReplConnection());
       await act(() => result.current.connect());
       await expect(result.current.reset()).rejects.toBe(boom);
+    });
+  });
+
+  describe('persistence — last device', () => {
+    it('writes USB IDs to localStorage after a successful connect', async () => {
+      const { result } = renderHook(() => useReplConnection());
+      await act(() => result.current.connect());
+      const stored = localStorage.getItem(LAST_DEVICE_KEY);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toEqual({
+        usbVendorId: 0x2e8a,
+        usbProductId: 0x0005,
+      });
+    });
+
+    it('does not write when the port reports no USB IDs', async () => {
+      mockRepl = makeMockRepl({});
+      vi.spyOn(ReplInterface, 'connect').mockResolvedValue(mockRepl);
+      const { result } = renderHook(() => useReplConnection());
+      await act(() => result.current.connect());
+      expect(localStorage.getItem(LAST_DEVICE_KEY)).toBeNull();
+    });
+
+    it('does not clear the persisted entry on user-initiated disconnect', async () => {
+      const { result } = renderHook(() => useReplConnection());
+      await act(() => result.current.connect());
+      await act(() => result.current.disconnect());
+      const stored = localStorage.getItem(LAST_DEVICE_KEY);
+      expect(stored).not.toBeNull();
+      expect(JSON.parse(stored!)).toEqual({
+        usbVendorId: 0x2e8a,
+        usbProductId: 0x0005,
+      });
+    });
+  });
+
+  describe('auto-reconnect on mount', () => {
+    beforeEach(() => {
+      localStorage.setItem(
+        LAST_DEVICE_KEY,
+        JSON.stringify({usbVendorId: 0x2e8a, usbProductId: 0x0005}),
+      );
+    });
+
+    it('connects when exactly one granted port matches the persisted IDs', async () => {
+      const matching = fakePort(0x2e8a, 0x0005);
+      const teardown = installFakeSerial([matching]);
+      const connectToPort = vi
+        .spyOn(ReplInterface, 'connectToPort')
+        .mockResolvedValue(mockRepl);
+      try {
+        const { result } = renderHook(() => useReplConnection());
+        // Allow the mount-time effect's promise chain to settle.
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(connectToPort).toHaveBeenCalledWith(matching);
+        expect(result.current.connectionState).toBe('connected');
+      } finally {
+        teardown();
+      }
+    });
+
+    it('does nothing when zero granted ports match', async () => {
+      const teardown = installFakeSerial([fakePort(0x1234, 0x5678)]);
+      const connectToPort = vi.spyOn(ReplInterface, 'connectToPort');
+      try {
+        const { result } = renderHook(() => useReplConnection());
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(connectToPort).not.toHaveBeenCalled();
+        expect(result.current.connectionState).toBe('disconnected');
+      } finally {
+        teardown();
+      }
+    });
+
+    it('does nothing when multiple granted ports match (ambiguous)', async () => {
+      const teardown = installFakeSerial([
+        fakePort(0x2e8a, 0x0005),
+        fakePort(0x2e8a, 0x0005),
+      ]);
+      const connectToPort = vi.spyOn(ReplInterface, 'connectToPort');
+      try {
+        const { result } = renderHook(() => useReplConnection());
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(connectToPort).not.toHaveBeenCalled();
+        expect(result.current.connectionState).toBe('disconnected');
+      } finally {
+        teardown();
+      }
+    });
+
+    it('does nothing when no device is persisted', async () => {
+      localStorage.removeItem(LAST_DEVICE_KEY);
+      const teardown = installFakeSerial([fakePort(0x2e8a, 0x0005)]);
+      const connectToPort = vi.spyOn(ReplInterface, 'connectToPort');
+      try {
+        const { result } = renderHook(() => useReplConnection());
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(connectToPort).not.toHaveBeenCalled();
+        expect(result.current.connectionState).toBe('disconnected');
+      } finally {
+        teardown();
+      }
+    });
+
+    it('swallows errors thrown by connectToPort', async () => {
+      const teardown = installFakeSerial([fakePort(0x2e8a, 0x0005)]);
+      vi.spyOn(ReplInterface, 'connectToPort').mockRejectedValue(
+        new Error('port stale'),
+      );
+      try {
+        const { result } = renderHook(() => useReplConnection());
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(result.current.connectionState).toBe('disconnected');
+      } finally {
+        teardown();
+      }
+    });
+
+    it('is a no-op when navigator.serial is unavailable', async () => {
+      const nav = navigator as unknown as { serial?: unknown };
+      const original = nav.serial;
+      delete nav.serial;
+      try {
+        const { result } = renderHook(() => useReplConnection());
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(result.current.connectionState).toBe('disconnected');
+      } finally {
+        if (original !== undefined) {
+          Object.defineProperty(navigator, 'serial', {
+            value: original,
+            configurable: true,
+          });
+        }
+      }
+    });
+
+    it('ignores malformed JSON in the persisted entry', async () => {
+      localStorage.setItem(LAST_DEVICE_KEY, '{not json');
+      const teardown = installFakeSerial([fakePort(0x2e8a, 0x0005)]);
+      const connectToPort = vi.spyOn(ReplInterface, 'connectToPort');
+      try {
+        const { result } = renderHook(() => useReplConnection());
+        await act(async () => {
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+        expect(connectToPort).not.toHaveBeenCalled();
+        expect(result.current.connectionState).toBe('disconnected');
+      } finally {
+        teardown();
+      }
     });
   });
 

--- a/src/hooks/useReplConnection.ts
+++ b/src/hooks/useReplConnection.ts
@@ -1,10 +1,33 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ReplDisconnectedError, ReplInterface, type RunResult } from '../ReplInterface';
 
 const MAX_HISTORY_LINES = 100;
+const LAST_DEVICE_KEY = 'cobweb:lastDevice';
+
+interface PersistedDevice {
+  usbVendorId: number;
+  usbProductId: number;
+}
+
+function readPersistedDevice(): PersistedDevice | null {
+  try {
+    const raw = localStorage.getItem(LAST_DEVICE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<PersistedDevice>;
+    if (
+      typeof parsed?.usbVendorId !== 'number' ||
+      typeof parsed?.usbProductId !== 'number'
+    ) {
+      return null;
+    }
+    return {usbVendorId: parsed.usbVendorId, usbProductId: parsed.usbProductId};
+  } catch {
+    return null;
+  }
+}
 
 export type ConnectionState = 'disconnected' | 'connected';
 
@@ -31,8 +54,7 @@ export function useReplConnection() {
     }
   }, []);
 
-  const connect = useCallback(async () => {
-    const repl = await ReplInterface.connect();
+  const wireRepl = useCallback((repl: ReplInterface) => {
     const dataListener = (e: Event) => handleData((e as CustomEvent<Uint8Array>).detail);
     // Fires when the device-side connection drops (cable yanked, USB error,
     // EOF). Explicit user-initiated disconnect removes this before it can fire.
@@ -53,7 +75,67 @@ export function useReplConnection() {
     disconnectListenerRef.current = disconnectListener;
     replRef.current = repl;
     setConnectionState('connected');
+
+    // Persist the USB IDs so the next page load can auto-reconnect to the
+    // same physical device. Quota or unavailable storage is non-fatal — we
+    // just lose the auto-reconnect for this session.
+    const info = repl.getPortInfo();
+    if (info?.usbVendorId !== undefined && info?.usbProductId !== undefined) {
+      try {
+        localStorage.setItem(
+          LAST_DEVICE_KEY,
+          JSON.stringify({
+            usbVendorId: info.usbVendorId,
+            usbProductId: info.usbProductId,
+          }),
+        );
+      } catch {
+        // ignore
+      }
+    }
   }, [handleData]);
+
+  const connect = useCallback(async () => {
+    const repl = await ReplInterface.connect();
+    wireRepl(repl);
+  }, [wireRepl]);
+
+  // Auto-reconnect on mount: if exactly one port granted by the browser
+  // matches the persisted USB IDs, open it silently. Zero / multiple matches
+  // do nothing — the user can click Connect manually.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!navigator.serial) return;
+      const target = readPersistedDevice();
+      if (!target) return;
+      try {
+        const ports = await navigator.serial.getPorts();
+        const matches = ports.filter((p) => {
+          const info = p.getInfo();
+          return (
+            info.usbVendorId === target.usbVendorId &&
+            info.usbProductId === target.usbProductId
+          );
+        });
+        if (matches.length !== 1) return;
+        if (cancelled || replRef.current) return;
+        const repl = await ReplInterface.connectToPort(matches[0]);
+        if (cancelled || replRef.current) {
+          // Raced with unmount or a manual connect; discard the orphan.
+          await repl.disconnect().catch(() => undefined);
+          return;
+        }
+        wireRepl(repl);
+      } catch {
+        // Stale port, permission revoked, device removed mid-load, etc.
+        // Stay disconnected; the user can click Connect manually.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [wireRepl]);
 
   const disconnect = useCallback(async () => {
     const repl = replRef.current;


### PR DESCRIPTION
## Summary

- Persist USB vendor + product IDs of the connected port to `cobweb:lastDevice`. On mount, if exactly one already-granted port matches, reconnect silently. Zero or multiple matches do nothing.
- User-initiated `disconnect()` does not clear the persisted entry — only a successful new connect overwrites it.
- `ReplInterface` gains `getPortInfo()` and a static `connectToPort(port)` that mirrors `connect()` without invoking the port chooser.

Closes #114

## Test plan

- [x] `npm run test` — 405 tests pass (new coverage: zero/one/two-match auto-reconnect, write-on-connect, persist-across-disconnect, missing/malformed persisted entry, Web Serial unavailable; `connectToPort` opens the supplied port without `requestPort`; `getPortInfo` returns the underlying USB IDs).
- [x] `npm run lint`, `npm run build` clean.
- [x] Manual: Connect to Pico → reload → reconnects silently with no chooser. Disconnect → reload → reconnects (disconnect doesn't clear). Unplug device → reload → stays disconnected, no error. Verified `cobweb:lastDevice` in localStorage.