### PR TITLE
feat(agent-tools): stop_program tool + toolbar Stop button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -270,6 +270,7 @@ export function App() {
     getReplHistory: () => replHistory,
     onData,
     deviceFs,
+    sendInterrupt: () => send('\x03'),
   });
 
   const runner = useMemo(() => {
@@ -347,6 +348,7 @@ export function App() {
             // promise rejection.
             runCode(getContent()).catch((err) => console.error('Run failed:', err));
           }}
+          onStop={() => send('\x03')}
           onSave={handleSaveClick}
           saveEnabled={origin.kind !== 'device' || deviceFsHook.isAvailable}
           onOpenSettings={() => setIsSettingsOpen(true)}

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -16,7 +16,8 @@ For short evaluations whose output you need back (sensor reads, expression eval,
 To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.
 To change an existing file on the device, you MUST use edit_device_file — same old_string/new_string contract as edit_editor. For multiple changes to the same device file, call edit_device_file once per change. Do not use write_device_file for edits. write_device_file is only permitted for brand-new device files or explicit full rewrites. Prefer edit_editor or write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
 To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.
-To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.`,
+To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.
+Use stop_program to send Ctrl+C and interrupt a running program.`,
   tools: [
     'read_editor',
     'write_editor',
@@ -30,5 +31,6 @@ To create a directory on the device, use make_device_dir. The parent directory m
     'edit_device_file',
     'delete_device_file',
     'make_device_dir',
+    'stop_program',
   ],
 });

--- a/src/agent/tools/StopProgramTool.test.ts
+++ b/src/agent/tools/StopProgramTool.test.ts
@@ -1,0 +1,50 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { StopProgramTool } from './StopProgramTool';
+import type { ToolBindings } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    sendInterrupt: () => {},
+    ...overrides,
+  };
+}
+
+describe('StopProgramTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new StopProgramTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('stop_program');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('calls sendInterrupt and returns "Interrupt sent."', async () => {
+    const sendInterrupt = vi.fn();
+    const tool = new StopProgramTool(() => makeBindings({ sendInterrupt }));
+    const result = await tool.call();
+    expect(sendInterrupt).toHaveBeenCalledOnce();
+    expect(result).toBe('Interrupt sent.');
+  });
+
+  it('reads bindings lazily via the getter', async () => {
+    const sendInterrupt = vi.fn();
+    let bindings = makeBindings({ sendInterrupt: () => {} });
+    const tool = new StopProgramTool(() => bindings);
+    await tool.call();
+    expect(sendInterrupt).not.toHaveBeenCalled();
+
+    bindings = makeBindings({ sendInterrupt });
+    await tool.call();
+    expect(sendInterrupt).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agent/tools/StopProgramTool.ts
+++ b/src/agent/tools/StopProgramTool.ts
@@ -1,0 +1,29 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+export class StopProgramTool implements Tool<Record<string, never>, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'stop_program',
+      description:
+        'Sends a keyboard interrupt (Ctrl+C) to the connected device, stopping any running program and returning to the REPL prompt. Use this to stop a program started with run_editor or a snippet that is still running.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: false,
+    };
+  }
+
+  async call(): Promise<string> {
+    this.getBindings().sendInterrupt();
+    return 'Interrupt sent.';
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -14,6 +14,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     getReplHistory: () => [],
     onData: () => () => {},
     deviceFs: null,
+    sendInterrupt: () => {},
     ...overrides,
   };
 }
@@ -34,6 +35,7 @@ describe('wireTools', () => {
       'read_repl_history',
       'run_editor',
       'run_snippet',
+      'stop_program',
       'write_device_file',
       'write_editor',
     ]);
@@ -43,7 +45,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(12);
+    expect(tools.getTools()).toHaveLength(13);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -16,6 +16,7 @@ import { ReadDeviceFileTool } from './tools/ReadDeviceFileTool';
 import { WriteDeviceFileTool } from './tools/WriteDeviceFileTool';
 import { DeleteDeviceFileTool } from './tools/DeleteDeviceFileTool';
 import { MakeDeviceDirTool } from './tools/MakeDeviceDirTool';
+import { StopProgramTool } from './tools/StopProgramTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -29,6 +30,7 @@ export interface ToolBindings {
   getReplHistory(): string[];
   onData(handler: (data: Uint8Array) => void): () => void;
   deviceFs: DeviceFs | null;
+  sendInterrupt(): void;
 }
 
 const REGISTERED = new WeakSet<ToolRegistry>();
@@ -57,4 +59,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new EditDeviceFileTool(get));
   tools.register(new DeleteDeviceFileTool(get));
   tools.register(new MakeDeviceDirTool(get));
+  tools.register(new StopProgramTool(get));
 }

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 // Copyright 2026 Andre Cipriani Bandarra
 // SPDX-License-Identifier: Apache-2.0
 
-import { Monitor, Moon, Play, Plug, RotateCcw, Save, Settings, Sun, Unplug } from 'lucide-react';
+import { Monitor, Moon, Play, Plug, RotateCcw, Save, Settings, Square, Sun, Unplug } from 'lucide-react';
 
 type ConnectionState = 'disconnected' | 'connected';
 type ThemePreference = 'light' | 'dark' | 'system';
@@ -12,6 +12,7 @@ interface ToolbarProps {
   onDisconnect: () => void;
   onReset: () => void;
   onRun: () => void;
+  onStop: () => void;
   onSave: () => void;
   saveEnabled: boolean;
   onOpenSettings: () => void;
@@ -37,6 +38,7 @@ export function Toolbar({
   onDisconnect,
   onReset,
   onRun,
+  onStop,
   onSave,
   saveEnabled,
   onOpenSettings,
@@ -58,7 +60,7 @@ export function Toolbar({
           <button
             onClick={onDisconnect}
             title="Disconnect"
-            className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors text-green-600 dark:text-green-400"
+            className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent active:opacity-75 transition-colors text-green-600 dark:text-green-400"
           >
             <Unplug size={14} />
             Disconnect
@@ -67,7 +69,7 @@ export function Toolbar({
           <button
             onClick={onConnect}
             title="Connect to device"
-            className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors"
+            className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent active:opacity-75 transition-colors"
           >
             <Plug size={14} />
             Connect
@@ -78,7 +80,7 @@ export function Toolbar({
           onClick={onReset}
           disabled={!connected}
           title="Reset device"
-          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent active:opacity-75 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <RotateCcw size={14} />
           Reset
@@ -88,17 +90,27 @@ export function Toolbar({
           onClick={onRun}
           disabled={!connected}
           title="Run current file"
-          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm bg-primary text-primary-foreground hover:bg-primary/90 active:opacity-75 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <Play size={14} />
           Run
         </button>
 
         <button
+          onClick={onStop}
+          disabled={!connected}
+          title="Stop running program"
+          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent active:opacity-75 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          <Square size={14} />
+          Stop
+        </button>
+
+        <button
           onClick={onSave}
           disabled={!saveEnabled}
           title={`Save (${SAVE_SHORTCUT_LABEL})`}
-          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          className="flex items-center gap-1.5 px-2 py-1 rounded text-sm hover:bg-accent active:opacity-75 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
         >
           <Save size={14} />
           Save
@@ -110,7 +122,7 @@ export function Toolbar({
       <button
         onClick={onCycleTheme}
         title={THEME_LABEL[themePreference]}
-        className="p-1.5 rounded hover:bg-accent transition-colors"
+        className="p-1.5 rounded hover:bg-accent active:opacity-75 transition-colors"
       >
         <ThemeIcon size={14} />
       </button>
@@ -118,7 +130,7 @@ export function Toolbar({
       <button
         onClick={onOpenSettings}
         title="Settings"
-        className="p-1.5 rounded hover:bg-accent transition-colors"
+        className="p-1.5 rounded hover:bg-accent active:opacity-75 transition-colors"
       >
         <Settings size={14} />
       </button>


### PR DESCRIPTION
## Summary

- Adds `StopProgramTool` (`stop_program`) — sends Ctrl+C via a new `sendInterrupt` binding, `scope: 'write'`, no approval required
- Adds a Stop button to the Toolbar immediately after Run, disabled when disconnected, backed by the same `send('\x03')` path
- Fixes missing `active:opacity-75` on all toolbar buttons so clicks give visual feedback (existing bug)

## Implementation notes

- `sendInterrupt: () => void` added to `ToolBindings` and wired in `App.tsx` to `() => send('\x03')`, the same `send` already used for REPL input
- `wireTools.test.ts` updated to include `sendInterrupt` in the stub bindings and account for the 13th registered tool

## Test plan

- [ ] Connect to a device — Stop button appears enabled, disabled when disconnected
- [ ] Run a long-running program, click Stop — Ctrl+C interrupts it and returns to REPL prompt
- [ ] Ask the agent to `stop_program` — it calls the tool without an approval prompt
- [ ] Click any toolbar button — brief opacity dip confirms click feedback works

Closes #142