### PR TITLE
feat(agent-tools): add open_device_file_in_editor and save_editor_to_device

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { AgentProvider } from '@mast-ai/react-ui';
+import { AgentProvider, INLINE_APPROVAL } from '@mast-ai/react-ui';
 import { AgentRunner } from '@mast-ai/core';
 import { SplitPane } from './components/SplitPane';
 import { StatusBar } from './components/StatusBar';
@@ -330,6 +330,16 @@ export function App() {
     <AgentProvider
       runner={runner}
       agent={CODING_AGENT}
+      onApprovalRequired={async (toolCall) => {
+        if (
+          (toolCall.name === 'open_device_file_in_editor' ||
+            toolCall.name === 'save_editor_to_device') &&
+          deviceFs === null
+        ) {
+          return 'Device is not connected.';
+        }
+        return INLINE_APPROVAL;
+      }}
       onConversationChange={(history, entries) => {
         localStorage.setItem('cobweb:conversation', JSON.stringify({ history, entries }));
       }}

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -18,7 +18,8 @@ To change an existing file on the device, you MUST use edit_device_file — same
 To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.
 To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.
 Use stop_program to send Ctrl+C and interrupt a running program.
-Use get_board_info to learn the board's firmware version, platform, and available RAM before writing board-specific code.`,
+Use get_board_info to learn the board's firmware version, platform, and available RAM before writing board-specific code.
+Use open_device_file_in_editor to open a device file in the editor in one step (instead of read_device_file + write_editor). Use save_editor_to_device to save the editor buffer to a device path in one step (instead of read_editor + write_device_file).`,
   tools: [
     'read_editor',
     'write_editor',
@@ -34,5 +35,7 @@ Use get_board_info to learn the board's firmware version, platform, and availabl
     'make_device_dir',
     'stop_program',
     'get_board_info',
+    'open_device_file_in_editor',
+    'save_editor_to_device',
   ],
 });

--- a/src/agent/tools/OpenDeviceFileInEditorTool.test.ts
+++ b/src/agent/tools/OpenDeviceFileInEditorTool.test.ts
@@ -1,0 +1,113 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { OpenDeviceFileInEditorTool } from './OpenDeviceFileInEditorTool';
+import type { ToolBindings } from '../wireTools';
+import { DeviceFs, DeviceFsError } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    sendInterrupt: () => {},
+    ...overrides,
+  };
+}
+
+function makeDeviceFs(readBytes: (path: string) => Promise<Uint8Array>): DeviceFs {
+  return { readBytes } as unknown as DeviceFs;
+}
+
+const encoder = new TextEncoder();
+
+describe('OpenDeviceFileInEditorTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new OpenDeviceFileInEditorTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('open_device_file_in_editor');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('definition makes path required', () => {
+    const tool = new OpenDeviceFileInEditorTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual(['path']);
+  });
+
+  it('returns a clear message when deviceFs is null', async () => {
+    const tool = new OpenDeviceFileInEditorTool(() => makeBindings({ deviceFs: null }));
+    await expect(tool.call({ path: '/main.py' })).resolves.toBe('Device is not connected.');
+  });
+
+  it('does not call setEditorContent when device is not connected', async () => {
+    const setEditorContent = vi.fn();
+    const tool = new OpenDeviceFileInEditorTool(() =>
+      makeBindings({ deviceFs: null, setEditorContent }),
+    );
+    await tool.call({ path: '/main.py' });
+    expect(setEditorContent).not.toHaveBeenCalled();
+  });
+
+  it('reads file, loads into editor, returns success message', async () => {
+    const code = 'print("hello")\n';
+    const readBytes = vi.fn().mockResolvedValue(encoder.encode(code));
+    const setEditorContent = vi.fn();
+    const tool = new OpenDeviceFileInEditorTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readBytes), setEditorContent }),
+    );
+    const result = await tool.call({ path: '/main.py' });
+    expect(readBytes).toHaveBeenCalledWith('/main.py');
+    expect(setEditorContent).toHaveBeenCalledWith(code);
+    expect(result).toBe('Editor opened /main.py.');
+  });
+
+  it('returns binary error message for non-UTF-8 files', async () => {
+    const binaryBytes = new Uint8Array([0xff, 0xfe, 0x00, 0x01]);
+    const readBytes = vi.fn().mockResolvedValue(binaryBytes);
+    const setEditorContent = vi.fn();
+    const tool = new OpenDeviceFileInEditorTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readBytes), setEditorContent }),
+    );
+    const result = await tool.call({ path: '/blob.bin' });
+    expect(result).toBe('Cannot open binary file in editor.');
+    expect(setEditorContent).not.toHaveBeenCalled();
+  });
+
+  it('returns DeviceFsError message (e.g. ENOENT)', async () => {
+    const readBytes = vi.fn().mockRejectedValue(new DeviceFsError('ENOENT: /nope'));
+    const tool = new OpenDeviceFileInEditorTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readBytes) }),
+    );
+    const result = await tool.call({ path: '/nope' });
+    expect(result).toBe('ENOENT: /nope');
+  });
+
+  it('propagates non-device errors from readBytes', async () => {
+    const readBytes = vi.fn().mockRejectedValue(new Error('disconnected'));
+    const tool = new OpenDeviceFileInEditorTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(readBytes) }),
+    );
+    await expect(tool.call({ path: '/main.py' })).rejects.toThrow('disconnected');
+  });
+
+  it('reads bindings lazily via the getter', async () => {
+    const code = 'x = 1';
+    const readBytes = vi.fn().mockResolvedValue(encoder.encode(code));
+    const setEditorContent = vi.fn();
+    let bindings = makeBindings({ deviceFs: null });
+    const tool = new OpenDeviceFileInEditorTool(() => bindings);
+    await tool.call({ path: '/main.py' });
+    expect(setEditorContent).not.toHaveBeenCalled();
+
+    bindings = makeBindings({ deviceFs: makeDeviceFs(readBytes), setEditorContent });
+    await tool.call({ path: '/main.py' });
+    expect(setEditorContent).toHaveBeenCalledWith(code);
+  });
+});

--- a/src/agent/tools/OpenDeviceFileInEditorTool.ts
+++ b/src/agent/tools/OpenDeviceFileInEditorTool.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import { DeviceFsError } from '../../DeviceFs';
+import type { ToolBindings } from '../wireTools';
+
+export interface OpenDeviceFileInEditorArgs {
+  path: string;
+}
+
+export class OpenDeviceFileInEditorTool implements Tool<OpenDeviceFileInEditorArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'open_device_file_in_editor',
+      description:
+        'Reads a file from the device and loads it into the editor in one step. ' +
+        'Use this instead of read_device_file + write_editor.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style).',
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: OpenDeviceFileInEditorArgs): Promise<string> {
+    const { deviceFs, setEditorContent } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+
+    let bytes: Uint8Array;
+    try {
+      bytes = await deviceFs.readBytes(args.path);
+    } catch (err) {
+      if (err instanceof DeviceFsError) return err.message;
+      throw err;
+    }
+
+    let text: string;
+    try {
+      text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    } catch {
+      return 'Cannot open binary file in editor.';
+    }
+
+    setEditorContent(text);
+    return `Editor opened ${args.path}.`;
+  }
+}

--- a/src/agent/tools/SaveEditorToDeviceTool.test.ts
+++ b/src/agent/tools/SaveEditorToDeviceTool.test.ts
@@ -1,0 +1,104 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { SaveEditorToDeviceTool } from './SaveEditorToDeviceTool';
+import type { ToolBindings } from '../wireTools';
+import { DeviceFs, DeviceFsError } from '../../DeviceFs';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    sendInterrupt: () => {},
+    ...overrides,
+  };
+}
+
+function makeDeviceFs(writeText: (path: string, text: string) => Promise<void>): DeviceFs {
+  return { writeText } as unknown as DeviceFs;
+}
+
+describe('SaveEditorToDeviceTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new SaveEditorToDeviceTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('save_editor_to_device');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('definition makes path required', () => {
+    const tool = new SaveEditorToDeviceTool(() => makeBindings());
+    const def = tool.definition();
+    expect((def.parameters as { required?: string[] }).required ?? []).toEqual(['path']);
+  });
+
+  it('returns a clear message when deviceFs is null', async () => {
+    const tool = new SaveEditorToDeviceTool(() => makeBindings({ deviceFs: null }));
+    await expect(tool.call({ path: '/main.py' })).resolves.toBe('Device is not connected.');
+  });
+
+  it('does not call deviceFs.writeText when device is not connected', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const tool = new SaveEditorToDeviceTool(() => makeBindings({ deviceFs: null }));
+    await tool.call({ path: '/main.py' });
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('writes editor content to the given path', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const tool = new SaveEditorToDeviceTool(() =>
+      makeBindings({
+        deviceFs: makeDeviceFs(writeText),
+        getEditorContent: () => 'print("hi")\n',
+      }),
+    );
+    await tool.call({ path: '/main.py' });
+    expect(writeText).toHaveBeenCalledWith('/main.py', 'print("hi")\n');
+  });
+
+  it('returns success message on write', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    const tool = new SaveEditorToDeviceTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(writeText) }),
+    );
+    await expect(tool.call({ path: '/lib/foo.py' })).resolves.toBe(
+      'Editor saved to /lib/foo.py.',
+    );
+  });
+
+  it('returns DeviceFsError message (e.g. ENOSPC)', async () => {
+    const writeText = vi.fn().mockRejectedValue(new DeviceFsError('ENOSPC: no space left'));
+    const tool = new SaveEditorToDeviceTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(writeText) }),
+    );
+    const result = await tool.call({ path: '/big.py' });
+    expect(result).toBe('ENOSPC: no space left');
+  });
+
+  it('propagates non-device errors from writeText', async () => {
+    const writeText = vi.fn().mockRejectedValue(new Error('disconnected'));
+    const tool = new SaveEditorToDeviceTool(() =>
+      makeBindings({ deviceFs: makeDeviceFs(writeText) }),
+    );
+    await expect(tool.call({ path: '/main.py' })).rejects.toThrow('disconnected');
+  });
+
+  it('reads bindings lazily via the getter', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    let bindings = makeBindings({ deviceFs: null });
+    const tool = new SaveEditorToDeviceTool(() => bindings);
+    await tool.call({ path: '/main.py' });
+    expect(writeText).not.toHaveBeenCalled();
+
+    bindings = makeBindings({ deviceFs: makeDeviceFs(writeText) });
+    await tool.call({ path: '/main.py' });
+    expect(writeText).toHaveBeenCalledOnce();
+  });
+});

--- a/src/agent/tools/SaveEditorToDeviceTool.ts
+++ b/src/agent/tools/SaveEditorToDeviceTool.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import { DeviceFsError } from '../../DeviceFs';
+import type { ToolBindings } from '../wireTools';
+
+export interface SaveEditorToDeviceArgs {
+  path: string;
+}
+
+export class SaveEditorToDeviceTool implements Tool<SaveEditorToDeviceArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'save_editor_to_device',
+      description:
+        'Saves the current editor contents to a file on the device in one step. ' +
+        'Use this instead of read_editor + write_device_file.',
+      parameters: {
+        type: 'object',
+        properties: {
+          path: {
+            type: 'string',
+            description: 'Absolute device path (POSIX-style).',
+          },
+        },
+        required: ['path'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: SaveEditorToDeviceArgs): Promise<string> {
+    const { deviceFs, getEditorContent } = this.getBindings();
+    if (deviceFs === null) return 'Device is not connected.';
+    const content = getEditorContent();
+    try {
+      await deviceFs.writeText(args.path, content);
+    } catch (err) {
+      if (err instanceof DeviceFsError) return err.message;
+      throw err;
+    }
+    return `Editor saved to ${args.path}.`;
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -31,11 +31,13 @@ describe('wireTools', () => {
       'get_board_info',
       'list_device_files',
       'make_device_dir',
+      'open_device_file_in_editor',
       'read_device_file',
       'read_editor',
       'read_repl_history',
       'run_editor',
       'run_snippet',
+      'save_editor_to_device',
       'stop_program',
       'write_device_file',
       'write_editor',
@@ -46,7 +48,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(14);
+    expect(tools.getTools()).toHaveLength(16);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -18,6 +18,8 @@ import { DeleteDeviceFileTool } from './tools/DeleteDeviceFileTool';
 import { MakeDeviceDirTool } from './tools/MakeDeviceDirTool';
 import { StopProgramTool } from './tools/StopProgramTool';
 import { GetBoardInfoTool } from './tools/GetBoardInfoTool';
+import { OpenDeviceFileInEditorTool } from './tools/OpenDeviceFileInEditorTool';
+import { SaveEditorToDeviceTool } from './tools/SaveEditorToDeviceTool';
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -62,4 +64,6 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new MakeDeviceDirTool(get));
   tools.register(new StopProgramTool(get));
   tools.register(new GetBoardInfoTool(get));
+  tools.register(new OpenDeviceFileInEditorTool(get));
+  tools.register(new SaveEditorToDeviceTool(get));
 }

--- a/src/components/CobwebApproval.tsx
+++ b/src/components/CobwebApproval.tsx
@@ -73,6 +73,30 @@ export function CobwebApproval({
         />
       );
     }
+    case 'open_device_file_in_editor': {
+      const odfArgs = entry.args as { path?: unknown } | undefined;
+      const odfPath = typeof odfArgs?.path === 'string' ? odfArgs.path : '';
+      return (
+        <OpenDeviceFileApprovalLoader
+          entry={entry}
+          approval={approval}
+          path={odfPath}
+          readDeviceFile={readDeviceFile}
+        />
+      );
+    }
+    case 'save_editor_to_device': {
+      const setdArgs = entry.args as { path?: unknown } | undefined;
+      const setdPath = typeof setdArgs?.path === 'string' ? setdArgs.path : '';
+      return (
+        <WriteApprovalCard
+          entry={entry}
+          approval={approval}
+          header={<>Save editor to <code>{setdPath}</code></>}
+          content={getEditorContent()}
+        />
+      );
+    }
     case 'delete_device_file': {
       const ddfArgs = entry.args as { path?: unknown } | undefined;
       const ddfPath = typeof ddfArgs?.path === 'string' ? ddfArgs.path : '';
@@ -196,6 +220,96 @@ function DeviceEditApprovalLoader({
       surface="file"
       headerLabel={headerLabel}
       source={state.source}
+    />
+  );
+}
+
+// ----- OpenDeviceFileApprovalLoader -----------------------------------------
+
+interface OpenDeviceFileApprovalLoaderProps extends ApprovalSlotProps {
+  path: string;
+  readDeviceFile: (path: string) => Promise<string | null>;
+}
+
+function OpenDeviceFileApprovalLoader({
+  entry,
+  approval,
+  path,
+  readDeviceFile,
+}: OpenDeviceFileApprovalLoaderProps): ReactNode {
+  type LoadState =
+    | { kind: 'loading' }
+    | { kind: 'loaded'; content: string }
+    | { kind: 'failed' };
+  const [state, setState] = useState<LoadState>({ kind: 'loading' });
+
+  useEffect(() => {
+    let cancelled = false;
+    readDeviceFile(path).then((content) => {
+      if (cancelled) return;
+      if (content === null) {
+        setState({ kind: 'failed' });
+      } else {
+        setState({ kind: 'loaded', content });
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [path, readDeviceFile]);
+
+  const header = (
+    <>
+      Open <code>{path}</code> in editor
+    </>
+  );
+
+  if (state.kind === 'loading') {
+    return (
+      <div className="cobweb-approval-card" data-tool-name={entry.name}>
+        <div className="cobweb-approval-header">
+          <span className="cobweb-approval-title">{header}</span>
+          <span className="cobweb-approval-status">requires approval</span>
+        </div>
+        <div className="cobweb-approval-notice">
+          <p>Loading file…</p>
+        </div>
+        <ApprovalActions
+          approveDisabled
+          onApprove={approval.approve}
+          onReject={approval.reject}
+        />
+      </div>
+    );
+  }
+
+  if (state.kind === 'failed') {
+    return (
+      <div className="cobweb-approval-card" data-tool-name={entry.name}>
+        <div className="cobweb-approval-header">
+          <span className="cobweb-approval-title">{header}</span>
+          <span className="cobweb-approval-status">requires approval</span>
+        </div>
+        <NoLongerAppliesNotice
+          message="File preview unavailable."
+          respondMessage="File preview unavailable."
+          onRespondWith={approval.respondWith}
+        />
+        <ApprovalActions
+          approveDisabled
+          onApprove={approval.approve}
+          onReject={approval.reject}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <WriteApprovalCard
+      entry={entry}
+      approval={approval}
+      header={header}
+      content={state.content}
     />
   );
 }


### PR DESCRIPTION
## Summary

- Adds `open_device_file_in_editor(path)` — reads a device file and loads it into the editor in one approval step; approval card shows the file content as a preview
- Adds `save_editor_to_device(path)` — saves the current editor buffer to a device path in one approval step; approval card shows the editor content
- Both tools return a useful error string for DeviceFs errors (e.g. ENOENT, ENOSPC); `open_device_file_in_editor` also returns an error for binary files
- `onApprovalRequired` in `AgentProvider` short-circuits both tools immediately with `'Device is not connected.'` when `deviceFs === null`, skipping the approval card entirely

## Test plan

- [x] Connect a device; ask agent to open a device file in the editor — approval card shows file content, approving loads the file
- [x] Ask agent to save the editor to a device path — approval card shows editor content, approving writes the file
- [x] Disconnect device; ask agent to open or save — no approval card, agent immediately sees the error
- [x] Ask agent to open a binary file — approval card shows "File preview unavailable", tool returns "Cannot open binary file in editor."
- [x] `npm run test` passes (470 tests)

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)