### PR TITLE
docs(docs-context): add PRD, SPEC, and implementation plan

### DIFF
--- a/docs/docs-context/PLAN.md
+++ b/docs/docs-context/PLAN.md
@@ -1,0 +1,80 @@
+# MicroPython Documentation and Board-Specific Context Injection — Implementation Plan
+
+Operational notes for executing the SPEC. Step-by-step ordering, branch names, and per-issue verification. The PRD/SPEC are the source of truth for *what* and *why*; this file is *when* and *how*.
+
+## Pre-flight
+
+- Parent epic: [#141](https://github.com/andreban/cobweb/issues/141).
+- Label: `docs-context` (exists).
+- Branching: each issue lands as its own PR off `main`. No long-lived integration branch — the feature is additive and self-contained.
+- The mast-ai dependency for phase 2's `search_documentation` (`nativeTools` constructor parameter) already shipped in `@mast-ai/google-genai@0.8.0` and is on the project. No upstream coordination required for any phase 1 issue.
+
+## Issue ordering
+
+A, B, C are independent and can land in any order or in parallel. Suggested sequence by user-visible value:
+
+1. **A — Board notes + `machineName` capture.** Highest leverage — solves cross-thread memory immediately and exposes `machineName` in `ToolBindings`. Touches `App.tsx`, `wireTools.ts`, `config.ts`, and adds a hook + three tools.
+2. **B — `fetch_url`.** Generic URL fetch. Standalone tool, no bindings extension. Smallest blast radius.
+3. **C — `list_installed_modules`.** Smallest probe tool. Closely mirrors `GetBoardInfoTool`'s shape.
+
+If parallelising, A goes first because it touches `App.tsx` and `wireTools.ts`; B and C then layer on with smaller diffs.
+
+## Per-issue execution
+
+For each issue:
+
+1. `git checkout main && git pull`.
+2. Create the feature branch (`git checkout -b feat/docs-context/<slug>`).
+3. Implement per the SPEC's "File map" subsection.
+4. Run `npm run lint && npm run test && npm run build`. Fix failures.
+5. Ask the user to test in the browser per the SPEC's UI verification subsection. Wait for confirmation before committing.
+6. Commit with the PR-description-style message (subject + body).
+7. Push and `gh pr create --base main` with a body including `Closes #<issue>`.
+
+### A — Board notes + `machineName` capture
+
+- Branch: `feat/docs-context/board-notes`
+- Slugs to add to `CODING_AGENT.tools`: `read_board_notes`, `write_board_notes`, `edit_board_notes`.
+- Order of work within the issue:
+  1. `useMachineName` hook + test.
+  2. Extend `ToolBindings` interface; wire the new field through `App.tsx`.
+  3. Add the three tools (`BoardNotesReadTool`, `BoardNotesWriteTool`, `BoardNotesEditTool`) + tests.
+  4. Register in `wireTools`; allowlist in `CODING_AGENT.tools`.
+  5. Add the coder-instructions nudge sentence.
+- Verification (SPEC §7 A): write a note → refresh → read returns the saved content; switch boards → no leakage.
+
+### B — `fetch_url`
+
+- Branch: `feat/docs-context/fetch-url`
+- Order of work:
+  1. URL translation helper (`translateGitHubUrl`) — pure function, easy to unit-test.
+  2. `FetchUrlTool` + test (stub `fetch` on `globalThis`).
+  3. Register in `wireTools`; allowlist in `CODING_AGENT.tools`.
+  4. Add the coder-instructions nudge sentence.
+- Verification (SPEC §7 B): paste a Pimoroni repo URL → README returned; CORS-rejecting URL → readable error string; `blob/` URL → translated to raw and fetched.
+
+### C — `list_installed_modules`
+
+- Branch: `feat/docs-context/list-installed-modules`
+- Order of work:
+  1. `ListInstalledModulesTool` (mirrors `GetBoardInfoTool`'s probe + timeout shape) + test.
+  2. Register in `wireTools`; allowlist in `CODING_AGENT.tools`.
+  3. Add the coder-instructions nudge sentence.
+- Verification (SPEC §7 C): connect a Pico → tool fires, output includes stdlib modules; on a vendor board, output includes vendor modules.
+
+## Cross-cutting checks (each PR)
+
+- The new tool name appears in `CODING_AGENT.tools` and *not* in `PLANNING_AGENT.tools`.
+- The coder-instructions nudge is appended to the existing `instructions` literal — no per-turn mutation.
+- Tool definitions correctly set `scope` (`'read'` for reads, `'write'` for the two notes writers) and `requiresApproval` (`true` for the writes).
+- Browser verification has been done by the user before commit. `npm run lint && npm run test && npm run build` all pass.
+
+## Closing the epic
+
+When A, B, and C are merged:
+
+1. Verify the success criteria in the PRD by exercising the three new tools in a single session (read notes → fetch a URL → list modules → write notes).
+2. Move `docs/docs-context/` to `docs/archive/docs-context/`. Per CLAUDE.md, archived docs are not rewritten.
+3. Close epic #141.
+
+Phase 2 work (`get_board_quickref`, `get_module_docs`, `search_documentation`, doc-fetcher utility with caching) is captured in SPEC §8. If picked up later, it gets a new feature subdirectory and its own epic — phase 1 establishes the tool surface phase 2 builds on without forcing a coupling.

--- a/docs/docs-context/PRD.md
+++ b/docs/docs-context/PRD.md
@@ -1,0 +1,91 @@
+# MicroPython Documentation and Board-Specific Context Injection — Product Requirements Document
+
+## Problem Statement
+
+The Cobweb coding agent has no access to MicroPython stdlib documentation, board-specific context (pinouts, available peripherals, vendor modules), or any memory of work done on a board in previous conversations. Three failure modes follow:
+
+- **Unreliable answers from training prior.** Niche boards and infrequently used MicroPython modules are sparsely covered by the model's training data. The agent confidently emits API signatures that don't exist on the connected firmware (wrong argument names, wrong return types, CPython behaviour where MicroPython diverges).
+- **Context churn from runtime probing.** When the agent compensates by running `dir(module)` / `help(module)` snippets through `run_snippet`, each probe burns a tool call, an approval prompt, and conversation tokens — and produces output the model has to parse before answering.
+- **No cross-thread memory.** Each new conversation starts blank. Anything the agent learned in a previous thread (the user's board has a `presto` module, the docs are at a particular Pimoroni repo, certain pins are wired to the touch panel) is lost. The user has to re-establish context every session.
+
+The `agent-tools` epic added a `get_board_info` probe that returns the firmware string, platform, free RAM, and `os.uname().machine` at session start. That gives the agent the board *identity* but not the *capabilities* (which modules are installed, where vendor docs live, what's been useful before).
+
+## Target Users
+
+Same as the parent PRD (educators, hobbyists, beginners). Scenarios this feature unlocks:
+
+- **Hobbyist with a Pimoroni Presto** asks "set up the display." The agent calls `list_installed_modules`, discovers `presto`, `picographics`, `plasma`. It calls `read_board_notes` and finds a URL the user pasted in a previous thread (`https://github.com/pimoroni/presto`). It calls `fetch_url` on that URL, reads the README, writes the working snippet — without the user re-explaining anything.
+- **Educator** connects a Raspberry Pi Pico and asks for an LED blink. The agent calls `read_board_notes`; nothing yet. It writes the working code from training prior, then `edit_board_notes` to record the GP25 onboard-LED note for next time.
+- **Beginner** pastes `https://github.com/adafruit/Adafruit_CircuitPython_NeoPixel` and asks "use this." The agent calls `fetch_url`, reads the API, writes code, and saves the URL to notes so the next session knows where to look.
+
+## Goals
+
+1. **Per-board persistent notes.** Add `read_board_notes`, `write_board_notes`, and `edit_board_notes` tools backed by `localStorage` keyed on `os.uname().machine`. The agent maintains a freeform markdown blob per board: vendor module surface, useful docs URLs, pin assignments, gotchas. Persists across page reloads and across conversations.
+2. **Generic URL fetching.** Add `fetch_url(url)` — accepts any URL, returns the body or a descriptive error string (CORS, 404, network). GitHub repo URLs auto-translate to `raw.githubusercontent.com` so pasted repo links resolve to README content. No caching in phase 1; every call hits the network.
+3. **Module-surface introspection.** Add `list_installed_modules` — runs `help('modules')` on the device and returns the list. Lets the agent learn what's actually available on the connected firmware (including vendor extensions like `presto`, `picographics`, etc.) without trial-and-error.
+4. **Coder-only allowlist for the new tools.** All three tools serve code generation, which is the coder's job. The planner stays lean — it routes work, it does not need API references or board memory.
+5. **Lean system prompts.** No injection. The new tools each get one nudge sentence in the coder's instructions — `read_board_notes` at the start of work, `list_installed_modules` when capabilities are uncertain, `fetch_url` for user-provided or notes-recorded URLs. Tool descriptions carry the bulk of the "when to call" guidance.
+
+## Out of Scope
+
+### Deferred to phase 2 (future work)
+
+- **Typed doc tools (`get_board_quickref`, `get_module_docs`).** Convenience wrappers around `fetch_url` with hardcoded URL patterns for upstream MicroPython docs. Add only if browser observation shows the model under-fetches when given the generic `fetch_url` plus URL hints in its instructions.
+- **`search_documentation` sub-agent.** Gemini-grounded web search via the native `googleSearch` tool. Genuinely useful as the fallback when `fetch_url` hits CORS, but provider-locked to Gemini and not foundational. Lands on its own once phase 1 is observed.
+- **Caching of fetched URLs.** Phase 1 hits the network on every `fetch_url` call. When typed doc tools land (or if observed network traffic from repeated fetches becomes a problem), a shared fetcher utility with Cache API caching — and likely firmware-version-keyed namespacing — gets introduced.
+
+### Not planned
+
+- **Pre-injecting docs into system prompts.** Considered and rejected (see "Considered alternatives").
+- **Auto-capture of fetched URLs into board notes.** Considered; the agent decides what's worth remembering. See "Considered alternatives".
+- **Vendor-aware fetcher routes** (e.g. detect "Pimoroni" in machine name, fall back to a Pimoroni-specific docs site). Adds maintenance per vendor; user-pasted URLs + board notes solves the same problem generically.
+- **Per-session user-provided notes via UI** (a "context panel" the user types into). The chat *is* the input channel — the agent records what the user mentions. UI affordances for managing notes outside chat are a possible follow-on.
+- **Cross-board notes.** Notes are scoped per `os.uname().machine`. Two physically distinct boards with the same machine string share notes; if that's confusing in practice, disambiguation UI is a follow-on.
+
+## Success Criteria
+
+- After connecting a board and starting a conversation, the agent can call `read_board_notes` and receive the saved markdown for that board (or `""` if none yet).
+- After the agent calls `write_board_notes(content)` or `edit_board_notes(old, new)` and the user approves, refreshing the page and starting a new conversation surfaces the same notes via `read_board_notes`.
+- Notes for one board (`os.uname().machine == "Raspberry Pi Pico"`) do not leak into another board (`"Pimoroni Presto with RP2350"`).
+- The agent can call `fetch_url("https://github.com/pimoroni/presto")` and receive the README contents in the tool result.
+- A `fetch_url` call against a CORS-rejecting host returns a clear string the agent can read and reason about; no unhandled rejection bubbles up.
+- The agent can call `list_installed_modules` and receive the `help('modules')` listing as text. On a Pimoroni Presto this includes `presto`, `picographics`, etc.; on a stock Pico it includes only the standard set.
+- The planner does not have any of the three new tools in its allowlist.
+- Writes to notes (`write_board_notes`, `edit_board_notes`) trigger the existing approval flow — the user sees what's about to be saved before it's saved.
+- `npm run lint`, `npm run test`, `npm run build` all pass. No new top-level dependencies (Cache API and `localStorage` are platform built-ins).
+
+## Considered alternatives
+
+### Pre-inject docs into the system prompt at connect / per turn (rejected)
+
+Probe at connect, scan editor imports per turn, mutate `agent.instructions` with assembled context. Pros: guaranteed presence. Cons: every turn pays the injection cost, defeats prompt caching at the provider level, and forces deterministic decisions ("which modules are imported *right now*") that don't necessarily match what the agent actually needs to look up.
+
+Tools-on-demand accepts a structural risk — the model has to *decide* to call the tool — and mitigates it via concise tool descriptions and a brief nudge in the coder's system prompt. If observation shows the model under-calls, the system prompt nudge can be tightened without changing the tool surface.
+
+### Restrict `fetch_url` to GitHub only (rejected)
+
+Phase 1 originally proposed limiting `fetch_url` to GitHub URLs because CORS-handling for arbitrary hosts is unpredictable. Replaced with: accept any URL, surface failures (CORS, 404, network) as readable strings the agent can act on. The agent can fall back to asking the user to paste content directly, or to a future `search_documentation`. This matches the rest of the tool design (`get_module_docs` returns a "no docs found" string the agent reasons about, not an error).
+
+GitHub-URL translation is kept as a usability nicety (`github.com/owner/repo` → `raw.githubusercontent.com/owner/repo/main/README.md` etc.) — not a restriction.
+
+### Auto-capture fetched URLs into board notes (rejected)
+
+Earlier draft proposed automatically appending every successful `fetch_url` to a per-board URL list. Replaced with agent-managed notes: the agent decides what's worth recording. Tradeoff: less deterministic (the model might under-record), but notes stay curated rather than polluted with every transient fetch. If observation shows under-recording, the system-prompt nudge tightens; the structural design doesn't change.
+
+### Vendor-aware fetcher routes (rejected)
+
+Detect "Pimoroni", "Adafruit", etc. in `os.uname().machine` and route module lookups to vendor-specific docs sites first. Adds per-vendor maintenance, and the user-pasted-URL-plus-notes path solves the same problem generically.
+
+## Key questions to resolve in the SPEC
+
+- Where does `machineName` (from `os.uname().machine`) get captured and exposed? Connect-time hook? Lazy on first tool call?
+- What's the localStorage layout for notes (key naming, value format, size cap)?
+- How does the approval flow render note edits — reuse the existing `edit_editor` approval card layout, or build something custom?
+
+## Constraints
+
+- No backend; all fetches must be client-side (satisfied by `raw.githubusercontent.com`'s `Access-Control-Allow-Origin: *` for the GitHub-translation case; arbitrary hosts may CORS-reject and that's surfaced to the agent).
+- Tool-result size cap: ~30 KB per fetched body, with a `[truncated]` marker pointing at the source URL when capped.
+- Notes per board cap: ~64 KB. Far more than the agent will reasonably write; protects localStorage from runaway growth.
+- localStorage must survive page reloads (it does by default).
+- No system-prompt mutation. The `instructions` strings on `PLANNING_AGENT` and `CODING_AGENT` are written once at module load.

--- a/docs/docs-context/SPEC.md
+++ b/docs/docs-context/SPEC.md
@@ -1,0 +1,408 @@
+# MicroPython Documentation and Board-Specific Context Injection — Technical Specification
+
+## Overview
+
+The PRD identifies three primitives for phase 1: per-board persistent notes, generic URL fetching, and module-surface introspection. Each is a small additive tool registered on the existing `models.tools` registry, allowlisted to `CODING_AGENT` only.
+
+The framework provides every primitive needed:
+
+- Tools register on `models.tools` via `wireTools`. The coder's allowlist in `CODING_AGENT.tools` controls visibility.
+- Approval-gated writes route through the existing `INLINE_APPROVAL` flow (`src/components/makeCobwebApproval.tsx`), the same path used by `edit_editor` / `write_device_file`.
+- `localStorage` and the Cache API are platform built-ins — no new dependencies.
+
+The work is therefore: three new tool files, a small bindings extension to expose `machineName`, a connect-time probe hook, and three short system-prompt nudge sentences appended to `CODING_AGENT.instructions`. No system-prompt mutation, no per-message hooks, no integration branch.
+
+---
+
+## 1. `list_installed_modules` tool — `src/agent/tools/ListInstalledModulesTool.ts`
+
+### Responsibility
+
+Probe the connected device for the list of installed modules (stdlib + vendor extensions) and return the result as text.
+
+### Definition
+
+```ts
+{
+  name: 'list_installed_modules',
+  description:
+    'Lists every MicroPython module installed on the connected device, including vendor extensions (e.g. "presto" or "picographics" on a Pimoroni board, "neopixel" on Adafruit boards). Call this when you need to know what is available before writing imports — particularly on unfamiliar or vendor-specific hardware. Returns the raw output of `help("modules")`.',
+  parameters: { type: 'object', properties: {}, additionalProperties: false },
+  scope: 'read',
+  requiresApproval: false,
+}
+```
+
+### Behaviour
+
+```ts
+const PROBE_SNIPPET = "help('modules')";
+const TIMEOUT_MS = 5_000;
+
+async call(_args, ctx): Promise<string> {
+  const run = this.getBindings().runCode(PROBE_SNIPPET);
+  // Timeout / abort handling mirrors GetBoardInfoTool.
+  const outcome = await Promise.race([run, timeout, aborted]);
+  if (outcome === 'timeout') return 'Module list unavailable: probe timed out.';
+  const { stdout, stderr } = outcome;
+  if (stderr.trim()) return `Module list unavailable: ${stderr.trim()}`;
+  if (!stdout.trim()) return 'Module list unavailable: empty response.';
+  return stdout;  // raw "help('modules')" output, columns and all
+}
+```
+
+If the device is not connected, `runCode` rejects with `"Not connected"` (existing `useReplConnection` behaviour); the tool catches and returns `"Board not connected. Connect a device to list its modules."`.
+
+### Tests — `ListInstalledModulesTool.test.ts`
+
+- Definition shape (name, scope, no parameters, no approval).
+- Successful probe → returns stdout verbatim.
+- `runCode` rejects with "Not connected" → returns "Board not connected" string.
+- stderr present → returns "Module list unavailable: <stderr>".
+- Probe timeout → returns "Module list unavailable: probe timed out".
+- Abort signal aborts the in-flight call.
+
+### File map
+
+**Add:**
+- `src/agent/tools/ListInstalledModulesTool.ts`
+- `src/agent/tools/ListInstalledModulesTool.test.ts`
+
+**Modify:**
+- `src/agent/wireTools.ts` — register the new tool.
+- `src/agent/config.ts` — append `'list_installed_modules'` to `CODING_AGENT.tools`. Add a sentence to coder instructions: *"When you are unsure whether a vendor or community module is available on the connected board (e.g. on Pimoroni, Adafruit, or other custom firmware), call `list_installed_modules` before writing imports."*
+
+---
+
+## 2. `fetch_url` tool — `src/agent/tools/FetchUrlTool.ts`
+
+### Responsibility
+
+Fetch any URL and return the body as text. Surface failures (CORS, 404, network) as descriptive strings the agent can reason about. Phase 1 does not cache — every call hits the network.
+
+### Definition
+
+```ts
+{
+  name: 'fetch_url',
+  description:
+    'Fetches the contents of a URL and returns the body as text. Use this when the user provides a documentation URL, when board notes record a URL worth consulting, or when you need to read a known docs page (including raw GitHub files for MicroPython upstream docs). GitHub repo and blob URLs auto-translate to raw.githubusercontent.com. On failure, returns a descriptive error string (CORS-blocked, 404, network error) so you can decide on a fallback.',
+  parameters: {
+    type: 'object',
+    properties: {
+      url: { type: 'string', description: 'The URL to fetch (http or https).' },
+    },
+    required: ['url'],
+    additionalProperties: false,
+  },
+  scope: 'read',
+  requiresApproval: false,
+}
+```
+
+### URL translation
+
+GitHub URLs translate to `raw.githubusercontent.com` for cleaner content:
+
+- `https://github.com/<owner>/<repo>` → try `raw.githubusercontent.com/<owner>/<repo>/main/README.md`. On 404, retry against `master`. On further 404, return `"No README.md found on main or master branches of <owner>/<repo>."`.
+- `https://github.com/<owner>/<repo>/blob/<branch>/<path>` → `raw.githubusercontent.com/<owner>/<repo>/<branch>/<path>`.
+- `https://github.com/<owner>/<repo>/tree/<branch>/<path>` → returns `"Directory listing is not supported. Provide a specific file URL."` (no GitHub API call in phase 1).
+
+Other hosts are fetched as-is.
+
+### Behaviour
+
+```ts
+const MAX_BYTES = 30 * 1024;
+
+async call({ url }, _ctx): Promise<string> {
+  const candidates = translateGitHubUrl(url);  // may return one or more candidates for repo URLs
+  for (const candidate of candidates) {
+    let response: Response;
+    try {
+      response = await fetch(candidate);
+    } catch (err) {
+      // Most CORS rejections surface as TypeError "Failed to fetch".
+      return `Could not fetch ${candidate}: ${describeError(err)}. The host may have blocked cross-origin access. Try search_documentation, paste the relevant section into chat, or provide a github.com URL instead.`;
+    }
+    if (response.status === 404) continue;  // try next README candidate, etc.
+    if (!response.ok) return `Fetched ${candidate} returned HTTP ${response.status}.`;
+    return truncate(await response.text(), candidate);
+  }
+  return `No content found at ${url}.`;
+}
+
+function truncate(body: string, url: string): string {
+  if (body.length <= MAX_BYTES) return body;
+  return body.slice(0, MAX_BYTES) + `\n\n... [truncated, see full file at ${url}]\n`;
+}
+```
+
+No caching in phase 1. The cost is one network round-trip per call; the saving is a substantial chunk of implementation and test surface (Cache API mocking, eviction story, namespacing). Phase 2 introduces caching when typed doc tools land, at which point a shared fetcher utility makes the cost worth it.
+
+### Tests — `FetchUrlTool.test.ts`
+
+- Definition shape.
+- Plain URL with successful fetch → body is returned.
+- GitHub repo URL → tries `main/README.md`, returns body on success.
+- GitHub repo URL with `main` 404 → retries `master`, returns body on success.
+- GitHub repo URL with both 404 → "No README.md found".
+- GitHub blob URL → translates to raw URL and fetches.
+- GitHub tree URL → "Directory listing is not supported".
+- `fetch` rejects (TypeError "Failed to fetch") → returns the CORS-style error string.
+- Non-OK status (500) → returns "HTTP 500" string.
+- Body over 30 KB → truncated with marker.
+
+Tests stub `fetch` on `globalThis`.
+
+### File map
+
+**Add:**
+- `src/agent/tools/FetchUrlTool.ts`
+- `src/agent/tools/FetchUrlTool.test.ts`
+
+**Modify:**
+- `src/agent/wireTools.ts` — register the new tool.
+- `src/agent/config.ts` — append `'fetch_url'` to `CODING_AGENT.tools`. Add a sentence to coder instructions: *"When the user provides a docs URL, when board notes record one, or when you need a known docs page (e.g. upstream MicroPython library RST at `https://raw.githubusercontent.com/micropython/micropython/master/docs/library/<module>.rst`), call `fetch_url`."*
+
+---
+
+## 3. Board notes — `src/agent/tools/BoardNotes*Tool.ts` (read / write / edit)
+
+### Responsibility
+
+Per-board persistent memory. The agent reads and updates a markdown blob keyed by `os.uname().machine`, surviving page reloads and cross-conversation. Writes are approval-gated; reads are not.
+
+### Storage layout
+
+- Key: `cobweb:board-notes:${machineName}`.
+- Value: a plain markdown string. No frontmatter, no JSON wrapper — keep it editable both by the agent and (later) by a settings-panel UI without parsing overhead.
+- Cap: 64 KB per board. Writes that would exceed the cap return an error.
+
+### Bindings extension — `src/agent/wireTools.ts`
+
+```ts
+export interface ToolBindings {
+  // ... existing fields
+  /** os.uname().machine value probed at connect, or null when disconnected. */
+  machineName: string | null;
+}
+```
+
+### Connect-time probe — `src/hooks/useMachineName.ts`
+
+```ts
+export function useMachineName(args: {
+  connectionState: ConnectionState;
+  runCode: (code: string) => Promise<RunResult>;
+}): string | null {
+  const [machineName, setMachineName] = useState<string | null>(null);
+  useEffect(() => {
+    if (args.connectionState !== 'connected') {
+      setMachineName(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const { stdout } = await args.runCode("import os; print(os.uname().machine)");
+        if (cancelled) return;
+        const value = stdout.trim();
+        setMachineName(value || null);
+      } catch {
+        // Probe failure is non-fatal; notes tools surface "Board not connected".
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [args.connectionState, args.runCode]);
+  return machineName;
+}
+```
+
+`App.tsx` calls this hook and passes the result into `wireTools`'s bindings. The probe runs once per connect transition; reconnecting the same board re-probes (cheap, and handles devices whose machine string is set after early boot).
+
+`GetBoardInfoTool` keeps its own probe — sharing the result via cross-system state would couple the connect-time hook to the agent runtime. The duplication cost is one extra `runCode` call per connect, which is negligible on the existing serial latency budget.
+
+### `read_board_notes`
+
+```ts
+{
+  name: 'read_board_notes',
+  description:
+    'Reads the persistent notes for the currently connected board. Notes are scoped per-board (by os.uname().machine) and survive across sessions. Use to recall context the agent established in previous conversations: vendor module surface, useful docs URLs, board-specific pin assignments, gotchas. Returns "" if no notes exist yet.',
+  parameters: { type: 'object', properties: {}, additionalProperties: false },
+  scope: 'read',
+  requiresApproval: false,
+}
+```
+
+```ts
+async call(_args, _ctx): Promise<string> {
+  const { machineName } = this.getBindings();
+  if (!machineName) return 'Board not connected. Notes are only available when a device is connected.';
+  return localStorage.getItem(`cobweb:board-notes:${machineName}`) ?? '';
+}
+```
+
+### `write_board_notes`
+
+```ts
+{
+  name: 'write_board_notes',
+  description:
+    'Replaces the persistent notes for the currently connected board with the provided content. Prefer edit_board_notes for incremental changes; use this for the first write or full rewrites. The user reviews the proposed content before it is saved.',
+  parameters: {
+    type: 'object',
+    properties: { content: { type: 'string' } },
+    required: ['content'],
+    additionalProperties: false,
+  },
+  scope: 'write',
+  requiresApproval: true,
+}
+```
+
+```ts
+async call({ content }, _ctx): Promise<string> {
+  const { machineName } = this.getBindings();
+  if (!machineName) return 'Board not connected.';
+  if (content.length > 64 * 1024) return `Content exceeds 64 KB note cap (${content.length} bytes). Trim before saving.`;
+  localStorage.setItem(`cobweb:board-notes:${machineName}`, content);
+  return `Saved ${content.length} bytes to notes for "${machineName}".`;
+}
+```
+
+### `edit_board_notes`
+
+```ts
+{
+  name: 'edit_board_notes',
+  description:
+    'Edits the persistent notes for the currently connected board by replacing one occurrence of old_string with new_string. old_string must appear exactly once in the current notes; add surrounding context to disambiguate if necessary. The user reviews the change before it is saved.',
+  parameters: {
+    type: 'object',
+    properties: {
+      old_string: { type: 'string' },
+      new_string: { type: 'string' },
+    },
+    required: ['old_string', 'new_string'],
+    additionalProperties: false,
+  },
+  scope: 'write',
+  requiresApproval: true,
+}
+```
+
+```ts
+async call({ old_string, new_string }, _ctx): Promise<string> {
+  const { machineName } = this.getBindings();
+  if (!machineName) return 'Board not connected.';
+  const current = localStorage.getItem(`cobweb:board-notes:${machineName}`) ?? '';
+  const occurrences = countOccurrences(current, old_string);
+  if (occurrences === 0) return `old_string not found in current notes.`;
+  if (occurrences > 1) return `old_string appears ${occurrences} times in current notes. Add surrounding context to make it unique.`;
+  const updated = current.replace(old_string, new_string);
+  if (updated.length > 64 * 1024) return `Updated content exceeds 64 KB note cap. Trim before saving.`;
+  localStorage.setItem(`cobweb:board-notes:${machineName}`, updated);
+  return `Notes updated for "${machineName}".`;
+}
+```
+
+The uniqueness contract mirrors `edit_editor` / `edit_device_file`. Same family of error messages so the model's existing skills transfer.
+
+### Approval rendering
+
+Phase 1 uses the default approval card — the user sees the tool name, the args (the full content for `write_board_notes`, the `old_string` / `new_string` pair for `edit_board_notes`), and approves or rejects. Custom diff rendering inside `makeCobwebApproval.tsx` is a polish item; defer until the basic flow is observed.
+
+### Tests — three test files
+
+- `BoardNotesReadTool.test.ts` — disconnected → "Board not connected"; connected with no entry → ""; connected with entry → returns it.
+- `BoardNotesWriteTool.test.ts` — disconnected → "Board not connected"; small content → written to localStorage, returns success message; oversize content → returns cap error, localStorage unchanged.
+- `BoardNotesEditTool.test.ts` — uniqueness violations (zero / multiple occurrences) → corresponding error strings; valid edit → localStorage updated; oversize result → cap error.
+
+Tests stub `localStorage` on `globalThis` (or use `happy-dom`'s built-in).
+
+### File map
+
+**Add:**
+- `src/agent/tools/BoardNotesReadTool.ts`
+- `src/agent/tools/BoardNotesWriteTool.ts`
+- `src/agent/tools/BoardNotesEditTool.ts`
+- `src/agent/tools/BoardNotesReadTool.test.ts`
+- `src/agent/tools/BoardNotesWriteTool.test.ts`
+- `src/agent/tools/BoardNotesEditTool.test.ts`
+- `src/hooks/useMachineName.ts`
+- `src/hooks/useMachineName.test.ts`
+
+**Modify:**
+- `src/agent/wireTools.ts` — extend `ToolBindings` with `machineName: string | null`; register the three new tools.
+- `src/agent/config.ts` — append `'read_board_notes'`, `'write_board_notes'`, `'edit_board_notes'` to `CODING_AGENT.tools`. Add a sentence to coder instructions: *"At the start of work on a connected board, call `read_board_notes` to recall context from previous sessions. When you learn something durable about the board (vendor modules, useful docs URLs, pin assignments, gotchas), update the notes via `edit_board_notes` (or `write_board_notes` for the first entry) so future sessions benefit."*
+- `src/App.tsx` — invoke `useMachineName`; pass the value into `wireTools` bindings.
+
+---
+
+## 4. System-prompt budget
+
+Three sentences total appended to `CODING_AGENT.instructions`:
+
+1. *"At the start of work on a connected board, call `read_board_notes` to recall context from previous sessions. When you learn something durable about the board (vendor modules, useful docs URLs, pin assignments, gotchas), update the notes via `edit_board_notes` (or `write_board_notes` for the first entry) so future sessions benefit."*
+2. *"When you are unsure whether a vendor or community module is available on the connected board, call `list_installed_modules` before writing imports."*
+3. *"When the user provides a docs URL, when board notes record one, or when you need a known docs page (e.g. upstream MicroPython library RST at `https://raw.githubusercontent.com/micropython/micropython/master/docs/library/<module>.rst`), call `fetch_url`."*
+
+These are append-only string additions to the existing instructions literal. No mutation, no per-turn assembly. The tool descriptions themselves carry the bulk of the "when to call" guidance; the system-prompt sentences exist only to nudge tool *order* (read notes first, fetch known URLs before searching, probe modules before importing unknowns).
+
+---
+
+## 5. Concurrency considerations
+
+No instruction mutation. No per-message hooks awaiting fetches before dispatch. The only shared state is the `machineName` binding, set by `useMachineName` on connect.
+
+- **Mid-turn disconnect.** Tool calls read `machineName` at call time via the bindings closure. A disconnect mid-tool returns "Board not connected" on subsequent calls; in-flight `runCode` rejects via the existing `ReplDisconnectedError` path.
+- **Concurrent tool calls.** `AgentRunner` may fire multiple tool calls per turn via `Promise.all`. `localStorage` is synchronous — concurrent `write_board_notes` + `edit_board_notes` in the same turn would race, but the model is unlikely to emit both, and the second wins (last-write semantics). Document but don't implement serialisation in phase 1.
+
+---
+
+## 6. Issue breakdown
+
+Three small additive PRs, all branched off `main` per CLAUDE.md's default. No integration branch — the surface is additive and self-contained. Issues are independent and can land in any order or in parallel.
+
+| Issue | Title | Files added | Files modified |
+|-------|-------|-------------|----------------|
+| A | Board notes (read / write / edit) + `machineName` capture | `BoardNotes{Read,Write,Edit}Tool.ts` + tests, `useMachineName.ts` + test | `wireTools.ts`, `config.ts`, `App.tsx` |
+| B | `fetch_url` tool | `FetchUrlTool.ts` + test | `wireTools.ts`, `config.ts` |
+| C | `list_installed_modules` tool | `ListInstalledModulesTool.ts` + test | `wireTools.ts`, `config.ts` |
+
+---
+
+## 7. UI verification (per issue)
+
+For each tool issue, browser verification follows the same shape:
+
+**A (board notes)**
+1. Connect a board, ask the agent to remember a note ("note that GP25 is the onboard LED on this Pico") → coder calls `write_board_notes`, approval card fires showing the content, user approves, tool returns success.
+2. Refresh the page, start a new conversation, ask "what do you know about this board?" → coder calls `read_board_notes`, the saved note is in the result.
+3. Disconnect, connect a different board → `read_board_notes` returns "" (no leakage between boards).
+4. Ask the agent to update an existing note via `edit_board_notes` → approval card fires showing the old/new strings, approve, tool returns success.
+5. With the board disconnected → all three tools return "Board not connected".
+
+**B (`fetch_url`)**
+1. Paste `https://github.com/pimoroni/presto` in chat → coder calls `fetch_url`, README content is returned.
+2. Paste a CORS-rejecting URL (e.g. some non-CORS-friendly docs site) → coder receives the descriptive error string, does not error out.
+3. Paste a `github.com/owner/repo/blob/main/foo.md` URL → translates to raw, fetches successfully.
+
+**C (`list_installed_modules`)**
+1. Connect a Pico → ask "what modules are available on this board?" → tool fires, response includes `machine`, `network`, etc.
+2. Connect a Pimoroni Presto (if available) → same prompt → tool fires, response includes `presto`, `picographics`, etc.
+3. With board disconnected → tool returns "Board not connected".
+
+---
+
+## 8. Future work (phase 2)
+
+These are explicitly out of scope for phase 1 but documented so the design space is clear when (or if) they're picked up:
+
+- **Typed doc tools.** `get_board_quickref` and `get_module_docs` as thin URL-builder wrappers. Add only if browser observation shows the model under-fetches when given the generic `fetch_url` plus URL hints.
+- **Doc fetcher utility with caching.** When the typed tools land (or sooner if observed network traffic from repeated `fetch_url` calls is wasteful), introduce a shared `src/docsContext/fetcher.ts` that wraps `fetch` with Cache API caching. At that point versioned cache names (`micropython-docs-v${firmwareVersion}`) likely become worth their cost. `FetchUrlTool` and the typed tools would both consume the shared fetcher.
+- **`search_documentation` sub-agent.** Gemini-only. Pattern matches `delegate_to_coder` (sub-agent + `createAgentTool` + dedicated `AgentRunner` with `nativeTools: [{ googleSearch: {} }]`). Natural fallback for `fetch_url` CORS errors. Coder-only allowlist; provider-conditional registration.
+- **Notes management UI.** A settings-panel section listing per-board notes with edit and clear controls. Useful when notes accumulate across many boards or when the agent over-records.
+- **Auto-summarisation of long-running notes.** If notes grow toward the 64 KB cap, a periodic "summarise oldest entries" pass keeps them lean. Probably triggered manually from a settings UI rather than automatically.


### PR DESCRIPTION
## Summary

Initial design for the docs-context epic (#141). Phase 1 ships three coder-only tools that close the board-context and cross-thread-memory gaps via tools-on-demand rather than system-prompt injection:

- **Board notes** (`read_board_notes` / `write_board_notes` / `edit_board_notes`) — per-board persistent markdown via `localStorage`, keyed by `os.uname().machine`. Cross-thread memory.
- **`fetch_url`** — generic URL fetch with GitHub repo/blob translation; surfaces CORS / 404 / network failures as readable strings the agent can act on. No caching in phase 1.
- **`list_installed_modules`** — probes `help('modules')` to expose vendor extensions on custom firmware (Pimoroni, Adafruit, etc.).

Sub-issues filed and linked under #141: #162, #163, #164.

Phase 2 (typed doc tools, search-grounding sub-agent, fetcher with caching) is captured in `SPEC.md` §8 but explicitly out of scope here. No long-lived integration branch — each phase 1 sub-issue lands directly on `main`.

## Test plan

- [x] `npm run lint` passes (no source changes)
- [x] `npm run test` passes (no source changes)
- [x] `npm run build` passes (no source changes)
- [x] Doc review for clarity and tradeoff framing

Docs-only PR.