### PR TITLE
docs(tool-approval): add multi_edit_editor and multi_edit_device_file

### DIFF
--- a/docs/tool-approval/PRD.md
+++ b/docs/tool-approval/PRD.md
@@ -6,18 +6,19 @@ The Cobweb agent currently writes to the user's editor and to the connected devi
 
 For a coding assistant the user trusts to touch their working buffer, this is the wrong default. Users want to see *what* the model is about to change *before* it lands, especially when the model is iterating on existing code or rewriting a `main.py` that controls real hardware. Other agentic editors (`agent-text-editor`, Claude Code's own Edit tool) solve this by suspending the tool call until the user clicks Accept or Reject, with a focused diff for partial edits.
 
-This feature introduces that approval gate to Cobweb. As a prerequisite, it also introduces the kind of tool that *deserves* a diff: a partial-edit `edit_editor` / `edit_device_file` tool, modelled on Claude Code's Edit tool (uniqueness-based find/replace). Whole-buffer `write_editor` / `write_device_file` continue to exist for new files and full rewrites, but get a confirmation card rather than a diff.
+This feature introduces that approval gate to Cobweb. As a prerequisite, it also introduces the kind of tool that *deserves* a diff: partial-edit `edit_editor` / `edit_device_file` tools modelled on Claude Code's Edit tool (uniqueness-based find/replace), and batched `multi_edit_editor` / `multi_edit_device_file` tools modelled on Claude Code's MultiEdit (an array of sequential edits applied atomically). Whole-buffer `write_editor` / `write_device_file` continue to exist for new files and full rewrites, but get a confirmation card rather than a diff.
 
 ## Target Users
 
 Same as the parent PRD (educators, hobbyists, beginners). Two scenarios this feature unlocks:
 
 - **Hobbyist** asks the agent to "tweak the LED blink rate" mid-iteration. The agent calls `edit_editor` with a small `old_string` / `new_string`. The user sees only the changed lines highlighted, accepts, and the buffer updates.
+- **Hobbyist** asks the agent to "rename the `tick` function to `step` everywhere and add a docstring." The agent calls `multi_edit_editor` with several `{ old_string, new_string }` edits in one call. The user sees one card with multiple diff hunks, accepts once, and all edits apply atomically.
 - **Educator** asks the agent to "save the lesson plan as `main.py` on the board." The agent calls `write_device_file`. The user sees a confirmation card showing the target path and a preview of the new file, accepts, and the file is written.
 
 ## Goals
 
-1. **Diff approval for partial edits.** Introduce `edit_editor` and `edit_device_file` tools that take `old_string` / `new_string`, verify uniqueness, and surface a focused diff in the chat panel. Accepting applies the edit; rejecting tells the model the edit was declined.
+1. **Diff approval for partial edits.** Introduce `edit_editor` and `edit_device_file` tools that take `old_string` / `new_string`, verify uniqueness, and surface a focused diff in the chat panel. Accepting applies the edit; rejecting tells the model the edit was declined. Introduce `multi_edit_editor` and `multi_edit_device_file` for batched edits — an array of `{ old_string, new_string }` applied sequentially and atomically (all-or-nothing). The diff card shows every changed region as a stacked hunk so the user reviews the cumulative result with one decision.
 2. **Confirmation approval for non-edit writes.** `write_editor`, `write_device_file`, `delete_device_file`, and `make_device_dir` show a confirmation card describing what will change. Approving runs the operation; rejecting tells the model.
 3. **Inline UI.** Approval cards render inside the conversation panel inline with the message stream, not as a separate modal — so the diff stays in the conversation context.
 4. **Suspend-and-resume tool model.** A tool's `call()` returns a Promise that only resolves once the user decides. The mast-ai agent loop blocks naturally; no special framework support is required.
@@ -26,7 +27,8 @@ Same as the parent PRD (educators, hobbyists, beginners). Two scenarios this fea
 ## Out of Scope
 
 - **Approve-all / always-allow toggle.** A "trust this tool for this session" affordance is appealing but adds preference state and an opt-out path that we'd rather defer until we have feedback on the explicit-approval flow.
-- **Multi-step tool batching.** Each tool call gets its own approval card. We do not group consecutive edits into a "review N edits" summary.
+- **Cross-call batching.** Each tool call gets its own approval card. We do not group multiple separate tool calls into a single summary — `multi_edit_*` covers the "several edits at once" need within one call.
+- **`replace_all` semantics.** Claude Code's MultiEdit lets each edit set `replace_all: true` to substitute every occurrence. v1 tools require uniqueness for every `old_string`; if real use cases call for bulk replace, we add it later.
 - **Edit-the-edit.** The user can Accept or Reject. They cannot tweak `new_string` before accepting. If they want a different edit, they Reject and ask the model again.
 - **Stale-read protection.** If the user edits the buffer between the model reading and the model proposing an edit, we still apply find/replace against the *current* buffer. Uniqueness of `old_string` is the only guard. (Same model as Claude Code's Edit tool.)
 - **Approval for read-only tools.** `read_editor`, `run_editor`, `run_snippet`, `read_repl_history`, `list_device_files`, `read_device_file` continue to run without approval. `run_editor` and `run_snippet` execute code on hardware but are part of the user's expected REPL loop; gating them would create constant approval prompts.
@@ -35,6 +37,7 @@ Same as the parent PRD (educators, hobbyists, beginners). Two scenarios this fea
 ## Success Criteria
 
 - A user asks the agent to make a small change to an existing program. The agent calls `edit_editor`. The conversation panel renders a card showing the changed region with red strikethrough + green highlight on the modified words, plus 2 lines of unchanged context above and below. Accept applies the edit to the buffer.
+- A user asks the agent to make several related changes in one go (e.g. rename a function and update its callers). The agent calls `multi_edit_editor` with an array of edits. The card shows one hunk per non-adjacent changed region, all from the same proposed final buffer. Accept applies every edit atomically; if any one of them fails uniqueness, the card shows which edit (by index) failed and what went wrong, Approve is disabled, and Reject sends a structured error back to the model.
 - A user asks the agent to write a new `main.py`. The agent calls `write_editor` with the full new code. The conversation panel renders a confirmation card showing the new content (scrollable preview). Accept replaces the buffer.
 - A user asks the agent to save the current buffer to `/main.py` on the device. The agent calls `write_device_file`. The card shows path + content preview. Accept writes the file.
 - A user asks the agent to delete `/old.py` on the device. The card shows the path with a destructive-action style. Accept deletes; reject tells the model "user declined."

--- a/docs/tool-approval/SPEC.md
+++ b/docs/tool-approval/SPEC.md
@@ -6,10 +6,11 @@
 
 What we are responsible for in this feature:
 
-1. Introducing two new partial-edit tools (`edit_editor`, `edit_device_file`) that take `old_string` / `new_string` and apply uniqueness-based find/replace, mirroring Claude Code's Edit tool.
-2. Flipping the existing `write_editor`'s `requiresApproval` to `true` so it joins the four already-flagged write tools (`write_device_file`, `delete_device_file`, `make_device_dir`).
-3. Plugging a custom `renderApproval` slot into `<ConversationPanel>` that dispatches on tool name — diff card for the two `edit_*` tools, content-preview card for `write_*` tools, confirm card for `delete_device_file` / `make_device_dir`.
-4. Updating the agent instructions in `CODING_AGENT` so the model knows when to reach for `edit_editor` (partial change to existing code) vs. `write_editor` (new program / full rewrite).
+1. Introducing two new single-edit tools (`edit_editor`, `edit_device_file`) that take `old_string` / `new_string` and apply uniqueness-based find/replace, mirroring Claude Code's Edit tool.
+2. Introducing two batched-edit tools (`multi_edit_editor`, `multi_edit_device_file`) that take an array of `{ old_string, new_string }` edits and apply them sequentially and atomically (all-or-nothing), mirroring Claude Code's MultiEdit.
+3. Flipping the existing `write_editor`'s `requiresApproval` to `true` so it joins the already-flagged write tools (`write_device_file`, `delete_device_file`, `make_device_dir`).
+4. Plugging a custom `renderApproval` slot into `<ConversationPanel>` that dispatches on tool name — multi-hunk diff card for the four `*edit*_*` tools, content-preview card for `write_*` tools, confirm card for `delete_device_file` / `make_device_dir`.
+5. Updating the agent instructions in `CODING_AGENT` so the model knows when to reach for `edit_editor` (one partial change), `multi_edit_editor` (several related changes in one call), `write_editor` (new program / full rewrite), and the device-file analogues.
 
 Everything else — queueing pending approvals, injecting "user cancelled" results into the runner, cancelling on `useAgent().cancel()` / `reset()` — is handled by the framework.
 
@@ -94,6 +95,68 @@ interface EditDeviceFileArgs {
 
 The host-side read–modify–write between approval and apply mirrors `WriteDeviceFileTool`'s existing model (no atomicity beyond what `DeviceFs.writeText` already provides).
 
+### `MultiEditEditorTool` (`multi_edit_editor`)
+
+Batched partial edits over the editor buffer. Each edit is the same shape as `edit_editor`'s args; the array is applied sequentially against the running buffer. All-or-nothing: if any edit's `old_string` is missing or non-unique against the buffer state at its turn, *no* edits apply and the model gets a structured error.
+
+**Args:**
+
+```ts
+interface MultiEditEditorArgs {
+  edits: Array<{
+    old_string: string;
+    new_string: string;
+  }>;
+}
+```
+
+**`ToolDefinition`:**
+
+- `name: 'multi_edit_editor'`
+- `scope: 'write'`
+- `requiresApproval: true`
+- Description (final wording in implementation):
+  > "Applies a sequence of `{ old_string, new_string }` edits to the editor in order. Each `old_string` must appear exactly once *at its turn* (i.e. after all earlier edits in the array have been applied). All edits succeed or none do. Use this when the agent needs to make several related changes — renaming a symbol everywhere, refactoring a small set of related lines, etc. — in one approval. For a single change, use `edit_editor`."
+
+**`call(args)` body:**
+
+Implemented in two stages so the simulation logic is shared with the renderer:
+
+1. `simulateMultiEdit(source, edits)` (in `src/lib/editApproval.ts`) walks the edits array, applying each successful step to a running string. It returns either:
+   - `{ ok: true; final: string; hunks: ChangedRegion[] }` — all edits validated and applied; `hunks` are the merged contiguous changed regions between `source` and `final`, each with `firstLine`, `before` lines, `after` lines, and `contextBefore` / `contextAfter` lines.
+   - `{ ok: false; index: number; reason: 'missing' | 'ambiguous'; count?: number }` — edit `index` failed; nothing was applied.
+2. `call()` reads the current editor content, calls `simulateMultiEdit`, and either:
+   - On `ok: true` → `setEditorContent(result.final)` and return `'Editor updated. N edit(s) applied.'`.
+   - On `ok: false; reason: 'missing'` → return `Edit #${index + 1}: old_string not found.`.
+   - On `ok: false; reason: 'ambiguous'` → return `Edit #${index + 1}: old_string is ambiguous — appears ${count} times.`.
+
+The same error strings are surfaced in the approval card (see "MultiEdit branch" below) so the user can choose Reject or `respondWith` the matching message.
+
+### `MultiEditDeviceFileTool` (`multi_edit_device_file`)
+
+Same shape as `multi_edit_editor`, scoped to a file on the device.
+
+**Args:**
+
+```ts
+interface MultiEditDeviceFileArgs {
+  path: string;
+  edits: Array<{
+    old_string: string;
+    new_string: string;
+  }>;
+}
+```
+
+**`ToolDefinition`:** as `multi_edit_editor`, with `path` documented in the description.
+
+**`call(args)` body:**
+
+1. If `bindings.deviceFs === null` → return `'Device is not connected.'`.
+2. Read + decode UTF-8 (fatal). On `TypeError` → return `'Cannot edit binary file.'`.
+3. Run `simulateMultiEdit`. On failure return the same `Edit #N: ...` strings as `multi_edit_editor`.
+4. On success → `deviceFs.writeText(path, result.final)` and return `'File updated. N edit(s) applied.'`.
+
 ---
 
 ## Modified tools
@@ -120,6 +183,8 @@ A single component, `<CobwebApproval>`, lives at `src/components/CobwebApproval.
 switch (entry.name) {
   case 'edit_editor':
   case 'edit_device_file':
+  case 'multi_edit_editor':
+  case 'multi_edit_device_file':
     return <EditApprovalCard entry={entry} approval={approval} ... />;
   case 'write_editor':
   case 'write_device_file':
@@ -138,19 +203,26 @@ The `default` branch falls back to the bundled `<InlineApproval>` so any future 
 
 Props (in addition to `entry` + `approval`): a way to read the source content for diffing.
 
-- For `edit_editor`: receives `getEditorContent: () => string`.
-- For `edit_device_file`: receives `readDeviceFile: (path: string) => Promise<string | null>` (returns `null` on binary or read error).
+- For `edit_editor` / `multi_edit_editor`: receives `getEditorContent: () => string`.
+- For `edit_device_file` / `multi_edit_device_file`: receives `readDeviceFile: (path: string) => Promise<string | null>` (returns `null` on binary or read error).
 
 Render flow:
 
-1. Parse `entry.args` into `{ old_string, new_string, path? }`.
+1. Parse `entry.args`. For `edit_*` tools, normalise to `{ edits: [{ old_string, new_string }], path? }`. For `multi_edit_*` tools, take `args.edits` (and `args.path` for device).
 2. Read source content. For the editor, synchronous. For device files, kick off the async read in `useEffect` and show a "loading…" placeholder until it resolves.
-3. Locate `old_string` in source. Three states:
-   - **Not found.** Show "Edit no longer applies — `old_string` is not in the buffer." Approve button disabled. Reject button enabled, plus a "Tell the agent" button that calls `approval.respondWith('old_string not found in editor.')` (same message the tool body would have produced).
-   - **Multiple matches.** Show "Edit is ambiguous — `old_string` appears N times." Same disabled-Approve / Reject / respondWith treatment.
-   - **Unique match.** Render the diff (below). Approve + Reject both enabled.
-4. **Diff rendering.** Expand the unique match to the boundary lines that contain it. Capture two lines of unchanged context above and two below (clipped at file start/end). Within the changed region, run `diffWords` from the `diff` package and render with red strikethrough on removed segments and green background on added segments. A small line-number gutter on the left starts at `firstContextLineNumber` and increments per rendered line, reflecting the source's line numbers (not 1-based-from-card).
-5. **Header line.** "Edit *editor*" or "Edit *`/path/to/file.py`*" depending on tool. The path comes from `args.path` for device edits.
+3. Run `simulateMultiEdit(source, edits)` from `src/lib/editApproval.ts`. Two outcomes:
+   - **Failure.** The card shows "Edit #N: old_string not found." or "Edit #N: old_string is ambiguous — appears M times.", referencing the failing edit's index (1-based for display). Approve is disabled. Reject is enabled. A secondary "Tell the agent" button calls `approval.respondWith(...)` with the exact same string the tool body would have produced (so the model gets a uniform error whether the user clicked Reject or the tool ran post-approval).
+   - **Success.** Render the cumulative diff as one or more hunks (below). Approve + Reject both enabled.
+4. **Multi-hunk diff rendering.** `simulateMultiEdit` returns merged contiguous changed regions between `source` and `final`. Two regions whose context windows overlap are merged into one hunk so the user does not see overlapping context. Each hunk renders:
+   - A small `@@ Lines X–Y @@` header with the source's line numbers.
+   - Two lines of unchanged context above and below, clipped at file start/end.
+   - The changed region itself, with `diffWords` from the `diff` package run on the contiguous (`before`, `after`) line block — red strikethrough on removed segments, green background on added segments.
+   - A line-number gutter on the left, reflecting the source's line numbers (not 1-based-from-card).
+5. **Header line.** Dispatches by tool kind:
+   - `edit_editor` → "Edit *editor*"
+   - `multi_edit_editor` → "Edit *editor* — N change(s)"
+   - `edit_device_file` → "Edit *`<path>`*"
+   - `multi_edit_device_file` → "Edit *`<path>`* — N change(s)"
 6. **Buttons.** Approve / Reject. Approve calls `approval.approve()`. Reject calls `approval.reject()`.
 
 ### `WriteApprovalCard`
@@ -201,24 +273,26 @@ const renderApproval: RenderApproval = (entry, approval) => (
 
 ### `wireTools.ts`
 
-Register two new tools alongside the others:
+Register the four new tools alongside the others:
 
 ```ts
 tools.register(new EditEditorTool(get));
 tools.register(new EditDeviceFileTool(get));
+tools.register(new MultiEditEditorTool(get));
+tools.register(new MultiEditDeviceFileTool(get));
 ```
 
 ### `CODING_AGENT.tools` (in `src/agent/config.ts`)
 
-Add `'edit_editor'` and `'edit_device_file'` to the `tools` list.
+Add `'edit_editor'`, `'edit_device_file'`, `'multi_edit_editor'`, and `'multi_edit_device_file'` to the `tools` list.
 
 ### `CODING_AGENT.instructions`
 
-Add a paragraph that steers the model toward `edit_*` for partial changes and away from `write_*` for them. Sketch:
+Steer the model toward the right edit tool. Sketch:
 
-> "For partial changes to existing code, prefer `edit_editor` (or `edit_device_file` for a file on the device) — they take an `old_string` / `new_string` and require uniqueness, and the user reviews a focused diff. Use `write_editor` only when creating a new program from scratch or replacing the whole buffer; use `write_device_file` only for new files or full rewrites. Both `edit_*` and `write_*` tools require user approval before they apply."
+> "For a single partial change to existing code, prefer `edit_editor` (or `edit_device_file` for a file on the device) — they take `old_string` / `new_string` and require uniqueness; the user reviews a focused diff. For several related changes in one go, use `multi_edit_editor` (or `multi_edit_device_file`) with an array of edits applied atomically — the user reviews all the diffs together and approves once. Use `write_editor` only when creating a new program from scratch or replacing the whole buffer; use `write_device_file` only for new files or full rewrites. Every editing tool requires user approval before it applies."
 
-The existing description of `write_editor` ("When asked to write code, use write_editor then offer to run it.") is rewritten so the default partial-edit path is `edit_editor`.
+The existing description of `write_editor` ("When asked to write code, use write_editor then offer to run it.") is rewritten so the default partial-edit path is `edit_editor` / `multi_edit_editor`.
 
 ### `<AgentProvider>`
 
@@ -234,9 +308,12 @@ No new props needed. The default `onApprovalRequired` is already "INLINE_APPROVA
 - `src/agent/tools/EditEditorTool.test.ts`
 - `src/agent/tools/EditDeviceFileTool.ts`
 - `src/agent/tools/EditDeviceFileTool.test.ts`
-- `src/components/CobwebApproval.tsx` (dispatcher + the three card components)
-- `src/components/CobwebApproval.test.tsx` *(see Testing — the three card components are pure functions of `entry` + bindings; component-level rendering tests are skipped per project convention, but the dispatch logic and "edit no longer applies" branches are covered by extracting a pure helper to `src/lib/editApproval.ts` with its own `.test.ts`.)*
-- `src/lib/editApproval.ts` — pure helpers: `findUniqueOccurrence(source, target): { kind: 'unique'; index: number } | { kind: 'missing' } | { kind: 'ambiguous'; count: number }`, `expandToContextLines(source, matchIndex, matchLength, contextLines): { before: string[]; old: string[]; new: string[] (computed by caller); after: string[]; firstLineNumber: number }`.
+- `src/agent/tools/MultiEditEditorTool.ts`
+- `src/agent/tools/MultiEditEditorTool.test.ts`
+- `src/agent/tools/MultiEditDeviceFileTool.ts`
+- `src/agent/tools/MultiEditDeviceFileTool.test.ts`
+- `src/components/CobwebApproval.tsx` (dispatcher + card components)
+- `src/lib/editApproval.ts` — pure helpers: `findUniqueOccurrence(source, target): { kind: 'unique'; index: number } | { kind: 'missing' } | { kind: 'ambiguous'; count: number }`, `simulateMultiEdit(source, edits): { ok: true; final: string; hunks: ChangedRegion[] } | { ok: false; index: number; reason: 'missing' | 'ambiguous'; count?: number }`, `mergeOverlappingHunks(hunks, contextLines): ChangedRegion[]`.
 - `src/lib/editApproval.test.ts`
 
 **Modify:**
@@ -261,9 +338,21 @@ No new props needed. The default `onApprovalRequired` is already "INLINE_APPROVA
 
 Per project convention, UI components are not unit-tested. The pure logic is — that is where bugs hide:
 
-- `src/lib/editApproval.test.ts` — `findUniqueOccurrence`: empty target, single match at start / middle / end, zero matches, two matches, overlapping matches (e.g. `target = 'aa'`, `source = 'aaaa'` → counted by non-overlapping replace semantics, matching `String.prototype.replace`'s behaviour). `expandToContextLines`: match at file start (no `before` lines), match at file end, match spanning the whole file, multi-line matches (the entire matched region is shown line-aligned).
+- `src/lib/editApproval.test.ts`:
+  - `findUniqueOccurrence`: empty target, single match at start / middle / end, zero matches, two matches, overlapping matches (e.g. `target = 'aa'`, `source = 'aaaa'` → counted by non-overlapping replace semantics, matching `String.prototype.replace`'s behaviour). Multi-line matches are exercised by `simulateMultiEdit`.
+  - `simulateMultiEdit`:
+    - Empty `edits` array → `ok: true`, `hunks: []`, `final === source`.
+    - Single edit, success — equivalent to single-edit-tool behaviour.
+    - Two non-adjacent edits → two hunks.
+    - Two edits whose context windows overlap (e.g. lines 5 and 7 with 2 lines context) → merged into one hunk.
+    - Edit #2's `old_string` references content produced by edit #1 → succeeds (running buffer; not original).
+    - Edit #2's `old_string` is missing in the original *but* present after edit #1 → succeeds.
+    - Edit #1 ambiguous → `ok: false; index: 0; reason: 'ambiguous'; count: N`.
+    - Edit #2 missing in the running buffer → `ok: false; index: 1; reason: 'missing'`. Verify the running buffer was *not* committed (caller sees the original).
 - `src/agent/tools/EditEditorTool.test.ts` — mock bindings; verify `not found`, `ambiguous`, `unique` paths return the expected strings and call `setEditorContent` only on the unique path.
 - `src/agent/tools/EditDeviceFileTool.test.ts` — mock `DeviceFs`; verify `'Device is not connected.'`, binary-file rejection, the three find-replace branches, and the success path calls `writeText` with the replaced content.
+- `src/agent/tools/MultiEditEditorTool.test.ts` — mock bindings; verify (a) the success path applies all edits and calls `setEditorContent` exactly once with the final string, (b) failures at edit index 0 and index 1 return the expected `Edit #N: ...` strings and do *not* call `setEditorContent`.
+- `src/agent/tools/MultiEditDeviceFileTool.test.ts` — mock `DeviceFs`; verify the disconnect / binary / failure paths do not call `writeText`, and the success path calls `writeText` exactly once with the final string.
 
 The renderer dispatch and "edit no longer applies" handling are validated end-to-end via manual browser testing against the success criteria in the PRD.
 
@@ -273,11 +362,13 @@ The renderer dispatch and "edit no longer applies" handling are validated end-to
 
 This feature ships behind the GitHub label `tool-approval`. Each item below becomes its own issue / PR.
 
-1. **Docs.** PRD + SPEC + GitHub label + epic issue. (This issue / PR; not a code change.)
-2. **`edit_editor` + diff approval renderer.** Adds `EditEditorTool`, `editApproval` helpers + tests, `CobwebApproval` dispatcher, `EditApprovalCard`. Flips `WriteEditorTool.requiresApproval` to `true` and adds a placeholder `WriteApprovalCard` that just shows "Replace editor with new content" + Approve/Reject (no preview yet — kept minimal so this PR is single-purpose). Wires `renderApproval` into `<AgentPanel>` and `<ConversationPanel>`. Updates `CODING_AGENT.instructions` for `edit_editor` only.
+1. **Docs.** PRD + SPEC + GitHub label + epic issue. (Initial docs PR plus a follow-up PR that folds MultiEdit in.)
+2. **`edit_editor` + diff approval renderer.** Adds `EditEditorTool`, `editApproval` helpers + tests (`findUniqueOccurrence`, `simulateMultiEdit` — implemented now, used here for the single-edit case and reused by phases 6–7), `CobwebApproval` dispatcher, `EditApprovalCard` with single-hunk rendering. Flips `WriteEditorTool.requiresApproval` to `true` and adds a placeholder `WriteApprovalCard` that just shows "Replace editor with new content" + Approve/Reject (no preview yet — kept minimal so this PR is single-purpose). Wires `renderApproval` into `<AgentPanel>` and `<ConversationPanel>`. Updates `CODING_AGENT.instructions` for `edit_editor` only.
 3. **`edit_device_file` + diff approval for it.** Adds `EditDeviceFileTool` + tests; extends the dispatcher to render `EditApprovalCard` for it (async source read). Updates instructions.
 4. **Confirmation cards.** Replaces the placeholder `WriteApprovalCard` with the scrollable preview; adds `ConfirmApprovalCard` for `delete_device_file` and `make_device_dir`. (Depends on #2.)
-5. **Polish + verification.** Manual cancel/reset testing during a pending approval; verify no orphaned promises survive; tighten copy on cards based on the live UX. (Depends on #2-4.)
+5. **Multi-hunk renderer + `multi_edit_editor`.** Extends `EditApprovalCard` to render multiple hunks via `simulateMultiEdit`'s output, including the `Edit #N: ...` failure branch. Adds `MultiEditEditorTool` + tests. Updates `CODING_AGENT.instructions` to mention `multi_edit_editor`. (Depends on #2.)
+6. **`multi_edit_device_file`.** Adds `MultiEditDeviceFileTool` + tests; routes it through the multi-hunk renderer. Updates instructions. (Depends on #3 and #5.)
+7. **Polish + verification.** Manual cancel/reset testing during a pending approval; verify no orphaned promises survive; tighten copy on cards (single-hunk, multi-hunk, failure-state, write-preview, confirm) based on the live UX. (Depends on #2-6.)
 
 Each issue body should reference this SPEC by section and state `Depends on #N` for explicit dependencies.
 
@@ -286,5 +377,6 @@ Each issue body should reference this SPEC by section and state `Depends on #N` 
 ## Open Questions
 
 - **Approve-all toggle.** PRD calls it out of scope. If users ask, the cleanest extension point is `<AgentProvider approvalOverride={['!edit_editor']}>` (suppress approval for one tool at runtime). We do not need a custom `onApprovalRequired` for this.
-- **Multi-edit tool.** Claude Code has a `MultiEdit` that batches several `old_string` / `new_string` pairs against the same buffer. Out of scope for v1; if it appears, it gets its own diff renderer that stacks per-pair diffs in one card.
-- **Diff styling.** v1 uses `diffWords`. Line-level diffing (`diffLines`) is an alternative for code; we prefer word-level since edits are typically tight. Revisit if the rendered diff is hard to read for whitespace-heavy languages.
+- **`replace_all`.** PRD calls it out of scope. Claude Code's MultiEdit accepts a per-edit `replace_all: true` to substitute every occurrence (uniqueness check is skipped). v1 enforces uniqueness for every edit; if real use cases hit, add `replace_all` as an optional per-edit field.
+- **Diff styling.** v1 uses `diffWords` within each hunk. Line-level diffing (`diffLines`) is an alternative for code; we prefer word-level since edits are typically tight. Revisit if the rendered diff is hard to read for whitespace-heavy languages.
+- **Hunk-merge context window.** Two hunks whose ±2-line context windows overlap are merged into one combined hunk in the renderer. The exact threshold (currently 2) lives as a constant in `editApproval.ts`; if the rendered output feels too dense or too sparse, tweak it before exposing it as a setting.


### PR DESCRIPTION
## Summary

- Folds two batched-edit tools (`multi_edit_editor`, `multi_edit_device_file`) into the tool-approval feature spec, modelled on Claude Code's MultiEdit. Each takes an array of `{ old_string, new_string }` and applies them sequentially, atomically (all-or-nothing), with the same uniqueness guard as the single-edit tools running against the *running* buffer at each step.
- Generalises the diff approval card to render multiple hunks via a new `simulateMultiEdit` helper. Single-edit tools become a degenerate case of the multi-hunk renderer.
- Adds two sub-issues for the implementation work and shifts the polish phase to depend on them.
- Removes the "MultiEdit out of scope" note from the PRD's Out-of-Scope and the SPEC's Open Questions; replaces it with a `replace_all` open question (we keep that out of v1).

## Test plan

Docs-only — no runtime change.

- [x] `npm run lint` clean
- [x] `npm run test` clean (410 tests)
- [x] `npm run build` clean
- [x] Reviewer skims the diff for clarity / scope.
