### PR TITLE
feat(tool-approval): edit_editor tool + diff approval renderer

### DIFF
--- a/docs/tool-approval/SPEC.md
+++ b/docs/tool-approval/SPEC.md
@@ -201,10 +201,12 @@ The `default` branch falls back to the bundled `<InlineApproval>` so any future 
 
 ### `EditApprovalCard`
 
-Props (in addition to `entry` + `approval`): a way to read the source content for diffing.
+Props (in addition to `entry` + `approval`):
 
-- For `edit_editor` / `multi_edit_editor`: receives `getEditorContent: () => string`.
-- For `edit_device_file` / `multi_edit_device_file`: receives `readDeviceFile: (path: string) => Promise<string | null>` (returns `null` on binary or read error).
+- A way to read the source content for diffing:
+  - For `edit_editor` / `multi_edit_editor`: `getEditorContent: () => string`.
+  - For `edit_device_file` / `multi_edit_device_file`: `readDeviceFile: (path: string) => Promise<string | null>` (returns `null` on binary or read error).
+- A reveal callback `revealEditorRange: (from: number, to: number) => void` (or, for the device cards once they land, the device-file equivalent). Auto-invoked once on first render of the card so the user immediately sees what part of the buffer the agent is asking about; also wired to a "Reveal" button in the card header so the user can re-scroll to the affected range any time.
 
 Render flow:
 
@@ -223,7 +225,18 @@ Render flow:
    - `multi_edit_editor` → "Edit *editor* — N change(s)"
    - `edit_device_file` → "Edit *`<path>`*"
    - `multi_edit_device_file` → "Edit *`<path>`* — N change(s)"
+
+   The header also carries a small "Reveal" button next to the "requires approval" label whenever `find.kind === 'unique'`, calling `revealEditorRange` (or the device-file equivalent) with the affected range.
 6. **Buttons.** Approve / Reject. Approve calls `approval.approve()`. Reject calls `approval.reject()`.
+
+#### Reveal-in-editor primitive
+
+`useEditor` exposes `revealRange(from, to)` for the editor card and an analogous helper will exist for the device card. The implementation:
+
+1. Dispatches `EditorView.scrollIntoView(EditorSelection.range(from, to), { y: 'center' })` to bring the affected range into the middle of the viewport.
+2. Adds a `cobweb-reveal-highlight` decoration on the range via a dedicated `StateField` + `StateEffect` pair, then clears it after ~1.7s. The `cobweb-reveal-highlight` class fades from amber → transparent via a CSS keyframe (`cobweb-reveal-fade`).
+
+This mirrors the `agent-text-editor` reference: a transient highlight gives the user a visual handshake of "this is the spot the agent wants to change" without permanently marking the buffer.
 
 ### `WriteApprovalCard`
 
@@ -250,6 +263,7 @@ const renderApproval: RenderApproval = (entry, approval) => (
     entry={entry}
     approval={approval}
     getEditorContent={getContent}
+    revealEditorRange={revealRange}
     readDeviceFile={async (p) => {
       try {
         return new TextDecoder('utf-8', { fatal: true }).decode(await deviceReadBytes(p));
@@ -267,9 +281,9 @@ const renderApproval: RenderApproval = (entry, approval) => (
 
 ## Wiring
 
-### `ToolBindings` — no new fields
+### `ToolBindings` — `replaceEditorRange`
 
-`edit_editor` only needs the existing `getEditorContent` and `setEditorContent`. `edit_device_file` only needs the existing `deviceFs`. No new binding required.
+`edit_editor` reads the editor via the existing `getEditorContent` but writes via a new `replaceEditorRange(from: number, to: number, replacement: string)` binding. The implementation dispatches a CodeMirror change scoped to the affected range so the user's scroll position is preserved across the edit; routing through `setEditorContent` (which replaces the entire document) reset the viewport on every Approve. `edit_device_file` only needs the existing `deviceFs`.
 
 ### `wireTools.ts`
 
@@ -319,10 +333,12 @@ No new props needed. The default `onApprovalRequired` is already "INLINE_APPROVA
 **Modify:**
 
 - `src/agent/tools/WriteEditorTool.ts` — flip `requiresApproval` to `true`; tighten description.
-- `src/agent/wireTools.ts` — register the two new tools.
+- `src/agent/wireTools.ts` — register the two new tools; add `replaceEditorRange` to `ToolBindings`.
 - `src/agent/config.ts` — add tool names; rewrite the partial-edit guidance paragraph.
+- `src/hooks/useEditor.ts` — add `replaceRange(from, to, replacement)` (targeted dispatch, scroll-preserving) and `revealRange(from, to)` (scroll into center + temporary highlight via a dedicated `StateField` + `StateEffect`).
 - `src/components/AgentPanel.tsx` — accept `renderApproval` prop; forward to `<ConversationPanel>`.
-- `src/App.tsx` — build the `renderApproval` closure with bindings; pass to `<AgentPanel>`.
+- `src/App.tsx` — register tools synchronously during render (so `<AgentProvider>` sees `requiresApproval` flags on its first memo and installs the approval proxy); build the `renderApproval` closure with editor + reveal bindings; pass to `<AgentPanel>`.
+- `src/index.css` — Cobweb approval-card + diff styles, plus the `cobweb-reveal-highlight` class and `cobweb-reveal-fade` keyframe used by `revealRange`.
 
 **No change:**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "codemirror": "^6.0.2",
+        "diff": "^8.0.4",
         "lucide-react": "^1.14.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "codemirror": "^6.0.2",
+    "diff": "^8.0.4",
     "lucide-react": "^1.14.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { DeviceFileNavigator } from './components/DeviceFileNavigator';
 import { EditorBanner } from './components/EditorBanner';
 import { SettingsPanel } from './components/SettingsPanel';
 import { AgentPanel } from './components/AgentPanel';
+import { makeCobwebApproval } from './components/makeCobwebApproval';
 import { useReplConnection } from './hooks/useReplConnection';
 import { useEditor, type EditorOrigin } from './hooks/useEditor';
 import { useDeviceFs } from './hooks/useDeviceFs';
@@ -35,8 +36,16 @@ export function App() {
     useReplConnection();
   const { config, save: saveConfig, clear: clearConfig } = useProviderConfig();
   const { theme, preference: themePreference, cycle: cycleTheme } = useTheme();
-  const { editorRef, getContent, setContent, origin, setOriginAndContent, isModified } =
-    useEditor(theme);
+  const {
+    editorRef,
+    getContent,
+    setContent,
+    replaceRange,
+    revealRange,
+    origin,
+    setOriginAndContent,
+    isModified,
+  } = useEditor(theme);
 
   const deviceFsHook = useDeviceFs({ connectionState, sendRaw });
   const {
@@ -248,22 +257,31 @@ export function App() {
     return () => window.removeEventListener('keydown', onKeyDown);
   }, [handleSaveClick]);
 
-  useEffect(() => {
-    wireTools(models.tools, {
-      getEditorContent: getContent,
-      setEditorContent: setContent,
-      runCode,
-      getReplHistory: () => replHistory,
-      onData,
-      deviceFs,
-    });
-  }, [getContent, setContent, runCode, replHistory, onData, deviceFs]);
+  // Register tool definitions during render — AgentProvider inspects the
+  // registry on its first memo to decide whether to install the approval
+  // proxy, so the tools (and their `requiresApproval` flags) must be in the
+  // registry before the provider mounts. wireTools is idempotent: the first
+  // call registers, every subsequent call only refreshes the bindings.
+  wireTools(models.tools, {
+    getEditorContent: getContent,
+    setEditorContent: setContent,
+    replaceEditorRange: replaceRange,
+    runCode,
+    getReplHistory: () => replHistory,
+    onData,
+    deviceFs,
+  });
 
   const runner = useMemo(() => {
     if (!config) return null;
     const adapter = createAdapter(config);
     return new AgentRunner(adapter, models.tools);
   }, [config]);
+
+  const renderApproval = useMemo(
+    () => makeCobwebApproval(getContent, revealRange),
+    [getContent, revealRange],
+  );
 
   const savedConversation = useMemo(
     () => JSON.parse(localStorage.getItem('cobweb:conversation') ?? 'null') as {
@@ -430,6 +448,7 @@ export function App() {
                     theme={theme}
                     inputPlaceholder="Ask the assistant…"
                     onResetConversation={() => localStorage.removeItem('cobweb:conversation')}
+                    renderApproval={renderApproval}
                   />,
                 ]}
               </SplitPane>,

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -8,16 +8,18 @@ export const CODING_AGENT = createAgent({
   instructions: `You are a MicroPython coding assistant for the Cobweb IDE.
 You have access to the user's code editor and a live MicroPython REPL connected to a microcontroller.
 Help the user write, debug, and understand MicroPython code.
-When asked to write code, use write_editor then offer to run it.
+For partial changes to existing code, use edit_editor: it takes an exact old_string and a new_string and requires the old_string to appear exactly once in the buffer — include enough surrounding context to disambiguate. The user reviews a focused diff before it applies.
+Use write_editor only when creating a new program from scratch or replacing the whole buffer; the user reviews the new content before it applies.
 To run the editor's contents (typically a full program that may run for a long time), use run_editor. It returns as soon as the program starts; the user watches output directly in the REPL. After run_editor, simply tell the user the program started — do NOT follow up with read_repl_history or run_editor again unless the user asks.
 For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
 To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.
-To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
+To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer edit_editor or write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
 To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.
 To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.`,
   tools: [
     'read_editor',
     'write_editor',
+    'edit_editor',
     'run_editor',
     'run_snippet',
     'read_repl_history',

--- a/src/agent/tools/DeleteDeviceFileTool.test.ts
+++ b/src/agent/tools/DeleteDeviceFileTool.test.ts
@@ -10,6 +10,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({ stdout: '', stderr: '' }),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/EditEditorTool.test.ts
+++ b/src/agent/tools/EditEditorTool.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { EditEditorTool } from './EditEditorTool';
+import type { ToolBindings } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    ...overrides,
+  };
+}
+
+describe('EditEditorTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new EditEditorTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('edit_editor');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('definition requires both old_string and new_string', () => {
+    const tool = new EditEditorTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual([
+      'old_string',
+      'new_string',
+    ]);
+  });
+
+  it('returns "old_string not found in editor." when the target is absent', async () => {
+    const replaceEditorRange = vi.fn();
+    const tool = new EditEditorTool(() =>
+      makeBindings({ getEditorContent: () => 'x = 1\n', replaceEditorRange }),
+    );
+    await expect(
+      tool.call({ old_string: 'missing', new_string: 'y' }),
+    ).resolves.toBe('old_string not found in editor.');
+    expect(replaceEditorRange).not.toHaveBeenCalled();
+  });
+
+  it('returns the ambiguous error message when the target appears more than once', async () => {
+    const replaceEditorRange = vi.fn();
+    const tool = new EditEditorTool(() =>
+      makeBindings({
+        getEditorContent: () => 'foo\nbar\nfoo\nfoo\n',
+        replaceEditorRange,
+      }),
+    );
+    await expect(
+      tool.call({ old_string: 'foo', new_string: 'baz' }),
+    ).resolves.toBe(
+      'old_string is ambiguous — appears 3 times. Include more surrounding context.',
+    );
+    expect(replaceEditorRange).not.toHaveBeenCalled();
+  });
+
+  it('dispatches a targeted range replacement on the unique path', async () => {
+    const replaceEditorRange = vi.fn();
+    const tool = new EditEditorTool(() =>
+      makeBindings({
+        getEditorContent: () => 'a = 1\nb = 2\nc = 3\n',
+        replaceEditorRange,
+      }),
+    );
+    await expect(
+      tool.call({ old_string: 'b = 2', new_string: 'b = 42' }),
+    ).resolves.toBe('Editor updated.');
+    // 'b = 2' starts at index 6 and is 5 chars long.
+    expect(replaceEditorRange).toHaveBeenCalledWith(6, 11, 'b = 42');
+  });
+
+  it('handles multi-line replacements', async () => {
+    const replaceEditorRange = vi.fn();
+    const tool = new EditEditorTool(() =>
+      makeBindings({
+        getEditorContent: () => 'def f():\n    return 1\n',
+        replaceEditorRange,
+      }),
+    );
+    await expect(
+      tool.call({
+        old_string: 'def f():\n    return 1',
+        new_string: 'def f():\n    return 42',
+      }),
+    ).resolves.toBe('Editor updated.');
+    expect(replaceEditorRange).toHaveBeenCalledWith(
+      0,
+      'def f():\n    return 1'.length,
+      'def f():\n    return 42',
+    );
+  });
+});

--- a/src/agent/tools/EditEditorTool.ts
+++ b/src/agent/tools/EditEditorTool.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+import { findUniqueOccurrence } from '../../lib/editApproval';
+
+export interface EditEditorArgs {
+  old_string: string;
+  new_string: string;
+}
+
+export class EditEditorTool implements Tool<EditEditorArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'edit_editor',
+      description:
+        "Replaces a unique substring `old_string` in the user's code editor with `new_string`. " +
+        '`old_string` must match the editor contents exactly (including whitespace) and must ' +
+        'appear exactly once — include enough surrounding context to disambiguate. Prefer this ' +
+        'over `write_editor` for any change that does not rewrite the whole buffer. Requires ' +
+        'user approval.',
+      parameters: {
+        type: 'object',
+        properties: {
+          old_string: {
+            type: 'string',
+            description:
+              'The exact substring currently in the editor to replace. Must appear exactly once.',
+          },
+          new_string: {
+            type: 'string',
+            description: 'The replacement text.',
+          },
+        },
+        required: ['old_string', 'new_string'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: EditEditorArgs): Promise<string> {
+    const { getEditorContent, replaceEditorRange } = this.getBindings();
+    const source = getEditorContent();
+    const result = findUniqueOccurrence(source, args.old_string);
+    if (result.kind === 'missing') return 'old_string not found in editor.';
+    if (result.kind === 'ambiguous') {
+      return `old_string is ambiguous — appears ${result.count} times. Include more surrounding context.`;
+    }
+    replaceEditorRange(
+      result.index,
+      result.index + args.old_string.length,
+      args.new_string,
+    );
+    return 'Editor updated.';
+  }
+}

--- a/src/agent/tools/ListDeviceFilesTool.test.ts
+++ b/src/agent/tools/ListDeviceFilesTool.test.ts
@@ -10,6 +10,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/MakeDeviceDirTool.test.ts
+++ b/src/agent/tools/MakeDeviceDirTool.test.ts
@@ -10,6 +10,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({ stdout: '', stderr: '' }),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/ReadDeviceFileTool.test.ts
+++ b/src/agent/tools/ReadDeviceFileTool.test.ts
@@ -10,6 +10,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/ReadEditorTool.test.ts
+++ b/src/agent/tools/ReadEditorTool.test.ts
@@ -9,6 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/ReadReplHistoryTool.test.ts
+++ b/src/agent/tools/ReadReplHistoryTool.test.ts
@@ -9,6 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/RunEditorTool.test.ts
+++ b/src/agent/tools/RunEditorTool.test.ts
@@ -9,6 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/RunSnippetTool.test.ts
+++ b/src/agent/tools/RunSnippetTool.test.ts
@@ -9,6 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/WriteDeviceFileTool.test.ts
+++ b/src/agent/tools/WriteDeviceFileTool.test.ts
@@ -10,6 +10,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({ stdout: '', stderr: '' }),
     getReplHistory: () => [],
     onData: () => () => {},

--- a/src/agent/tools/WriteEditorTool.test.ts
+++ b/src/agent/tools/WriteEditorTool.test.ts
@@ -9,6 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
@@ -23,7 +24,7 @@ describe('WriteEditorTool', () => {
     const def = tool.definition();
     expect(def.name).toBe('write_editor');
     expect(def.scope).toBe('write');
-    expect(def.requiresApproval).toBe(false);
+    expect(def.requiresApproval).toBe(true);
   });
 
   it('definition requires the code argument', () => {

--- a/src/agent/tools/WriteEditorTool.ts
+++ b/src/agent/tools/WriteEditorTool.ts
@@ -15,7 +15,9 @@ export class WriteEditorTool implements Tool<WriteEditorArgs, string> {
     return {
       name: 'write_editor',
       description:
-        "Replaces the entire contents of the user's code editor with the given code.",
+        "Replaces the entire contents of the user's code editor with the given code. Use " +
+        'this only for new programs or full rewrites; use `edit_editor` for partial changes. ' +
+        'Requires user approval.',
       parameters: {
         type: 'object',
         properties: {
@@ -28,7 +30,7 @@ export class WriteEditorTool implements Tool<WriteEditorArgs, string> {
         additionalProperties: false,
       },
       scope: 'write',
-      requiresApproval: false,
+      requiresApproval: true,
     };
   }
 

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -9,6 +9,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
   return {
     getEditorContent: () => '',
     setEditorContent: () => {},
+    replaceEditorRange: () => {},
     runCode: async () => ({stdout: '', stderr: ''}),
     getReplHistory: () => [],
     onData: () => () => {},
@@ -24,6 +25,7 @@ describe('wireTools', () => {
     const names = tools.getTools().map((t) => t.name).sort();
     expect(names).toEqual([
       'delete_device_file',
+      'edit_editor',
       'list_device_files',
       'make_device_dir',
       'read_device_file',
@@ -40,7 +42,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(10);
+    expect(tools.getTools()).toHaveLength(11);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -6,6 +6,7 @@ import type { RunResult } from '../ReplInterface';
 import type { DeviceFs } from '../DeviceFs';
 import { ReadEditorTool } from './tools/ReadEditorTool';
 import { WriteEditorTool } from './tools/WriteEditorTool';
+import { EditEditorTool } from './tools/EditEditorTool';
 import { RunEditorTool } from './tools/RunEditorTool';
 import { RunSnippetTool } from './tools/RunSnippetTool';
 import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
@@ -18,6 +19,11 @@ import { MakeDeviceDirTool } from './tools/MakeDeviceDirTool';
 export interface ToolBindings {
   getEditorContent(): string;
   setEditorContent(code: string): void;
+  /**
+   * Targeted partial edit. Used by `edit_editor` so the user's scroll
+   * position is preserved after the edit applies.
+   */
+  replaceEditorRange(from: number, to: number, replacement: string): void;
   runCode(code: string): Promise<RunResult>;
   getReplHistory(): string[];
   onData(handler: (data: Uint8Array) => void): () => void;
@@ -40,6 +46,7 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
 
   tools.register(new ReadEditorTool(get));
   tools.register(new WriteEditorTool(get));
+  tools.register(new EditEditorTool(get));
   tools.register(new RunEditorTool(get));
   tools.register(new RunSnippetTool(get));
   tools.register(new ReadReplHistoryTool(get));

--- a/src/components/AgentPanel.tsx
+++ b/src/components/AgentPanel.tsx
@@ -1,16 +1,22 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { ConversationPanel, useAgent } from '@mast-ai/react-ui';
+import { ConversationPanel, useAgent, type RenderApproval } from '@mast-ai/react-ui';
 import { SquarePen } from 'lucide-react';
 
 interface AgentPanelProps {
   theme: 'light' | 'dark';
   inputPlaceholder?: string;
   onResetConversation?: () => void;
+  renderApproval?: RenderApproval;
 }
 
-export function AgentPanel({ theme, inputPlaceholder, onResetConversation }: AgentPanelProps) {
+export function AgentPanel({
+  theme,
+  inputPlaceholder,
+  onResetConversation,
+  renderApproval,
+}: AgentPanelProps) {
   const { reset, messages, isReady } = useAgent();
   const hasMessages = messages.length > 0;
 
@@ -34,7 +40,11 @@ export function AgentPanel({ theme, inputPlaceholder, onResetConversation }: Age
         </button>
       </div>
       <div className="flex-1 min-h-0">
-        <ConversationPanel theme={theme} inputPlaceholder={inputPlaceholder} />
+        <ConversationPanel
+          theme={theme}
+          inputPlaceholder={inputPlaceholder}
+          renderApproval={renderApproval}
+        />
       </div>
     </div>
   );

--- a/src/components/CobwebApproval.tsx
+++ b/src/components/CobwebApproval.tsx
@@ -1,0 +1,352 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { diffWords, type ChangeObject } from 'diff';
+import {
+  InlineApproval,
+  type PendingApproval,
+  type ToolEventEntry,
+} from '@mast-ai/react-ui';
+import { findUniqueOccurrence, expandToContextLines } from '../lib/editApproval';
+
+interface ApprovalSlotProps {
+  entry: ToolEventEntry;
+  approval: PendingApproval;
+}
+
+interface CobwebApprovalProps extends ApprovalSlotProps {
+  getEditorContent: () => string;
+  revealEditorRange: (from: number, to: number) => void;
+}
+
+export function CobwebApproval({
+  entry,
+  approval,
+  getEditorContent,
+  revealEditorRange,
+}: CobwebApprovalProps): ReactNode {
+  switch (entry.name) {
+    case 'edit_editor':
+      return (
+        <EditApprovalCard
+          entry={entry}
+          approval={approval}
+          getEditorContent={getEditorContent}
+          revealEditorRange={revealEditorRange}
+        />
+      );
+    case 'write_editor':
+      return <WriteApprovalCard entry={entry} approval={approval} />;
+    default:
+      return (
+        <InlineApproval
+          entry={entry}
+          approve={approval.approve}
+          reject={approval.reject}
+          respondWith={approval.respondWith}
+        />
+      );
+  }
+}
+
+// ----- EditApprovalCard ------------------------------------------------------
+
+interface EditApprovalCardProps extends ApprovalSlotProps {
+  getEditorContent: () => string;
+  revealEditorRange: (from: number, to: number) => void;
+}
+
+function EditApprovalCard({
+  entry,
+  approval,
+  getEditorContent,
+  revealEditorRange,
+}: EditApprovalCardProps): ReactNode {
+  const args = entry.args as { old_string?: unknown; new_string?: unknown } | undefined;
+  const oldString = typeof args?.old_string === 'string' ? args.old_string : '';
+  const newString = typeof args?.new_string === 'string' ? args.new_string : '';
+
+  // Diff against the live editor — the buffer the user sees right now is the
+  // buffer the edit will apply to, so the renderer must read fresh on every
+  // render rather than caching at construction time.
+  const source = getEditorContent();
+  const find = useMemo(
+    () => findUniqueOccurrence(source, oldString),
+    [source, oldString],
+  );
+
+  // Auto-reveal once when the card mounts so the user immediately sees
+  // which part of the buffer the agent is asking about. We deliberately
+  // don't repeat on every change to `find.index` — the user is typing then
+  // and an unsolicited scroll would steal their focus.
+  const didReveal = useRef(false);
+  useEffect(() => {
+    if (didReveal.current) return;
+    if (find.kind !== 'unique') return;
+    didReveal.current = true;
+    revealEditorRange(find.index, find.index + oldString.length);
+  }, [find, oldString.length, revealEditorRange]);
+
+  return (
+    <div className="cobweb-approval-card" data-tool-name={entry.name}>
+      <div className="cobweb-approval-header">
+        <span className="cobweb-approval-title">Edit editor</span>
+        <div className="cobweb-approval-header-actions">
+          {find.kind === 'unique' && (
+            <button
+              type="button"
+              className="cobweb-reveal-button"
+              onClick={() =>
+                revealEditorRange(find.index, find.index + oldString.length)
+              }
+              title="Scroll editor to this location"
+            >
+              Reveal
+            </button>
+          )}
+          <span className="cobweb-approval-status">requires approval</span>
+        </div>
+      </div>
+
+      {find.kind === 'unique' ? (
+        <DiffBlock
+          source={source}
+          index={find.index}
+          oldString={oldString}
+          newString={newString}
+        />
+      ) : find.kind === 'missing' ? (
+        <NoLongerAppliesNotice
+          message="old_string was not found in the current editor — the buffer may have changed since the agent proposed this edit."
+          respondMessage="old_string not found in editor."
+          onRespondWith={approval.respondWith}
+        />
+      ) : (
+        <NoLongerAppliesNotice
+          message={`old_string is now ambiguous — it appears ${find.count} times in the current editor.`}
+          respondMessage={`old_string is ambiguous — appears ${find.count} times. Include more surrounding context.`}
+          onRespondWith={approval.respondWith}
+        />
+      )}
+
+      <ApprovalActions
+        approveDisabled={find.kind !== 'unique'}
+        onApprove={approval.approve}
+        onReject={approval.reject}
+      />
+    </div>
+  );
+}
+
+// ----- WriteApprovalCard ----------------------------------------------------
+
+function WriteApprovalCard({ entry, approval }: ApprovalSlotProps): ReactNode {
+  return (
+    <div className="cobweb-approval-card" data-tool-name={entry.name}>
+      <div className="cobweb-approval-header">
+        <span className="cobweb-approval-title">Replace editor with new content</span>
+        <span className="cobweb-approval-status">requires approval</span>
+      </div>
+      <ApprovalActions onApprove={approval.approve} onReject={approval.reject} />
+    </div>
+  );
+}
+
+// ----- Diff rendering --------------------------------------------------------
+
+interface DiffBlockProps {
+  source: string;
+  index: number;
+  oldString: string;
+  newString: string;
+}
+
+function DiffBlock({ source, index, oldString, newString }: DiffBlockProps): ReactNode {
+  const hunk = useMemo(
+    () => expandToContextLines(source, index, oldString, newString),
+    [source, index, oldString, newString],
+  );
+  const wordDiff = useMemo(
+    () => diffWords(hunk.before.join('\n'), hunk.after.join('\n')),
+    [hunk.before, hunk.after],
+  );
+
+  const beforeRows = splitByNewline(renderHalf(wordDiff, 'removed'));
+  const afterRows = splitByNewline(renderHalf(wordDiff, 'added'));
+
+  // Line numbers are 1-based and reference the *source* buffer.
+  const ctxBeforeStart = hunk.firstLine;
+  const removedStart = ctxBeforeStart + hunk.contextBefore.length;
+  const ctxAfterStart = removedStart + hunk.before.length;
+
+  return (
+    <pre className="cobweb-diff">
+      {hunk.contextBefore.map((line, i) => (
+        <DiffLine key={`ctx-before-${i}`} kind="context" lineNumber={ctxBeforeStart + i}>
+          {line}
+        </DiffLine>
+      ))}
+      {beforeRows.map((parts, i) => (
+        <DiffLine key={`removed-${i}`} kind="removed" lineNumber={removedStart + i}>
+          {parts}
+        </DiffLine>
+      ))}
+      {/* Replacement lines have no source line numbers — leave the gutter
+          blank so the column stays a stable reference to the current buffer. */}
+      {afterRows.map((parts, i) => (
+        <DiffLine key={`added-${i}`} kind="added" lineNumber={null}>
+          {parts}
+        </DiffLine>
+      ))}
+      {hunk.contextAfter.map((line, i) => (
+        <DiffLine key={`ctx-after-${i}`} kind="context" lineNumber={ctxAfterStart + i}>
+          {line}
+        </DiffLine>
+      ))}
+    </pre>
+  );
+}
+
+function renderHalf(changes: ChangeObject<string>[], side: 'removed' | 'added'): ReactNode[] {
+  // Build inline nodes that, when joined and split on `\n`, produce one
+  // visual line per source/replacement line.
+  const out: ReactNode[] = [];
+  changes.forEach((change, i) => {
+    if (change.added) {
+      if (side === 'added') {
+        out.push(
+          <span key={i} className="cobweb-diff-added-word">
+            {change.value}
+          </span>,
+        );
+      }
+      return;
+    }
+    if (change.removed) {
+      if (side === 'removed') {
+        out.push(
+          <span key={i} className="cobweb-diff-removed-word">
+            {change.value}
+          </span>,
+        );
+      }
+      return;
+    }
+    out.push(<span key={i}>{change.value}</span>);
+  });
+  return out;
+}
+
+function splitByNewline(nodes: ReactNode[]): ReactNode[][] {
+  // Walk every span; split its text content on '\n' and emit a fresh row each
+  // time we cross a newline. Highlighted spans are split into per-line pieces
+  // so the row layout stays one DOM line per visual line.
+  const rows: ReactNode[][] = [[]];
+  let key = 0;
+  for (const node of nodes) {
+    if (typeof node === 'object' && node !== null && 'props' in node) {
+      const props = (node as { props: { className?: string; children?: unknown } }).props;
+      const text = String(props.children ?? '');
+      const className = props.className;
+      const pieces = text.split('\n');
+      pieces.forEach((piece, i) => {
+        if (piece.length > 0) {
+          if (className) {
+            rows[rows.length - 1].push(
+              <span key={`s-${key++}`} className={className}>
+                {piece}
+              </span>,
+            );
+          } else {
+            rows[rows.length - 1].push(piece);
+          }
+        }
+        if (i < pieces.length - 1) rows.push([]);
+      });
+    } else {
+      rows[rows.length - 1].push(node);
+    }
+  }
+  return rows;
+}
+
+interface DiffLineProps {
+  kind: 'context' | 'removed' | 'added';
+  lineNumber: number | null;
+  children: ReactNode;
+}
+
+function DiffLine({ kind, lineNumber, children }: DiffLineProps): ReactNode {
+  const sigil = kind === 'removed' ? '-' : kind === 'added' ? '+' : ' ';
+  return (
+    <div className={`cobweb-diff-line cobweb-diff-line-${kind}`}>
+      <span className="cobweb-diff-gutter">{lineNumber ?? ''}</span>
+      <span className="cobweb-diff-sigil">{sigil}</span>
+      <span className="cobweb-diff-content">
+        {children}
+        {/* Empty-line preserve: zero-width space so the row keeps its height. */}
+        {'​'}
+      </span>
+    </div>
+  );
+}
+
+// ----- Failure notice + actions ---------------------------------------------
+
+interface NoLongerAppliesNoticeProps {
+  message: string;
+  respondMessage: string;
+  onRespondWith: (s: string) => void;
+}
+
+function NoLongerAppliesNotice({
+  message,
+  respondMessage,
+  onRespondWith,
+}: NoLongerAppliesNoticeProps): ReactNode {
+  return (
+    <div className="cobweb-approval-notice">
+      <p>{message}</p>
+      <button
+        type="button"
+        className="cobweb-approval-button cobweb-approval-button-secondary"
+        onClick={() => onRespondWith(respondMessage)}
+      >
+        Tell the agent
+      </button>
+    </div>
+  );
+}
+
+interface ApprovalActionsProps {
+  approveDisabled?: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+function ApprovalActions({
+  approveDisabled = false,
+  onApprove,
+  onReject,
+}: ApprovalActionsProps): ReactNode {
+  return (
+    <div className="cobweb-approval-actions">
+      <button
+        type="button"
+        className="cobweb-approval-button cobweb-approval-button-approve"
+        onClick={onApprove}
+        disabled={approveDisabled}
+      >
+        Approve
+      </button>
+      <button
+        type="button"
+        className="cobweb-approval-button cobweb-approval-button-reject"
+        onClick={onReject}
+      >
+        Reject
+      </button>
+    </div>
+  );
+}

--- a/src/components/makeCobwebApproval.tsx
+++ b/src/components/makeCobwebApproval.tsx
@@ -1,0 +1,19 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { RenderApproval } from '@mast-ai/react-ui';
+import { CobwebApproval } from './CobwebApproval';
+
+export function makeCobwebApproval(
+  getEditorContent: () => string,
+  revealEditorRange: (from: number, to: number) => void,
+): RenderApproval {
+  return (entry, approval) => (
+    <CobwebApproval
+      entry={entry}
+      approval={approval}
+      getEditorContent={getEditorContent}
+      revealEditorRange={revealEditorRange}
+    />
+  );
+}

--- a/src/hooks/useEditor.test.ts
+++ b/src/hooks/useEditor.test.ts
@@ -58,6 +58,11 @@ vi.mock('codemirror', () => {
     },
   };
   (EditorViewMock as unknown as { theme: (spec: unknown) => unknown[] }).theme = () => [];
+  (EditorViewMock as unknown as { scrollIntoView: (...a: unknown[]) => unknown }).scrollIntoView =
+    () => ({});
+  (EditorViewMock as unknown as { decorations: { from: () => unknown[] } }).decorations = {
+    from: () => [],
+  };
   return { EditorView: EditorViewMock, basicSetup: [] };
 });
 
@@ -69,8 +74,29 @@ vi.mock('@codemirror/state', () => {
   return {
     EditorState: { create: vi.fn().mockReturnValue({}) },
     Compartment: CompartmentMock,
+    EditorSelection: { range: (from: number, to: number) => ({ from, to }) },
+    StateEffect: {
+      define: () => ({
+        of: (value: unknown) => value,
+        is: () => false,
+      }),
+    },
+    StateField: {
+      define: () => ({
+        provide: () => [],
+      }),
+    },
   };
 });
+
+vi.mock('@codemirror/view', () => ({
+  Decoration: {
+    none: [],
+    set: () => [],
+    mark: () => ({ range: () => ({}) }),
+  },
+  EditorView: { decorations: { from: () => [] } },
+}));
 
 vi.mock('@codemirror/lang-python', () => ({
   python: vi.fn().mockReturnValue([]),

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -3,9 +3,43 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { EditorView, basicSetup } from 'codemirror';
-import { Compartment, EditorState, Extension } from '@codemirror/state';
+import {
+  Compartment,
+  EditorSelection,
+  EditorState,
+  Extension,
+  StateEffect,
+  StateField,
+} from '@codemirror/state';
+import { Decoration, type DecorationSet } from '@codemirror/view';
 import { python } from '@codemirror/lang-python';
 import { catppuccinLatte, catppuccinMocha } from '@catppuccin/codemirror';
+
+const REVEAL_HIGHLIGHT_MS = 1700;
+
+const setRevealHighlight = StateEffect.define<{ from: number; to: number } | null>();
+
+const revealHighlightField = StateField.define<DecorationSet>({
+  create: () => Decoration.none,
+  update(deco, tr) {
+    deco = deco.map(tr.changes);
+    for (const e of tr.effects) {
+      if (e.is(setRevealHighlight)) {
+        deco =
+          e.value === null
+            ? Decoration.none
+            : Decoration.set([
+                Decoration.mark({ class: 'cobweb-reveal-highlight' }).range(
+                  e.value.from,
+                  e.value.to,
+                ),
+              ]);
+      }
+    }
+    return deco;
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
 
 export type EditorOrigin =
   | { kind: 'untitled' }
@@ -67,6 +101,7 @@ export function useEditor(theme: 'light' | 'dark') {
           themeCompartment.current.of(themeExtension(theme)),
           fillHeight,
           modifiedListener,
+          revealHighlightField,
         ],
       }),
       parent: editorRef.current,
@@ -110,6 +145,39 @@ export function useEditor(theme: 'light' | 'dark') {
     });
   }, []);
 
+  // Targeted partial edit. Unlike setContent's full-document replacement,
+  // CodeMirror keeps the viewport stable across small dispatches — so the
+  // user's scroll position is preserved when the agent applies an edit.
+  const replaceRange = useCallback(
+    (from: number, to: number, replacement: string): void => {
+      const view = viewRef.current;
+      if (!view) return;
+      view.dispatch({
+        changes: { from, to, insert: replacement },
+      });
+    },
+    [],
+  );
+
+  const revealRange = useCallback((from: number, to: number): void => {
+    const view = viewRef.current;
+    if (!view) return;
+    const docLen = view.state.doc.length;
+    const safeFrom = Math.max(0, Math.min(from, docLen));
+    const safeTo = Math.max(safeFrom, Math.min(to, docLen));
+    view.dispatch({
+      effects: [
+        EditorView.scrollIntoView(EditorSelection.range(safeFrom, safeTo), { y: 'center' }),
+        setRevealHighlight.of({ from: safeFrom, to: safeTo }),
+      ],
+    });
+    setTimeout(() => {
+      const v = viewRef.current;
+      if (!v) return;
+      v.dispatch({ effects: setRevealHighlight.of(null) });
+    }, REVEAL_HIGHLIGHT_MS);
+  }, []);
+
   const setOriginAndContent = useCallback((newOrigin: EditorOrigin, content: string): void => {
     snapshotRef.current = content;
     originRef.current = newOrigin;
@@ -128,5 +196,14 @@ export function useEditor(theme: 'light' | 'dark') {
     }
   }, []);
 
-  return { editorRef, getContent, setContent, origin, setOriginAndContent, isModified };
+  return {
+    editorRef,
+    getContent,
+    setContent,
+    replaceRange,
+    revealRange,
+    origin,
+    setOriginAndContent,
+    isModified,
+  };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -168,3 +168,198 @@
     overflow: hidden;
   }
 }
+
+/* ---------- Cobweb tool-approval cards ---------- */
+
+.cobweb-approval-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--card);
+    color: var(--card-foreground);
+    font-size: 0.8125rem;
+}
+
+.cobweb-approval-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.cobweb-approval-title {
+    font-weight: 600;
+}
+
+.cobweb-approval-status {
+    color: var(--muted-foreground);
+    font-size: 0.75rem;
+}
+
+.cobweb-approval-header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.cobweb-reveal-button {
+    padding: 0.15rem 0.5rem;
+    border-radius: 0.25rem;
+    border: 1px solid var(--border);
+    background: transparent;
+    color: var(--muted-foreground);
+    font: inherit;
+    font-size: 0.75rem;
+    cursor: pointer;
+}
+
+.cobweb-reveal-button:hover {
+    background: var(--muted);
+    color: var(--foreground);
+}
+
+.cobweb-approval-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.cobweb-approval-button {
+    padding: 0.4rem 0.9rem;
+    border-radius: 0.375rem;
+    border: 1px solid transparent;
+    font: inherit;
+    cursor: pointer;
+}
+
+.cobweb-approval-button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.cobweb-approval-button-approve {
+    background: var(--primary);
+    color: var(--primary-foreground);
+}
+
+.cobweb-approval-button-reject {
+    background: transparent;
+    border-color: var(--border);
+    color: inherit;
+}
+
+.cobweb-approval-button-secondary {
+    background: var(--muted);
+    color: var(--foreground);
+    border-color: var(--border);
+}
+
+.cobweb-approval-notice {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    background: var(--muted);
+    border-radius: 0.375rem;
+}
+
+.cobweb-approval-notice p {
+    margin: 0;
+    color: var(--muted-foreground);
+}
+
+/* Diff display ----------------------------------------------------------- */
+
+.cobweb-diff {
+    margin: 0;
+    padding: 0.5rem 0;
+    border-radius: 0.375rem;
+    background: var(--muted);
+    font-family: ui-monospace, monospace;
+    font-size: 0.75rem;
+    line-height: 1.4;
+    overflow-x: auto;
+    white-space: pre;
+}
+
+.cobweb-diff-line {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+    padding: 0 0.5rem;
+}
+
+.cobweb-diff-gutter {
+    display: inline-block;
+    min-width: 2ch;
+    text-align: right;
+    color: var(--muted-foreground);
+    user-select: none;
+}
+
+.cobweb-diff-sigil {
+    display: inline-block;
+    width: 1ch;
+    user-select: none;
+}
+
+.cobweb-diff-content {
+    flex: 1;
+    min-width: 0;
+}
+
+.cobweb-diff-line-removed {
+    background: color-mix(in srgb, var(--destructive) 15%, transparent);
+}
+
+.cobweb-diff-line-removed .cobweb-diff-sigil {
+    color: var(--destructive);
+}
+
+.cobweb-diff-line-added {
+    background: color-mix(in srgb, #16a34a 18%, transparent);
+}
+
+.cobweb-diff-line-added .cobweb-diff-sigil {
+    color: #16a34a;
+}
+
+.dark .cobweb-diff-line-added {
+    background: color-mix(in srgb, #4ade80 22%, transparent);
+}
+
+.dark .cobweb-diff-line-added .cobweb-diff-sigil {
+    color: #4ade80;
+}
+
+.cobweb-diff-removed-word {
+    background: color-mix(in srgb, var(--destructive) 35%, transparent);
+    text-decoration: line-through;
+}
+
+.cobweb-diff-added-word {
+    background: color-mix(in srgb, #16a34a 35%, transparent);
+}
+
+.dark .cobweb-diff-added-word {
+    background: color-mix(in srgb, #4ade80 35%, transparent);
+}
+
+/* Reveal-in-editor highlight ------------------------------------------- */
+
+.cobweb-reveal-highlight {
+    background-color: rgba(234, 179, 8, 0.28);
+    animation: cobweb-reveal-fade 1.7s ease-out forwards;
+    border-radius: 2px;
+}
+
+@keyframes cobweb-reveal-fade {
+    0% {
+        background-color: rgba(234, 179, 8, 0.45);
+    }
+    100% {
+        background-color: transparent;
+    }
+}

--- a/src/lib/editApproval.test.ts
+++ b/src/lib/editApproval.test.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { findUniqueOccurrence, expandToContextLines } from './editApproval';
+
+describe('findUniqueOccurrence', () => {
+  it('treats an empty target as missing', () => {
+    expect(findUniqueOccurrence('abc', '')).toEqual({ kind: 'missing' });
+  });
+
+  it('finds a unique match at the start', () => {
+    expect(findUniqueOccurrence('foobar', 'foo')).toEqual({ kind: 'unique', index: 0 });
+  });
+
+  it('finds a unique match in the middle', () => {
+    expect(findUniqueOccurrence('alpha beta gamma', 'beta')).toEqual({
+      kind: 'unique',
+      index: 6,
+    });
+  });
+
+  it('finds a unique match at the end', () => {
+    expect(findUniqueOccurrence('hello world', 'world')).toEqual({
+      kind: 'unique',
+      index: 6,
+    });
+  });
+
+  it('reports missing when the target is absent', () => {
+    expect(findUniqueOccurrence('foo', 'bar')).toEqual({ kind: 'missing' });
+  });
+
+  it('reports ambiguous when the target appears more than once', () => {
+    const result = findUniqueOccurrence('foo bar foo', 'foo');
+    expect(result).toEqual({ kind: 'ambiguous', count: 2 });
+  });
+
+  it('counts overlapping candidates with non-overlapping replace semantics', () => {
+    // 'aaaa' contains 'aa' at offsets 0 and 2 under non-overlapping scan
+    // (the same model as String.prototype.replace).
+    const result = findUniqueOccurrence('aaaa', 'aa');
+    expect(result).toEqual({ kind: 'ambiguous', count: 2 });
+  });
+
+  it('matches across newlines', () => {
+    const src = 'line1\nline2\nline3';
+    expect(findUniqueOccurrence(src, 'line2\nline3')).toEqual({
+      kind: 'unique',
+      index: 6,
+    });
+  });
+});
+
+describe('expandToContextLines', () => {
+  it('returns 2 lines of context above and below by default', () => {
+    const src = ['a', 'b', 'c', 'TARGET', 'd', 'e', 'f'].join('\n');
+    const idx = src.indexOf('TARGET');
+    const hunk = expandToContextLines(src, idx, 'TARGET', 'X');
+    expect(hunk.contextBefore).toEqual(['b', 'c']);
+    expect(hunk.before).toEqual(['TARGET']);
+    expect(hunk.after).toEqual(['X']);
+    expect(hunk.contextAfter).toEqual(['d', 'e']);
+    expect(hunk.firstLine).toBe(2); // line 'b' is the 2nd line (1-based)
+  });
+
+  it('clips context at the start of the file', () => {
+    const src = ['TARGET', 'a', 'b', 'c'].join('\n');
+    const hunk = expandToContextLines(src, 0, 'TARGET', 'X');
+    expect(hunk.contextBefore).toEqual([]);
+    expect(hunk.before).toEqual(['TARGET']);
+    expect(hunk.after).toEqual(['X']);
+    expect(hunk.contextAfter).toEqual(['a', 'b']);
+    expect(hunk.firstLine).toBe(1);
+  });
+
+  it('clips context at the end of the file', () => {
+    const src = ['a', 'b', 'TARGET'].join('\n');
+    const idx = src.indexOf('TARGET');
+    const hunk = expandToContextLines(src, idx, 'TARGET', 'X');
+    expect(hunk.contextBefore).toEqual(['a', 'b']);
+    expect(hunk.before).toEqual(['TARGET']);
+    expect(hunk.after).toEqual(['X']);
+    expect(hunk.contextAfter).toEqual([]);
+  });
+
+  it('expands to whole source lines when the target is mid-line', () => {
+    const src = ['x = 1', 'y = 2  # tweak me', 'z = 3'].join('\n');
+    const idx = src.indexOf('tweak me');
+    const hunk = expandToContextLines(src, idx, 'tweak me', 'updated');
+    expect(hunk.before).toEqual(['y = 2  # tweak me']);
+    expect(hunk.after).toEqual(['y = 2  # updated']);
+  });
+
+  it('handles multi-line replacements', () => {
+    const src = ['a', 'b', 'first', 'second', 'c', 'd'].join('\n');
+    const idx = src.indexOf('first');
+    const hunk = expandToContextLines(src, idx, 'first\nsecond', 'one\ntwo\nthree');
+    expect(hunk.before).toEqual(['first', 'second']);
+    expect(hunk.after).toEqual(['one', 'two', 'three']);
+    expect(hunk.contextBefore).toEqual(['a', 'b']);
+    expect(hunk.contextAfter).toEqual(['c', 'd']);
+  });
+
+  it('respects a custom contextLines value', () => {
+    const src = ['a', 'b', 'c', 'd', 'TARGET', 'e', 'f', 'g'].join('\n');
+    const idx = src.indexOf('TARGET');
+    const hunk = expandToContextLines(src, idx, 'TARGET', 'X', 1);
+    expect(hunk.contextBefore).toEqual(['d']);
+    expect(hunk.contextAfter).toEqual(['e']);
+  });
+});

--- a/src/lib/editApproval.ts
+++ b/src/lib/editApproval.ts
@@ -1,0 +1,128 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export type FindResult =
+  | { kind: 'unique'; index: number }
+  | { kind: 'missing' }
+  | { kind: 'ambiguous'; count: number };
+
+/**
+ * Counts non-overlapping occurrences of `target` in `source` using literal
+ * substring matching (no regex). Empty `target` is treated as `missing`.
+ *
+ * Counting matches `String.prototype.replace`'s left-to-right, non-overlapping
+ * scan, so `findUniqueOccurrence('aaaa', 'aa')` reports `count: 2`.
+ */
+export function findUniqueOccurrence(source: string, target: string): FindResult {
+  if (target === '') return { kind: 'missing' };
+
+  let count = 0;
+  let firstIndex = -1;
+  let from = 0;
+  while (true) {
+    const at = source.indexOf(target, from);
+    if (at === -1) break;
+    if (firstIndex === -1) firstIndex = at;
+    count++;
+    if (count > 1) return { kind: 'ambiguous', count: countAll(source, target, at + target.length) };
+    from = at + target.length;
+  }
+
+  if (count === 0) return { kind: 'missing' };
+  return { kind: 'unique', index: firstIndex };
+}
+
+function countAll(source: string, target: string, startFrom: number): number {
+  let count = 2;
+  let from = startFrom;
+  while (true) {
+    const at = source.indexOf(target, from);
+    if (at === -1) break;
+    count++;
+    from = at + target.length;
+  }
+  return count;
+}
+
+export interface ContextHunk {
+  /** 1-based line number of the first rendered line (the topmost context line). */
+  firstLine: number;
+  /** Lines in the source that were replaced. */
+  before: string[];
+  /** Replacement lines. */
+  after: string[];
+  /** Up to `contextLines` source lines preceding the change, clipped at file start. */
+  contextBefore: string[];
+  /** Up to `contextLines` source lines following the change, clipped at file end. */
+  contextAfter: string[];
+}
+
+/**
+ * Given a substring replacement defined by a 0-based `index` and the
+ * `oldString` / `newString` pair, computes the set of lines affected and the
+ * surrounding context window. Newlines in either string are tolerated; the
+ * helper expands the changed range to the full source lines that contain the
+ * replacement so the renderer can show whole lines on either side of the diff.
+ *
+ * `contextLines` defaults to 2 (matches the SPEC's "2 lines above/below").
+ */
+export function expandToContextLines(
+  source: string,
+  index: number,
+  oldString: string,
+  newString: string,
+  contextLines = 2,
+): ContextHunk {
+  const lines = splitLines(source);
+  const startLine = lineNumberAt(source, index); // 0-based
+  const endLine = lineNumberAt(source, index + oldString.length); // 0-based, inclusive
+
+  const before = lines.slice(startLine, endLine + 1);
+  const replacedSourceSlice = before.join('\n');
+  const replacement =
+    replacedSourceSlice.slice(0, index - lineStartOffset(source, startLine)) +
+    newString +
+    replacedSourceSlice.slice(
+      index - lineStartOffset(source, startLine) + oldString.length,
+    );
+  const after = replacement.split('\n');
+
+  const ctxStart = Math.max(0, startLine - contextLines);
+  const ctxEnd = Math.min(lines.length - 1, endLine + contextLines);
+
+  return {
+    firstLine: ctxStart + 1,
+    before,
+    after,
+    contextBefore: lines.slice(ctxStart, startLine),
+    contextAfter: lines.slice(endLine + 1, ctxEnd + 1),
+  };
+}
+
+function splitLines(source: string): string[] {
+  // Preserve a trailing empty line if `source` ends with `\n` — keeping the
+  // semantic line count stable matters for line-number display.
+  return source.split('\n');
+}
+
+function lineNumberAt(source: string, index: number): number {
+  // Returns 0-based line number of the character at `index`.
+  let line = 0;
+  for (let i = 0; i < index && i < source.length; i++) {
+    if (source.charCodeAt(i) === 10 /* \n */) line++;
+  }
+  return line;
+}
+
+function lineStartOffset(source: string, line: number): number {
+  // Returns the byte offset of the start of `line` (0-based).
+  if (line === 0) return 0;
+  let seen = 0;
+  for (let i = 0; i < source.length; i++) {
+    if (source.charCodeAt(i) === 10) {
+      seen++;
+      if (seen === line) return i + 1;
+    }
+  }
+  return source.length;
+}


### PR DESCRIPTION
## Summary

- Adds the `edit_editor` partial-edit tool (uniqueness-based find/replace, mirrors Claude Code's Edit tool) behind a focused word-level diff approval card.
- Builds the tool-approval pipeline: `<CobwebApproval>` dispatcher, `<EditApprovalCard>` (3 states — unique → diff, missing → "Tell the agent" notice, ambiguous → notice with the count), placeholder `<WriteApprovalCard>` for `write_editor`, fallback to the framework's `<InlineApproval>` for any future flagged tool we forget.
- Flips `write_editor` to `requiresApproval: true` and tightens its description so the model reaches for `edit_editor` for partial changes.

Closes #127.

## Implementation notes

- **Pure helpers in `src/lib/editApproval.ts`:** `findUniqueOccurrence` (literal substring scan with non-overlapping replace semantics) and `expandToContextLines` (computes the ±2-line context window around a substring replacement, handling multi-line targets and start/end clipping). Both unit-tested.
- **Scroll preservation:** `EditEditorTool` writes via a new `replaceEditorRange(from, to, replacement)` binding that dispatches a CodeMirror change scoped to the affected range — `setEditorContent`'s whole-document replacement was resetting the viewport on every Approve.
- **Reveal-in-editor (per `agent-text-editor`):** `useEditor.revealRange(from, to)` scrolls the affected range into the centre of the viewport and adds a `cobweb-reveal-highlight` decoration via a dedicated `StateField` + `StateEffect`, then clears it after ~1.7s with an amber-to-transparent CSS fade. `<EditApprovalCard>` auto-invokes it once on first render and exposes a manual "Reveal" button in the header.
- **Approval-flag activation:** `wireTools` now runs synchronously in `App.tsx`'s render body before `<AgentProvider>` mounts. The provider memos a wrapping decision over the registry on its first run; without the synchronous call the registry was empty at that moment and tools registered later (including the existing `write_device_file` / `delete_device_file` / `make_device_dir` with `requiresApproval: true`) were silently bypassing the approval flow.
- `diff` (jsdiff) added as an explicit dependency for `diffWords`.

## Out of scope (per #127)

- Real preview content for `<WriteApprovalCard>` (#129).
- `edit_device_file` (#128) and the `multi_edit_*` tools (#133, #134).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 430/430 passing
- [x] `npm run build` clean
- [x] Manual browser test (confirmed): asking the agent to tweak existing code triggers `edit_editor`; the conversation panel renders a focused word-level diff with ±2 lines of context; the affected lines briefly highlight in the editor; Approve applies the edit and preserves scroll position; Reject leaves the buffer untouched. Asking the agent to write a fresh program triggers `write_editor`; the placeholder approval card appears with Approve/Reject.