### PR TITLE
feat(tool-approval): add edit_device_file tool with diff approval

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -278,9 +278,25 @@ export function App() {
     return new AgentRunner(adapter, models.tools);
   }, [config]);
 
+  const readDeviceFileForApproval = useCallback(
+    async (path: string): Promise<string | null> => {
+      try {
+        const bytes = await deviceReadBytes(path);
+        try {
+          return new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+        } catch {
+          return null;
+        }
+      } catch {
+        return null;
+      }
+    },
+    [deviceReadBytes],
+  );
+
   const renderApproval = useMemo(
-    () => makeCobwebApproval(getContent, revealRange),
-    [getContent, revealRange],
+    () => makeCobwebApproval(getContent, revealRange, readDeviceFileForApproval),
+    [getContent, revealRange, readDeviceFileForApproval],
   );
 
   const savedConversation = useMemo(

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -8,12 +8,12 @@ export const CODING_AGENT = createAgent({
   instructions: `You are a MicroPython coding assistant for the Cobweb IDE.
 You have access to the user's code editor and a live MicroPython REPL connected to a microcontroller.
 Help the user write, debug, and understand MicroPython code.
-For partial changes to existing code, use edit_editor: it takes an exact old_string and a new_string and requires the old_string to appear exactly once in the buffer — include enough surrounding context to disambiguate. The user reviews a focused diff before it applies.
+For partial changes to existing code, use edit_editor (for the editor buffer) or edit_device_file (for a UTF-8 file on the device): each takes an exact old_string and a new_string and requires the old_string to appear exactly once — include enough surrounding context to disambiguate. The user reviews a focused diff before it applies.
 Use write_editor only when creating a new program from scratch or replacing the whole buffer; the user reviews the new content before it applies.
 To run the editor's contents (typically a full program that may run for a long time), use run_editor. It returns as soon as the program starts; the user watches output directly in the REPL. After run_editor, simply tell the user the program started — do NOT follow up with read_repl_history or run_editor again unless the user asks.
 For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
 To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.
-To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer edit_editor or write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
+To save UTF-8 text to a file on the device, use write_device_file. It overwrites any existing file and requires user approval. Prefer edit_device_file for partial changes to an existing device file; only use write_device_file for new files or full rewrites. Prefer edit_editor or write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
 To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.
 To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.`,
   tools: [
@@ -26,6 +26,7 @@ To create a directory on the device, use make_device_dir. The parent directory m
     'list_device_files',
     'read_device_file',
     'write_device_file',
+    'edit_device_file',
     'delete_device_file',
     'make_device_dir',
   ],

--- a/src/agent/tools/EditDeviceFileTool.test.ts
+++ b/src/agent/tools/EditDeviceFileTool.test.ts
@@ -1,0 +1,163 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { EditDeviceFileTool } from './EditDeviceFileTool';
+import type { ToolBindings } from '../wireTools';
+import { DeviceFs, DeviceFsError } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    ...overrides,
+  };
+}
+
+interface DeviceFsStub {
+  readBytes?: (path: string) => Promise<Uint8Array>;
+  writeText?: (path: string, text: string) => Promise<void>;
+}
+
+function makeDeviceFs(stub: DeviceFsStub): DeviceFs {
+  return stub as unknown as DeviceFs;
+}
+
+function utf8(text: string): Uint8Array {
+  return new TextEncoder().encode(text);
+}
+
+describe('EditDeviceFileTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new EditDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('edit_device_file');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('definition makes path, old_string, and new_string required', () => {
+    const tool = new EditDeviceFileTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual([
+      'path',
+      'old_string',
+      'new_string',
+    ]);
+  });
+
+  it('returns "Device is not connected." when deviceFs is null', async () => {
+    const tool = new EditDeviceFileTool(() => makeBindings({ deviceFs: null }));
+    await expect(
+      tool.call({ path: '/main.py', old_string: 'a', new_string: 'b' }),
+    ).resolves.toBe('Device is not connected.');
+  });
+
+  it('returns "Cannot edit binary file." when the file is not valid UTF-8', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const readBytes = vi.fn().mockResolvedValue(new Uint8Array([0xff, 0xfe, 0xfd]));
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await expect(
+      tool.call({ path: '/blob.bin', old_string: 'a', new_string: 'b' }),
+    ).resolves.toBe('Cannot edit binary file.');
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('returns "old_string not found in file." when the target is absent', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const readBytes = vi.fn().mockResolvedValue(utf8('x = 1\n'));
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await expect(
+      tool.call({ path: '/main.py', old_string: 'missing', new_string: 'y' }),
+    ).resolves.toBe('old_string not found in file.');
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('returns the ambiguous error message when the target appears more than once', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const readBytes = vi.fn().mockResolvedValue(utf8('foo\nbar\nfoo\nfoo\n'));
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await expect(
+      tool.call({ path: '/main.py', old_string: 'foo', new_string: 'baz' }),
+    ).resolves.toBe(
+      'old_string is ambiguous — appears 3 times. Include more surrounding context.',
+    );
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('writes the replaced content on the unique path', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const readBytes = vi.fn().mockResolvedValue(utf8('a = 1\nb = 2\nc = 3\n'));
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await expect(
+      tool.call({ path: '/main.py', old_string: 'b = 2', new_string: 'b = 42' }),
+    ).resolves.toBe('File updated.');
+    expect(readBytes).toHaveBeenCalledWith('/main.py');
+    expect(writeText).toHaveBeenCalledWith('/main.py', 'a = 1\nb = 42\nc = 3\n');
+  });
+
+  it('handles multi-line replacements', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const readBytes = vi.fn().mockResolvedValue(utf8('def f():\n    return 1\n'));
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await expect(
+      tool.call({
+        path: '/lib/x.py',
+        old_string: 'def f():\n    return 1',
+        new_string: 'def f():\n    return 42',
+      }),
+    ).resolves.toBe('File updated.');
+    expect(writeText).toHaveBeenCalledWith(
+      '/lib/x.py',
+      'def f():\n    return 42\n',
+    );
+  });
+
+  it('does not interpret `$&` and friends in new_string', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const readBytes = vi.fn().mockResolvedValue(utf8('marker'));
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await tool.call({ path: '/p.py', old_string: 'marker', new_string: '$& $1' });
+    expect(writeText).toHaveBeenCalledWith('/p.py', '$& $1');
+  });
+
+  it('propagates DeviceFsError from readBytes', async () => {
+    const readBytes = vi.fn().mockRejectedValue(new DeviceFsError('ENOENT: /nope'));
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await expect(
+      tool.call({ path: '/nope', old_string: 'a', new_string: 'b' }),
+    ).rejects.toBeInstanceOf(DeviceFsError);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('propagates DeviceFsError from writeText', async () => {
+    const readBytes = vi.fn().mockResolvedValue(utf8('hello'));
+    const writeText = vi.fn().mockRejectedValue(new DeviceFsError('ENOSPC: full'));
+    const tool = new EditDeviceFileTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs({ readBytes, writeText }) }),
+    );
+    await expect(
+      tool.call({ path: '/main.py', old_string: 'hello', new_string: 'hi' }),
+    ).rejects.toBeInstanceOf(DeviceFsError);
+  });
+});

--- a/src/agent/tools/EditDeviceFileTool.ts
+++ b/src/agent/tools/EditDeviceFileTool.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+import { findUniqueOccurrence } from '../../lib/editApproval';
+
+export interface EditDeviceFileArgs {
+  path: string;
+  old_string: string;
+  new_string: string;
+}
+
+export class EditDeviceFileTool implements Tool<EditDeviceFileArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'edit_device_file',
+      description:
+        'Replaces a unique substring `old_string` in the UTF-8 text file at `path` on the ' +
+        'connected microcontroller with `new_string`. `old_string` must match the file contents ' +
+        'exactly (including whitespace) and must appear exactly once — include enough surrounding ' +
+        'context to disambiguate. Prefer this over `write_device_file` for any change that does ' +
+        'not rewrite the whole file. Requires user approval.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style).',
+          },
+          old_string: {
+            type: 'string',
+            description:
+              'The exact substring currently in the file to replace. Must appear exactly once.',
+          },
+          new_string: {
+            type: 'string',
+            description: 'The replacement text.',
+          },
+        },
+        required: ['path', 'old_string', 'new_string'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: EditDeviceFileArgs): Promise<string> {
+    const { deviceFs } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+
+    const bytes = await deviceFs.readBytes(args.path);
+    let source: string;
+    try {
+      source = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch (err) {
+      if (err instanceof TypeError) return 'Cannot edit binary file.';
+      throw err;
+    }
+
+    const result = findUniqueOccurrence(source, args.old_string);
+    if (result.kind === 'missing') return 'old_string not found in file.';
+    if (result.kind === 'ambiguous') {
+      return `old_string is ambiguous — appears ${result.count} times. Include more surrounding context.`;
+    }
+
+    const replaced =
+      source.slice(0, result.index) +
+      args.new_string +
+      source.slice(result.index + args.old_string.length);
+    await deviceFs.writeText(args.path, replaced);
+    return 'File updated.';
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -25,6 +25,7 @@ describe('wireTools', () => {
     const names = tools.getTools().map((t) => t.name).sort();
     expect(names).toEqual([
       'delete_device_file',
+      'edit_device_file',
       'edit_editor',
       'list_device_files',
       'make_device_dir',
@@ -42,7 +43,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(11);
+    expect(tools.getTools()).toHaveLength(12);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -7,6 +7,7 @@ import type { DeviceFs } from '../DeviceFs';
 import { ReadEditorTool } from './tools/ReadEditorTool';
 import { WriteEditorTool } from './tools/WriteEditorTool';
 import { EditEditorTool } from './tools/EditEditorTool';
+import { EditDeviceFileTool } from './tools/EditDeviceFileTool';
 import { RunEditorTool } from './tools/RunEditorTool';
 import { RunSnippetTool } from './tools/RunSnippetTool';
 import { ReadReplHistoryTool } from './tools/ReadReplHistoryTool';
@@ -53,6 +54,7 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new ListDeviceFilesTool(get));
   tools.register(new ReadDeviceFileTool(get));
   tools.register(new WriteDeviceFileTool(get));
+  tools.register(new EditDeviceFileTool(get));
   tools.register(new DeleteDeviceFileTool(get));
   tools.register(new MakeDeviceDirTool(get));
 }

--- a/src/components/CobwebApproval.tsx
+++ b/src/components/CobwebApproval.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { diffWords, type ChangeObject } from 'diff';
 import {
   InlineApproval,
@@ -18,6 +18,7 @@ interface ApprovalSlotProps {
 interface CobwebApprovalProps extends ApprovalSlotProps {
   getEditorContent: () => string;
   revealEditorRange: (from: number, to: number) => void;
+  readDeviceFile: (path: string) => Promise<string | null>;
 }
 
 export function CobwebApproval({
@@ -25,6 +26,7 @@ export function CobwebApproval({
   approval,
   getEditorContent,
   revealEditorRange,
+  readDeviceFile,
 }: CobwebApprovalProps): ReactNode {
   switch (entry.name) {
     case 'edit_editor':
@@ -32,8 +34,18 @@ export function CobwebApproval({
         <EditApprovalCard
           entry={entry}
           approval={approval}
-          getEditorContent={getEditorContent}
-          revealEditorRange={revealEditorRange}
+          surface="editor"
+          headerLabel={<>Edit editor</>}
+          source={getEditorContent()}
+          revealRange={revealEditorRange}
+        />
+      );
+    case 'edit_device_file':
+      return (
+        <DeviceEditApprovalLoader
+          entry={entry}
+          approval={approval}
+          readDeviceFile={readDeviceFile}
         />
       );
     case 'write_editor':
@@ -50,27 +62,119 @@ export function CobwebApproval({
   }
 }
 
+// ----- DeviceEditApprovalLoader ---------------------------------------------
+
+interface DeviceEditApprovalLoaderProps extends ApprovalSlotProps {
+  readDeviceFile: (path: string) => Promise<string | null>;
+}
+
+function DeviceEditApprovalLoader({
+  entry,
+  approval,
+  readDeviceFile,
+}: DeviceEditApprovalLoaderProps): ReactNode {
+  const args = entry.args as { path?: unknown } | undefined;
+  const path = typeof args?.path === 'string' ? args.path : '';
+
+  type LoadState =
+    | { kind: 'loading' }
+    | { kind: 'loaded'; source: string }
+    | { kind: 'failed' };
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    readDeviceFile(path).then((source) => {
+      if (cancelled) return;
+      if (source === null) {
+        setState({ kind: 'failed' });
+      } else {
+        setState({ kind: 'loaded', source });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [path, readDeviceFile]);
+
+  const headerLabel = (
+    <>
+      Edit <code>{path}</code>
+    </>
+  );
+
+  if (state.kind === 'loading') {
+    return (
+      <div className="cobweb-approval-card" data-tool-name={entry.name}>
+        <div className="cobweb-approval-header">
+          <span className="cobweb-approval-title">{headerLabel}</span>
+          <span className="cobweb-approval-status">requires approval</span>
+        </div>
+        <div className="cobweb-approval-notice">
+          <p>Loading file…</p>
+        </div>
+        <ApprovalActions
+          approveDisabled
+          onApprove={approval.approve}
+          onReject={approval.reject}
+        />
+      </div>
+    );
+  }
+
+  if (state.kind === 'failed') {
+    return (
+      <div className="cobweb-approval-card" data-tool-name={entry.name}>
+        <div className="cobweb-approval-header">
+          <span className="cobweb-approval-title">{headerLabel}</span>
+          <span className="cobweb-approval-status">requires approval</span>
+        </div>
+        <NoLongerAppliesNotice
+          message="Cannot edit binary file."
+          respondMessage="Cannot edit binary file."
+          onRespondWith={approval.respondWith}
+        />
+        <ApprovalActions
+          approveDisabled
+          onApprove={approval.approve}
+          onReject={approval.reject}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <EditApprovalCard
+      entry={entry}
+      approval={approval}
+      surface="file"
+      headerLabel={headerLabel}
+      source={state.source}
+    />
+  );
+}
+
 // ----- EditApprovalCard ------------------------------------------------------
 
 interface EditApprovalCardProps extends ApprovalSlotProps {
-  getEditorContent: () => string;
-  revealEditorRange: (from: number, to: number) => void;
+  source: string;
+  surface: 'editor' | 'file';
+  headerLabel: ReactNode;
+  revealRange?: (from: number, to: number) => void;
 }
 
 function EditApprovalCard({
   entry,
   approval,
-  getEditorContent,
-  revealEditorRange,
+  source,
+  surface,
+  headerLabel,
+  revealRange,
 }: EditApprovalCardProps): ReactNode {
   const args = entry.args as { old_string?: unknown; new_string?: unknown } | undefined;
   const oldString = typeof args?.old_string === 'string' ? args.old_string : '';
   const newString = typeof args?.new_string === 'string' ? args.new_string : '';
 
-  // Diff against the live editor — the buffer the user sees right now is the
-  // buffer the edit will apply to, so the renderer must read fresh on every
-  // render rather than caching at construction time.
-  const source = getEditorContent();
   const find = useMemo(
     () => findUniqueOccurrence(source, oldString),
     [source, oldString],
@@ -84,21 +188,32 @@ function EditApprovalCard({
   useEffect(() => {
     if (didReveal.current) return;
     if (find.kind !== 'unique') return;
+    if (!revealRange) return;
     didReveal.current = true;
-    revealEditorRange(find.index, find.index + oldString.length);
-  }, [find, oldString.length, revealEditorRange]);
+    revealRange(find.index, find.index + oldString.length);
+  }, [find, oldString.length, revealRange]);
+
+  const surfaceWord = surface === 'editor' ? 'editor' : 'file';
+  const missingNotice = `old_string was not found in the current ${surfaceWord} — the ${
+    surface === 'editor' ? 'buffer' : 'file'
+  } may have changed since the agent proposed this edit.`;
+  const missingRespond = `old_string not found in ${surfaceWord}.`;
+  const ambiguousNotice = (count: number) =>
+    `old_string is now ambiguous — it appears ${count} times in the current ${surfaceWord}.`;
+  const ambiguousRespond = (count: number) =>
+    `old_string is ambiguous — appears ${count} times. Include more surrounding context.`;
 
   return (
     <div className="cobweb-approval-card" data-tool-name={entry.name}>
       <div className="cobweb-approval-header">
-        <span className="cobweb-approval-title">Edit editor</span>
+        <span className="cobweb-approval-title">{headerLabel}</span>
         <div className="cobweb-approval-header-actions">
-          {find.kind === 'unique' && (
+          {find.kind === 'unique' && revealRange && (
             <button
               type="button"
               className="cobweb-reveal-button"
               onClick={() =>
-                revealEditorRange(find.index, find.index + oldString.length)
+                revealRange(find.index, find.index + oldString.length)
               }
               title="Scroll editor to this location"
             >
@@ -118,14 +233,14 @@ function EditApprovalCard({
         />
       ) : find.kind === 'missing' ? (
         <NoLongerAppliesNotice
-          message="old_string was not found in the current editor — the buffer may have changed since the agent proposed this edit."
-          respondMessage="old_string not found in editor."
+          message={missingNotice}
+          respondMessage={missingRespond}
           onRespondWith={approval.respondWith}
         />
       ) : (
         <NoLongerAppliesNotice
-          message={`old_string is now ambiguous — it appears ${find.count} times in the current editor.`}
-          respondMessage={`old_string is ambiguous — appears ${find.count} times. Include more surrounding context.`}
+          message={ambiguousNotice(find.count)}
+          respondMessage={ambiguousRespond(find.count)}
           onRespondWith={approval.respondWith}
         />
       )}

--- a/src/components/makeCobwebApproval.tsx
+++ b/src/components/makeCobwebApproval.tsx
@@ -7,6 +7,7 @@ import { CobwebApproval } from './CobwebApproval';
 export function makeCobwebApproval(
   getEditorContent: () => string,
   revealEditorRange: (from: number, to: number) => void,
+  readDeviceFile: (path: string) => Promise<string | null>,
 ): RenderApproval {
   return (entry, approval) => (
     <CobwebApproval
@@ -14,6 +15,7 @@ export function makeCobwebApproval(
       approval={approval}
       getEditorContent={getEditorContent}
       revealEditorRange={revealEditorRange}
+      readDeviceFile={readDeviceFile}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Adds `EditDeviceFileTool` — uniqueness-based find/replace against UTF-8 device files, mirroring `edit_editor`. Reads via `deviceFs.readBytes`, decodes UTF-8 fatal (returns `Cannot edit binary file.` on `TypeError`), writes via `deviceFs.writeText`. Returns `Device is not connected.` when the device is offline.
- Routes `edit_device_file` through the existing approval pipeline. `<CobwebApproval>` now wraps device edits in a loader that calls `readDeviceFile(path)`, shows a loading state, and forwards the resolved source to the same `<EditApprovalCard>` used by `edit_editor`. `null` from `readDeviceFile` (binary or read error) renders a "Cannot edit binary file." notice with Reject + ""Tell the agent"".
- Updates `CODING_AGENT.tools` and the partial-edit guidance paragraph to mention `edit_device_file` alongside `edit_editor`.

Closes #128.

## Implementation notes

- **`<EditApprovalCard>` factoring.** Extracted `source: string`, `headerLabel: ReactNode`, `surface: 'editor' | 'file'`, and an optional `revealRange` prop. The editor path passes a synchronous `getEditorContent()` and the existing `revealRange` callback; the device path freezes the source at load time and omits reveal (no device-side reveal primitive in this PR). `surface` drives the missing/ambiguous wording — ""in editor"" vs ""in file"" — and the respond-with strings the tool itself returns post-approval.
- **`<DeviceEditApprovalLoader>`.** Async wrapper that reads the file once on mount via the closure passed from `App.tsx` (which does `deviceReadBytes` + UTF-8-fatal decode and collapses binary + read errors to `null` per SPEC). The loading state shows ""Loading file…"" with Approve disabled.
- **Header.** ""Edit `<path>`"" for device edits, ""Edit editor"" for editor edits — matches the SPEC §""`EditApprovalCard`"".
- **`new_string` literal.** Tool body builds the replacement via `slice + concat + slice` rather than `String.prototype.replace` so `\$&` / `\$1` in `new_string` aren't reinterpreted as backrefs. Covered by a regression test.

## Out of scope (per #128)

- `write_device_file` / `delete_device_file` / `make_device_dir` confirmation cards (#129).
- `multi_edit_device_file` (#134).

## Test plan

- [x] `npm run lint` clean
- [x] `npm run test` 441/441 passing (added 11, updated 2 in `wireTools.test.ts`)
- [x] `npm run build` clean
- [x] Manual browser test against a real Pico (confirmed): asking the agent to tweak an existing file on the device triggers `edit_device_file`; the conversation panel shows ""Loading file…"" briefly, then a focused word-level diff against the live device contents; Approve writes via `DeviceFs.writeText`; Reject leaves the file untouched.