### PR TITLE
feat(multi-agent): add PLANNING_AGENT config and delegate_to_coder factory

### DIFF
--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -3,6 +3,25 @@
 
 import { createAgent } from '@mast-ai/core';
 
+export const PLANNING_AGENT = createAgent({
+  name: 'cobweb-planner',
+  instructions: `You are a MicroPython coding assistant for the Cobweb IDE. You have read-only access to the editor, the device filesystem, the REPL history, and board info, plus a delegate_to_coder tool that hands work to a coder sub-agent.
+
+For trivial questions you can answer from the read-only tools (e.g. board info, file listings, current editor contents), answer directly without delegating.
+
+For any task that requires changing the editor, the device filesystem, or running code, call delegate_to_coder with a self-contained task string. The coder starts each call with no conversation history, so the task string must stand alone — but it does have the same read tools as you (read_editor, read_device_file, list_device_files, read_repl_history, get_board_info). Refer to files by path and let the coder read them; do not paste file contents into the task string. Include only what the coder cannot reconstruct from reading: the user's intent, exact constraints (line numbers, function names, before/after behaviour), and success criteria.
+
+Multi-step requests can call delegate_to_coder multiple times in one turn. After each delegation, briefly summarise what was done before deciding the next step.`,
+  tools: [
+    'read_editor',
+    'read_device_file',
+    'list_device_files',
+    'read_repl_history',
+    'get_board_info',
+    'delegate_to_coder',
+  ],
+});
+
 export const CODING_AGENT = createAgent({
   name: 'cobweb-assistant',
   instructions: `You are a MicroPython coding assistant for the Cobweb IDE.

--- a/src/agent/tools/DelegateToCoderTool.test.ts
+++ b/src/agent/tools/DelegateToCoderTool.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import type { AgentConfig, AgentEvent, AgentRunner, ToolContext } from '@mast-ai/core';
+import { createDelegateToCoderTool } from './DelegateToCoderTool';
+import { CODING_AGENT } from '../config';
+
+interface StubBuilderState {
+  parentContext?: ToolContext;
+  signal?: AbortSignal;
+  runStreamInput?: string;
+}
+
+function makeStubRunner(events: AgentEvent[]): {
+  runner: AgentRunner;
+  state: StubBuilderState;
+  runBuilder: ReturnType<typeof vi.fn>;
+} {
+  const state: StubBuilderState = {};
+
+  const builder = {
+    forwardTo(parentContext: ToolContext) {
+      state.parentContext = parentContext;
+      return this;
+    },
+    signal(signal: AbortSignal) {
+      state.signal = signal;
+      return this;
+    },
+    async *runStream(input: string): AsyncIterable<AgentEvent> {
+      state.runStreamInput = input;
+      for (const event of events) {
+        if (event.type !== 'done') {
+          state.parentContext?.onEvent?.(event);
+        }
+        yield event;
+      }
+    },
+  };
+
+  const runBuilder = vi.fn((agent: AgentConfig) => {
+    void agent;
+    return builder;
+  });
+  const runner = { runBuilder } as unknown as AgentRunner;
+  return { runner, state, runBuilder };
+}
+
+describe('createDelegateToCoderTool', () => {
+  it('definition has the expected name, scope, and parameters', () => {
+    const { runner } = makeStubRunner([]);
+    const tool = createDelegateToCoderTool(runner);
+    const def = tool.definition();
+
+    expect(def.name).toBe('delegate_to_coder');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBeUndefined();
+    expect(def.parameters).toMatchObject({
+      type: 'object',
+      properties: {
+        task: { type: 'string' },
+      },
+      required: ['task'],
+    });
+  });
+
+  it('passes the task string as input to runStream and runs CODING_AGENT', async () => {
+    const events: AgentEvent[] = [
+      { type: 'done', output: 'coder finished', history: [] },
+    ];
+    const { runner, state, runBuilder } = makeStubRunner(events);
+    const tool = createDelegateToCoderTool(runner);
+
+    const result = await tool.call({ task: 'foo' }, {});
+
+    expect(runBuilder).toHaveBeenCalledWith(CODING_AGENT);
+    expect(state.runStreamInput).toBe('foo');
+    expect(result).toBe('coder finished');
+  });
+
+  it('forwards sub-agent events (text_delta, tool_call_started) to context.onEvent', async () => {
+    const events: AgentEvent[] = [
+      { type: 'tool_call_started', name: 'edit_editor', args: { foo: 1 } },
+      { type: 'text_delta', delta: 'hello' },
+      { type: 'done', output: 'ok', history: [] },
+    ];
+    const { runner } = makeStubRunner(events);
+    const tool = createDelegateToCoderTool(runner);
+    const onEvent = vi.fn();
+
+    await tool.call({ task: 'do something' }, { onEvent });
+
+    expect(onEvent).toHaveBeenCalledTimes(2);
+    expect(onEvent).toHaveBeenNthCalledWith(1, {
+      type: 'tool_call_started',
+      name: 'edit_editor',
+      args: { foo: 1 },
+    });
+    expect(onEvent).toHaveBeenNthCalledWith(2, {
+      type: 'text_delta',
+      delta: 'hello',
+    });
+  });
+
+  it('forwards the abort signal from context to the builder', async () => {
+    const events: AgentEvent[] = [{ type: 'done', output: '', history: [] }];
+    const { runner, state } = makeStubRunner(events);
+    const tool = createDelegateToCoderTool(runner);
+    const controller = new AbortController();
+
+    await tool.call({ task: 't' }, { signal: controller.signal });
+
+    expect(state.signal).toBe(controller.signal);
+  });
+});

--- a/src/agent/tools/DelegateToCoderTool.ts
+++ b/src/agent/tools/DelegateToCoderTool.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { createAgentTool, type AgentRunner, type Tool } from '@mast-ai/core';
+import { CODING_AGENT } from '../config';
+
+export function createDelegateToCoderTool(runner: AgentRunner): Tool {
+  return createAgentTool(runner, CODING_AGENT, {
+    name: 'delegate_to_coder',
+    description:
+      'Hands a scoped, self-contained task to the coder sub-agent. Use for any work that requires editing the editor, the device filesystem, or running code on the device. The coder starts with no conversation history, so the task string must include all required context (paths, constraints, success criteria).',
+    parameters: {
+      type: 'object',
+      properties: {
+        task: {
+          type: 'string',
+          description:
+            'Self-contained instruction for the coder. Include relevant file paths, exact constraints, and success criteria.',
+        },
+      },
+      required: ['task'],
+    },
+    scope: 'write',
+    buildInput: (args) => (args as { task: string }).task,
+  });
+}


### PR DESCRIPTION
## Summary

Adds the planner agent and the agent-tool factory that wraps `CODING_AGENT` as a sub-agent. Intentionally dead code at runtime — the entry point still routes to `CODING_AGENT` until #156 lands.

- `src/agent/config.ts` — adds `PLANNING_AGENT` (`cobweb-planner`) with the read-only allowlist + `delegate_to_coder` and the routing-contract instructions from `docs/multi-agent/SPEC.md` §1. `CODING_AGENT` is unchanged.
- `src/agent/tools/DelegateToCoderTool.ts` — exports `createDelegateToCoderTool(runner)` that wraps `CODING_AGENT` via `createAgentTool`. \`scope: 'write'\`, no \`requiresApproval\` (the approval boundary stays at the innermost write tool, per SPEC §2). \`buildInput\` returns the \`task\` string verbatim — coder gets a clean slate per delegation.
- `src/agent/tools/DelegateToCoderTool.test.ts` — covers definition shape, that the tool calls \`runner.runBuilder(CODING_AGENT)\` and passes the \`task\` as input to \`runStream\`, that sub-agent events forward to \`context.onEvent\`, and that \`context.signal\` is forwarded to the builder.

Closes #155. Branched off `multi-agent` and targeted there per the epic's branching strategy in SPEC §6.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (474 passing, 4 new)
- [x] `npm run build`
- [x] App still loads in the browser — registration is not wired yet, so this PR is purely additive at runtime.