### PR TITLE
fix(agent-panel): improve chat layout

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -169,6 +169,22 @@
   }
 }
 
+/* ---------- mast-ai layout overrides ---------- */
+
+.mast-message-list {
+    padding: 8px;
+    border-radius: 0;
+}
+
+[data-mast-chat-input] {
+    border-radius: 0;
+    padding: 8px;
+}
+
+.mast-chat-input-textarea {
+    min-height: calc(4 * 1.5em);
+}
+
 /* ---------- Cobweb tool-approval cards ---------- */
 
 .cobweb-approval-card {


### PR DESCRIPTION
## Summary

- Add 8px padding to the message list and chat input wrapper
- Remove rounded corners from message list and chat input wrapper (looked out of place in the panel)
- Set `min-height` on the textarea to show ~4 rows by default instead of 1