### PR TITLE
feat(ui-state-persistence): reopen last local folder on load

### DIFF
--- a/src/components/FileNavigator.tsx
+++ b/src/components/FileNavigator.tsx
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { ChevronDown, ChevronRight, File, Folder, FolderOpen } from 'lucide-react';
-import { useCallback, useImperativeHandle, useState } from 'react';
+import { useCallback, useEffect, useImperativeHandle, useState } from 'react';
 import type { DragEvent as ReactDragEvent, RefObject } from 'react';
 import { basename } from '../lib/devicePath';
+import {
+  clearFolderHandle,
+  loadFolderHandle,
+  saveFolderHandle,
+} from '../lib/handleStore';
 import {
   DEVICE_PATH_MIME,
   LOCAL_PATH_MIME,
@@ -51,18 +56,83 @@ export function FileNavigator({
   ref,
 }: FileNavigatorProps) {
   const [root, setRoot] = useState<LocalTreeNode | null>(null);
+  // A handle was restored from IndexedDB but the browser still requires the
+  // user to re-grant readwrite permission. Triggers the "Reopen" button in
+  // the header, which calls requestPermission inside the click gesture.
+  const [pendingHandle, setPendingHandle] = useState<FileSystemDirectoryHandle | null>(null);
   const [isDeviceDragOver, setIsDeviceDragOver] = useState(false);
 
-  const openDirectory = async () => {
-    const dirHandle = await window.showDirectoryPicker();
-    const children = await loadChildren(dirHandle);
+  const setRootFromHandle = (handle: FileSystemDirectoryHandle, children: LocalTreeEntry[]) => {
     setRoot({
-      handle: dirHandle,
-      name: dirHandle.name,
+      handle,
+      name: handle.name,
       isDir: true,
       expanded: true,
       children,
     });
+  };
+
+  const openDirectory = async () => {
+    const dirHandle = await window.showDirectoryPicker();
+    const children = await loadChildren(dirHandle);
+    setRootFromHandle(dirHandle, children);
+    setPendingHandle(null);
+    await saveFolderHandle(dirHandle);
+  };
+
+  // Mount-time restore: if a handle is persisted and permission is still
+  // granted, reopen silently. If the browser requires a re-grant, surface a
+  // "Reopen" button instead of opening unprompted.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const handle = await loadFolderHandle();
+      if (cancelled || !handle) return;
+      let perm: PermissionState;
+      try {
+        perm = await handle.queryPermission({ mode: 'readwrite' });
+      } catch {
+        // queryPermission unsupported — fall back to manual Open Folder.
+        return;
+      }
+      if (cancelled) return;
+      if (perm === 'granted') {
+        try {
+          const children = await loadChildren(handle);
+          if (cancelled) return;
+          setRootFromHandle(handle, children);
+        } catch {
+          // Folder no longer exists, was renamed, or permission revoked
+          // mid-iterate. Drop the stale handle.
+          await clearFolderHandle();
+        }
+      } else {
+        setPendingHandle(handle);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const reopenPending = async () => {
+    if (!pendingHandle) return;
+    try {
+      const perm = await pendingHandle.requestPermission({ mode: 'readwrite' });
+      if (perm !== 'granted') {
+        // User declined — reveal the regular Open Folder button so they
+        // can pick a different folder.
+        setPendingHandle(null);
+        return;
+      }
+      const children = await loadChildren(pendingHandle);
+      setRootFromHandle(pendingHandle, children);
+      setPendingHandle(null);
+    } catch {
+      // Folder gone, permission API failure, etc. Drop the stale handle.
+      setPendingHandle(null);
+      await clearFolderHandle();
+    }
   };
 
   const toggleFolder = async (path: string[]) => {
@@ -153,14 +223,27 @@ export function FileNavigator({
       }}
     >
       <div className="flex items-center gap-1 px-2 py-1 border-b border-border">
-        <button
-          onClick={openDirectory}
-          title="Open folder"
-          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors w-full"
-        >
-          <FolderOpen size={14} />
-          Open Folder
-        </button>
+        {pendingHandle ? (
+          <button
+            onClick={reopenPending}
+            title={`Reopen ${pendingHandle.name}`}
+            className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors w-full min-w-0"
+          >
+            <FolderOpen size={14} className="shrink-0" />
+            <span className="truncate">
+              Reopen <em>{pendingHandle.name}</em>
+            </span>
+          </button>
+        ) : (
+          <button
+            onClick={openDirectory}
+            title="Open folder"
+            className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors w-full"
+          >
+            <FolderOpen size={14} />
+            Open Folder
+          </button>
+        )}
       </div>
       <div className="flex-1 overflow-y-auto">
         {root && (

--- a/src/lib/handleStore.test.ts
+++ b/src/lib/handleStore.test.ts
@@ -1,0 +1,190 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  clearFolderHandle,
+  loadFolderHandle,
+  saveFolderHandle,
+} from './handleStore';
+
+/**
+ * happy-dom does not ship a real IndexedDB. We install a minimal in-memory
+ * stand-in that supports the request shapes `handleStore` uses: open with
+ * version + onupgradeneeded, transaction(store, mode), and
+ * objectStore(name).{put, get, delete}. Each test starts with a fresh
+ * indexedDB so the store doesn't bleed across cases.
+ */
+class FakeIDBRequest<T = unknown> {
+  result!: T;
+  error: DOMException | null = null;
+  onsuccess: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onupgradeneeded: (() => void) | null = null;
+  onblocked: (() => void) | null = null;
+
+  succeed(value: T) {
+    this.result = value;
+    queueMicrotask(() => this.onsuccess?.());
+  }
+
+  fail(err: DOMException) {
+    this.error = err;
+    queueMicrotask(() => this.onerror?.());
+  }
+}
+
+class FakeObjectStore {
+  constructor(private store: Map<string, unknown>, private tx: FakeTransaction) {}
+
+  put(value: unknown, key: string): FakeIDBRequest<string> {
+    const req = new FakeIDBRequest<string>();
+    this.store.set(key, value);
+    this.tx.requestSettled(() => req.succeed(key));
+    return req;
+  }
+
+  get(key: string): FakeIDBRequest<unknown> {
+    const req = new FakeIDBRequest<unknown>();
+    const result = this.store.get(key);
+    this.tx.requestSettled(() => req.succeed(result));
+    return req;
+  }
+
+  delete(key: string): FakeIDBRequest<undefined> {
+    const req = new FakeIDBRequest<undefined>();
+    this.store.delete(key);
+    this.tx.requestSettled(() => req.succeed(undefined));
+    return req;
+  }
+}
+
+class FakeTransaction {
+  oncomplete: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onabort: (() => void) | null = null;
+  error: DOMException | null = null;
+  private pending = 0;
+  private settled = false;
+
+  constructor(private storeMap: Map<string, unknown>) {}
+
+  objectStore(): FakeObjectStore {
+    return new FakeObjectStore(this.storeMap, this);
+  }
+
+  requestSettled(fire: () => void) {
+    this.pending++;
+    queueMicrotask(() => {
+      fire();
+      this.pending--;
+      // Schedule completion after the current microtask wave so the request's
+      // onsuccess can fire before tx.oncomplete (matching real IndexedDB).
+      queueMicrotask(() => {
+        if (this.pending === 0 && !this.settled) {
+          this.settled = true;
+          this.oncomplete?.();
+        }
+      });
+    });
+  }
+}
+
+class FakeIDBDatabase {
+  constructor(private storeMap: Map<string, unknown>) {}
+  transaction(): FakeTransaction {
+    return new FakeTransaction(this.storeMap);
+  }
+  createObjectStore() {
+    // No-op: our store map is already shared across "object stores".
+  }
+  close() {}
+}
+
+interface FakeIndexedDBState {
+  storeMap: Map<string, unknown>;
+}
+
+function installFakeIndexedDB(): FakeIndexedDBState {
+  const state: FakeIndexedDBState = { storeMap: new Map() };
+  let initialized = false;
+  const fakeIndexedDB = {
+    open() {
+      const req = new FakeIDBRequest<FakeIDBDatabase>();
+      queueMicrotask(() => {
+        // Real IndexedDB populates `req.result` before firing
+        // onupgradeneeded so the handler can call createObjectStore on it.
+        const db = new FakeIDBDatabase(state.storeMap);
+        req.result = db;
+        if (!initialized) {
+          initialized = true;
+          req.onupgradeneeded?.();
+        }
+        req.onsuccess?.();
+      });
+      return req;
+    },
+  };
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: fakeIndexedDB,
+    configurable: true,
+    writable: true,
+  });
+  return state;
+}
+
+function uninstallIndexedDB() {
+  // Reset to undefined; subsequent installs overwrite via defineProperty.
+  Object.defineProperty(globalThis, 'indexedDB', {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function fakeHandle(name = 'project'): FileSystemDirectoryHandle {
+  return { kind: 'directory', name } as unknown as FileSystemDirectoryHandle;
+}
+
+describe('handleStore', () => {
+  beforeEach(() => {
+    installFakeIndexedDB();
+  });
+
+  afterEach(() => {
+    uninstallIndexedDB();
+  });
+
+  it('returns null when nothing has been stored', async () => {
+    expect(await loadFolderHandle()).toBeNull();
+  });
+
+  it('round-trips a handle through save → load', async () => {
+    const handle = fakeHandle('my-folder');
+    await saveFolderHandle(handle);
+    const loaded = await loadFolderHandle();
+    expect(loaded).toBe(handle);
+  });
+
+  it('overwrites the previous handle on subsequent save', async () => {
+    await saveFolderHandle(fakeHandle('first'));
+    const second = fakeHandle('second');
+    await saveFolderHandle(second);
+    expect(await loadFolderHandle()).toBe(second);
+  });
+
+  it('clear removes the stored handle', async () => {
+    await saveFolderHandle(fakeHandle('temp'));
+    await clearFolderHandle();
+    expect(await loadFolderHandle()).toBeNull();
+  });
+
+  it('returns null and swallows errors when IndexedDB is unavailable', async () => {
+    uninstallIndexedDB();
+    expect(await loadFolderHandle()).toBeNull();
+    // Save / clear must not throw either — the call sites await them in
+    // contexts that should not care if persistence is unavailable.
+    await expect(saveFolderHandle(fakeHandle())).resolves.toBeUndefined();
+    await expect(clearFolderHandle()).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/handleStore.ts
+++ b/src/lib/handleStore.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Persists the user's most recently opened local folder so the app can
+ * auto-restore it on reload. `FileSystemDirectoryHandle` is structured-
+ * cloneable but not JSON-serialisable, so we use IndexedDB rather than
+ * localStorage. Errors (IndexedDB unavailable, quota, schema mismatch) are
+ * swallowed — the app falls back to the manual "Open Folder" path.
+ */
+
+const DB_NAME = 'cobweb';
+const STORE_NAME = 'handles';
+const KEY = 'lastFolder';
+const DB_VERSION = 1;
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === 'undefined') {
+      reject(new Error('IndexedDB is not available'));
+      return;
+    }
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+    req.onupgradeneeded = () => {
+      req.result.createObjectStore(STORE_NAME);
+    };
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => reject(new Error('IndexedDB open blocked'));
+  });
+}
+
+function withStore<T>(
+  mode: IDBTransactionMode,
+  task: (store: IDBObjectStore) => IDBRequest<T>,
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    openDb()
+      .then((db) => {
+        const tx = db.transaction(STORE_NAME, mode);
+        const store = tx.objectStore(STORE_NAME);
+        const req = task(store);
+        let result: T;
+        req.onsuccess = () => {
+          result = req.result;
+        };
+        req.onerror = () => reject(req.error);
+        // Resolve only after the tx commits — for writes, this is when the
+        // value is durable; for reads, the result is already populated.
+        tx.oncomplete = () => {
+          db.close();
+          resolve(result);
+        };
+        tx.onerror = () => {
+          db.close();
+          reject(tx.error);
+        };
+        tx.onabort = () => {
+          db.close();
+          reject(tx.error);
+        };
+      })
+      .catch(reject);
+  });
+}
+
+export async function saveFolderHandle(
+  handle: FileSystemDirectoryHandle,
+): Promise<void> {
+  try {
+    await withStore('readwrite', (s) => s.put(handle, KEY));
+  } catch {
+    // ignore
+  }
+}
+
+export async function loadFolderHandle(): Promise<FileSystemDirectoryHandle | null> {
+  try {
+    const result = await withStore<FileSystemDirectoryHandle | undefined>(
+      'readonly',
+      (s) => s.get(KEY),
+    );
+    return result ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearFolderHandle(): Promise<void> {
+  try {
+    await withStore('readwrite', (s) => s.delete(KEY));
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary

- New `src/lib/handleStore.ts` persists the `FileSystemDirectoryHandle` of the most recently opened folder via IndexedDB (db `cobweb`, store `handles`, key `lastFolder`). localStorage isn't an option — handles are structured-cloneable but not JSON-serialisable.
- `FileNavigator` restores the tree silently on mount when permission is still granted. If the browser requires a re-grant, the header replaces **Open Folder** with **Reopen *<folder>***; clicking calls `requestPermission` inside the user-gesture stack.
- Stale handles (folder gone / permission revoked / IndexedDB unavailable) fall back cleanly to the manual path.

Closes #115

## Test plan

- [x] `npm run test` — 410 tests pass (handleStore round-trip, overwrite, clear, empty-store-null, IndexedDB-unavailable).
- [x] `npm run lint`, `npm run build` clean.
- [x] Manual: pick folder → reload → tree restores silently. Restart Chrome (forces permission re-prompt) → reload → "Reopen <folder>" button appears, click reopens. Pick a different folder → that one becomes persisted.