### PR TITLE
Visually distinguish sub-agent conversation blocks

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -185,6 +185,36 @@
     min-height: calc(4 * 1.5em);
 }
 
+/* Sub-agent conversation block — distinct rail + tinted background so the
+   coder's interleaved tool calls and final text read as a separate context
+   from the planner's top-level activity. */
+[data-mast-root] .mast-tool-call-block-nested,
+[data-mast-root] .mast-tool-call-block-sub-text {
+    margin-left: 0;
+    padding: 0.5rem 0.75rem;
+    background: color-mix(in srgb, var(--primary) 7%, transparent);
+    border-left: 3px solid var(--primary);
+    border-radius: 0.25rem;
+}
+
+.dark [data-mast-root] .mast-tool-call-block-nested,
+.dark [data-mast-root] .mast-tool-call-block-sub-text {
+    background: color-mix(in srgb, var(--primary) 14%, transparent);
+}
+
+[data-mast-root] .mast-tool-call-block[data-tool-name="delegate_to_coder"]
+    > .mast-tool-call-block-body
+    > .mast-tool-call-block-nested::before {
+    content: "↳ Coder sub-agent";
+    display: block;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--primary);
+    margin-bottom: 0.5rem;
+}
+
 /* ---------- Cobweb tool-approval cards ---------- */
 
 .cobweb-approval-card {


### PR DESCRIPTION
## Summary

The nested area where the coder sub-agent's tool calls and final text render was visually almost identical to the planner's top-level activity (just a thin 2px border). This pure-CSS change makes the boundary obvious.

- `.mast-tool-call-block-nested` and `.mast-tool-call-block-sub-text` now render with a tinted primary-color background, a 3px primary-color left rail, and rounded corners.
- The dark theme uses a stronger tint mix (14% vs. 7%) so the sub-agent block stays visible against the dark muted background.
- A small uppercase "↳ Coder sub-agent" label is injected via `::before` on the nested area, scoped to `[data-tool-name="delegate_to_coder"]`. When other sub-agent tools land (e.g. `search_documentation` from #141), they can be added to the selector.

## Test plan

- [x] Manually verified in the browser that the planner → `delegate_to_coder` flow now renders the coder's nested tool calls with a distinct rail, tint, and "Coder sub-agent" label.
- [ ] Re-check after merge that the styling holds up across light/dark themes and longer multi-step delegations.