### PR TITLE
chore: thinner split-pane handles

### DIFF
--- a/src/components/SplitPane.tsx
+++ b/src/components/SplitPane.tsx
@@ -92,12 +92,26 @@ export function SplitPane({
           onPointerUp={onPointerUp}
           style={{
             flexShrink: 0,
-            [isHorizontal ? 'width' : 'height']: '8px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            [isHorizontal ? 'width' : 'height']: '10px',
             [isHorizontal ? 'height' : 'width']: '100%',
+            [isHorizontal ? 'marginInline' : 'marginBlock']: '-3px',
             cursor: isHorizontal ? 'col-resize' : 'row-resize',
-            background: 'var(--split-pane-divider, #e5e7eb)',
+            background: 'transparent',
+            zIndex: 1,
           }}
-        />
+        >
+          <div
+            style={{
+              [isHorizontal ? 'width' : 'height']: '4px',
+              [isHorizontal ? 'height' : 'width']: '100%',
+              background: 'var(--split-pane-divider, #e5e7eb)',
+              pointerEvents: 'none',
+            }}
+          />
+        </div>
       )}
       <div
         style={{


### PR DESCRIPTION
## Summary

- Reduce the visible split-pane divider from 8px to a 4px bar centered inside a 10px transparent hit area.
- Apply -3px margin on each side so the divider's layout footprint is 4px (down from 8px), letting panes sit flush against the thin line.
- The 10px hit area keeps the divider easy to grab — including on touch — even though the visual is half the previous thickness.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (410/410 pass)
- [x] `npm run build`
- [x] Manual: drag horizontal and vertical splitters in the browser, confirm panes look flush against the thin line and the divider is still easy to grab.