### PR TITLE
feat(agent-tools): add get_board_info tool

### DIFF
--- a/docs/agent-tools/SPEC.md
+++ b/docs/agent-tools/SPEC.md
@@ -55,63 +55,72 @@ In `App.tsx`:
 
 ---
 
-## 2. Board context injection
+## 2. `get_board_info` tool
+
+Rather than probing the board at connect time and injecting the result into the system prompt, board information is exposed as a tool the agent can call on demand. This avoids connect-time latency and system prompt bloat for sessions where board context is never needed.
 
 ### Probe snippet
 
-Run once after connect (short timeout, e.g. 5 s):
 ```python
-import sys,gc;print(sys.implementation.name,sys.implementation.version,sys.platform,gc.mem_free())
+import sys,gc,os;print(sys.implementation.name,sys.implementation.version,sys.platform,gc.mem_free());print(os.uname().machine)
 ```
 
-Expected stdout: `micropython (1, 23, 0, '') rp2 200000` (fields space-separated; version is a Python tuple repr).
-
-### `BoardInfo` type
-
-```ts
-interface BoardInfo {
-  name: string;      // e.g. "micropython"
-  version: string;   // e.g. "1.23.0" (dots joined from tuple prefix)
-  platform: string;  // e.g. "rp2"
-  freeRam: number;   // bytes
-}
+Expected stdout (two lines):
+```
+micropython (1, 26, 0, '') rp2 7633920
+Presto with RP2350
 ```
 
-### `probeBoard` utility — `src/agent/probeBoard.ts`
+Line 1: firmware fields space-separated; version is a Python tuple repr. Line 2: machine name from `os.uname().machine` (may contain spaces).
 
-```ts
-async function probeBoard(
-  runCode: (code: string) => Promise<{ stdout: string; stderr: string }>
-): Promise<BoardInfo | null>
-```
+### `GetBoardInfoTool` — `src/agent/tools/GetBoardInfoTool.ts`
 
-Parses stdout by splitting on spaces and extracting fields. The version tuple `(1, 23, 0, '')` is parsed by stripping parens, splitting on `, `, taking numeric elements, and joining with `.`. Returns `null` on any parse failure, timeout, or non-empty stderr.
+**`ToolDefinition`:**
+- `name: 'get_board_info'`
+- `scope: 'read'`
+- `requiresApproval: false`
+- Description: `"Queries the connected MicroPython board for its firmware version, platform, and available RAM. Call this at the start of a session to understand what board you are working with."`
+- Args: `{}` (none)
 
-### Dynamic agent instructions — `config.ts`
+**`call()` body:**
+1. Run the probe snippet via `bindings.runCode(PROBE_SNIPPET)` with a 5 s timeout.
+2. If timeout → return `'Board info unavailable: probe timed out.'`
+3. If `stderr` is non-empty → return `` `Board info unavailable: ${stderr.trim()}` ``
+4. Split stdout by `\n`, trim and filter blank lines. Parse line 1 with `/^(\S+)\s+\(([^)]+)\)\s+(\S+)\s+(\d+)$/`:
+   - `name` = group 1
+   - `version` = group 2 split on `', '`, numeric parts only, joined with `.`
+   - `platform` = group 3
+   - `freeRamKb` = `Math.round(parseInt(group 4) / 1024)`
+   - `machine` = line 2 if present, otherwise `undefined`
+5. If line 1 parse fails → return `'Board info unavailable: unexpected probe output.'`
+6. `boardLabel = machine ?? \`${name} on ${platform}\``
+7. Return `` `Connected board: ${boardLabel} (${name} ${version}, free RAM: ~${freeRamKb} KB)` ``
 
-Replace the `CODING_AGENT` constant with a `createCodingAgent(boardInfo?: BoardInfo | null)` factory function. When `boardInfo` is provided, prepend a one-line preamble to `instructions`:
+**Timeout:** 5 000 ms (well below `ReplInterface.sendRaw`'s 30 s default).
 
-```
-Connected board: micropython 1.23.0 on rp2 (free RAM: ~195 KB)
-```
+### `config.ts` instructions update
 
-`App.tsx` passes `createCodingAgent(boardInfo)` as the `agent` prop, memoised on `boardInfo`.
+Add `'get_board_info'` to the `tools` list. Add one sentence to `instructions`: `"Use get_board_info to learn the board's firmware version, platform, and available RAM before writing board-specific code."`
 
-### `App.tsx` wiring
+### Tests — `GetBoardInfoTool.test.ts`
 
-- Add `boardInfo` state: `const [boardInfo, setBoardInfo] = useState<BoardInfo | null>(null)`.
-- `useEffect` on `connectionState`: when it becomes `'connected'`, call `probeBoard(runCode).then(setBoardInfo)`; when it becomes `'disconnected'`, call `setBoardInfo(null)`.
-- `const agent = useMemo(() => createCodingAgent(boardInfo), [boardInfo])` — pass as `agent={agent}` to `<AgentProvider>`.
+- Both lines present → `'Connected board: Presto with RP2350 (micropython 1.26.0, free RAM: ~7455 KB)'`
+- Machine line absent → falls back to `name on platform` in board label
+- Malformed stdout → `'Board info unavailable: unexpected probe output.'`
+- Empty stdout → `'Board info unavailable: unexpected probe output.'`
+- Non-empty stderr → `'Board info unavailable: ...'`
+- Timeout (fake timers, advance 5 000 ms) → `'Board info unavailable: probe timed out.'`
+- Abort signal fires → rejects
 
 ### File map
 
 **Add:**
-- `src/agent/probeBoard.ts`
-- `src/agent/probeBoard.test.ts`
+- `src/agent/tools/GetBoardInfoTool.ts`
+- `src/agent/tools/GetBoardInfoTool.test.ts`
 
 **Modify:**
-- `src/agent/config.ts` — `CODING_AGENT` → `createCodingAgent(boardInfo?)` factory
-- `src/App.tsx` — board probe effect; `boardInfo` state; memoised `agent`
+- `src/agent/wireTools.ts` — register `GetBoardInfoTool`
+- `src/agent/config.ts` — add `'get_board_info'` to tools list; add instruction sentence
 
 ---
 
@@ -257,7 +266,7 @@ Add or update `src/agent/tools/RunSnippetTool.test.ts`:
 | Issue | Title | Files added | Files modified |
 |-------|-------|-------------|----------------|
 | A | `stop_program` tool + toolbar Stop button | `StopProgramTool.ts`, `.test.ts` | `wireTools.ts`, `config.ts`, `Toolbar.tsx`, `App.tsx` |
-| B | Board context injection | `probeBoard.ts`, `.test.ts` | `config.ts`, `App.tsx` |
+| B | `get_board_info` tool | `GetBoardInfoTool.ts`, `.test.ts` | `wireTools.ts`, `config.ts` |
 | C | `open_device_file_in_editor` + `save_editor_to_device` | 4 tool + test files | `wireTools.ts`, `config.ts`, `CobwebApproval.tsx` |
 | D | Structured `run_snippet` output | — | `RunSnippetTool.ts` |
 

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -17,7 +17,8 @@ To inspect the device's filesystem (e.g. to confirm what's on the board before w
 To change an existing file on the device, you MUST use edit_device_file — same old_string/new_string contract as edit_editor. For multiple changes to the same device file, call edit_device_file once per change. Do not use write_device_file for edits. write_device_file is only permitted for brand-new device files or explicit full rewrites. Prefer edit_editor or write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
 To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.
 To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.
-Use stop_program to send Ctrl+C and interrupt a running program.`,
+Use stop_program to send Ctrl+C and interrupt a running program.
+Use get_board_info to learn the board's firmware version, platform, and available RAM before writing board-specific code.`,
   tools: [
     'read_editor',
     'write_editor',
@@ -32,5 +33,6 @@ Use stop_program to send Ctrl+C and interrupt a running program.`,
     'delete_device_file',
     'make_device_dir',
     'stop_program',
+    'get_board_info',
   ],
 });

--- a/src/agent/tools/GetBoardInfoTool.test.ts
+++ b/src/agent/tools/GetBoardInfoTool.test.ts
@@ -1,0 +1,127 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { GetBoardInfoTool } from './GetBoardInfoTool';
+import type { ToolBindings } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    sendInterrupt: () => {},
+    ...overrides,
+  };
+}
+
+describe('GetBoardInfoTool', () => {
+  it('definition has correct name, scope, and no approval required', () => {
+    const tool = new GetBoardInfoTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('get_board_info');
+    expect(def.scope).toBe('read');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('returns formatted board info with machine name when both lines are present', async () => {
+    const tool = new GetBoardInfoTool(
+      () =>
+        makeBindings({
+          runCode: async () => ({
+            stdout: "micropython (1, 26, 0, '') rp2 7633920\nPresto with RP2350\n",
+            stderr: '',
+          }),
+        }),
+    );
+    const result = await tool.call({}, {});
+    expect(result).toBe('Connected board: Presto with RP2350 (micropython 1.26.0, free RAM: ~7455 KB)');
+  });
+
+  it('falls back to name+platform when machine line is absent', async () => {
+    const tool = new GetBoardInfoTool(
+      () =>
+        makeBindings({
+          runCode: async () => ({
+            stdout: "micropython (1, 23, 0, '') rp2 200000\n",
+            stderr: '',
+          }),
+        }),
+    );
+    const result = await tool.call({}, {});
+    expect(result).toBe('Connected board: micropython on rp2 (micropython 1.23.0, free RAM: ~195 KB)');
+  });
+
+  it('returns error for malformed stdout', async () => {
+    const tool = new GetBoardInfoTool(
+      () => makeBindings({ runCode: async () => ({ stdout: 'not valid output\n', stderr: '' }) }),
+    );
+    const result = await tool.call({}, {});
+    expect(result).toBe('Board info unavailable: unexpected probe output.');
+  });
+
+  it('returns error for empty stdout', async () => {
+    const tool = new GetBoardInfoTool(
+      () => makeBindings({ runCode: async () => ({ stdout: '', stderr: '' }) }),
+    );
+    const result = await tool.call({}, {});
+    expect(result).toBe('Board info unavailable: unexpected probe output.');
+  });
+
+  it('returns error when stderr is non-empty', async () => {
+    const tool = new GetBoardInfoTool(
+      () => makeBindings({ runCode: async () => ({ stdout: '', stderr: 'ImportError: no module named gc\n' }) }),
+    );
+    const result = await tool.call({}, {});
+    expect(result).toBe('Board info unavailable: ImportError: no module named gc');
+  });
+
+  it('rejects when the abort signal fires before runCode resolves', async () => {
+    const controller = new AbortController();
+    let neverResolve!: () => void;
+    const tool = new GetBoardInfoTool(
+      () =>
+        makeBindings({
+          runCode: () =>
+            new Promise((res) => {
+              neverResolve = () => res({ stdout: '', stderr: '' });
+            }),
+        }),
+    );
+    const promise = tool.call({}, { signal: controller.signal });
+    controller.abort();
+    await expect(promise).rejects.toThrow('aborted');
+    neverResolve();
+  });
+
+  describe('with fake timers', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('returns timed-out message after 5 000 ms', async () => {
+      let release!: () => void;
+      const tool = new GetBoardInfoTool(
+        () =>
+          makeBindings({
+            runCode: () =>
+              new Promise((resolve) => {
+                release = () => resolve({ stdout: '', stderr: '' });
+              }),
+          }),
+      );
+      const promise = tool.call({}, {});
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await promise;
+      expect(result).toBe('Board info unavailable: probe timed out.');
+      release();
+    });
+  });
+});

--- a/src/agent/tools/GetBoardInfoTool.ts
+++ b/src/agent/tools/GetBoardInfoTool.ts
@@ -1,0 +1,71 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolContext, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+
+const PROBE_SNIPPET =
+  "import sys,gc,os;print(sys.implementation.name,sys.implementation.version,sys.platform,gc.mem_free());print(os.uname().machine)";
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+function parseOutput(stdout: string): string | null {
+  const lines = stdout.trim().split('\n').map((l) => l.trim()).filter(Boolean);
+  const m = lines[0]?.match(/^(\S+)\s+\(([^)]+)\)\s+(\S+)\s+(\d+)$/);
+  if (!m) return null;
+  const [, name, versionTuple, platform, ramStr] = m;
+  const version = versionTuple
+    .split(', ')
+    .filter((p) => /^\d+$/.test(p))
+    .join('.');
+  const freeRamKb = Math.round(parseInt(ramStr, 10) / 1024);
+  const machine = lines[1];
+  const boardLabel = machine ?? `${name} on ${platform}`;
+  return `Connected board: ${boardLabel} (${name} ${version}, free RAM: ~${freeRamKb} KB)`;
+}
+
+export class GetBoardInfoTool implements Tool<Record<string, never>, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'get_board_info',
+      description:
+        'Queries the connected MicroPython board for its firmware version, platform, and available RAM. ' +
+        'Call this at the start of a session to understand what board you are working with.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      scope: 'read',
+      requiresApproval: false,
+    };
+  }
+
+  async call(_args: Record<string, never>, ctx: ToolContext): Promise<string> {
+    const run = this.getBindings().runCode(PROBE_SNIPPET);
+    const aborted = new Promise<never>((_, reject) => {
+      const onAbort = () => reject(new Error('aborted'));
+      if (ctx.signal?.aborted) {
+        onAbort();
+        return;
+      }
+      ctx.signal?.addEventListener('abort', onAbort, { once: true });
+    });
+    const timeout = new Promise<'timeout'>((resolve) =>
+      setTimeout(() => resolve('timeout'), PROBE_TIMEOUT_MS),
+    );
+
+    const outcome = await Promise.race([run, timeout, aborted]);
+    if (outcome === 'timeout') {
+      run.catch(() => {});
+      return 'Board info unavailable: probe timed out.';
+    }
+    const { stdout, stderr } = outcome;
+    if (stderr) return `Board info unavailable: ${stderr.trim()}`;
+    const result = parseOutput(stdout);
+    if (!result) return 'Board info unavailable: unexpected probe output.';
+    return result;
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -28,6 +28,7 @@ describe('wireTools', () => {
       'delete_device_file',
       'edit_device_file',
       'edit_editor',
+      'get_board_info',
       'list_device_files',
       'make_device_dir',
       'read_device_file',
@@ -45,7 +46,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(13);
+    expect(tools.getTools()).toHaveLength(14);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -17,6 +17,7 @@ import { WriteDeviceFileTool } from './tools/WriteDeviceFileTool';
 import { DeleteDeviceFileTool } from './tools/DeleteDeviceFileTool';
 import { MakeDeviceDirTool } from './tools/MakeDeviceDirTool';
 import { StopProgramTool } from './tools/StopProgramTool';
+import { GetBoardInfoTool } from './tools/GetBoardInfoTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -60,4 +61,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new DeleteDeviceFileTool(get));
   tools.register(new MakeDeviceDirTool(get));
   tools.register(new StopProgramTool(get));
+  tools.register(new GetBoardInfoTool(get));
 }


### PR DESCRIPTION
## Summary

- Adds a `get_board_info` tool the agent can call on demand to query the connected board's firmware version, platform, machine name, and available RAM
- Uses a two-line probe: line 1 captures `sys.implementation` + `gc.mem_free()`, line 2 captures `os.uname().machine` (handles board names with spaces like "Presto with RP2350")
- Returns e.g. `Connected board: Presto with RP2350 (micropython 1.26.0, free RAM: ~7455 KB)`

## Design note

The original spec (#143) called for a connect-time probe that injected board info into the system prompt. This PR uses a tool instead — the agent pays one tool call the first time it needs board context, avoiding connect-time latency and system prompt tokens for sessions where board details are never needed. Issue comment: https://github.com/andreban/cobweb/issues/143#issuecomment-4406036852

## Test plan

- [x] `npm run test` — 452 tests pass
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Manual: connected Pimoroni Presto, called `get_board_info` from agent panel, confirmed output matches expected format

Closes #143