### PR TITLE
feat(docs-context): per-board persistent notes with diff approval

### DIFF
--- a/docs/docs-context/SPEC.md
+++ b/docs/docs-context/SPEC.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-The PRD identifies three primitives for phase 1: per-board persistent notes, generic URL fetching, and module-surface introspection. Each is a small additive tool registered on the existing `models.tools` registry, allowlisted to `CODING_AGENT` only.
+The PRD identifies three primitives for phase 1: per-board persistent notes, generic URL fetching, and module-surface introspection. Each is a small additive tool registered on the existing `models.tools` registry. The board-notes tools are allowlisted to both `PLANNING_AGENT` and `CODING_AGENT` so the planner can recall and update notes without delegating; `fetch_url` and `list_installed_modules` stay coder-only.
 
 The framework provides every primitive needed:
 
-- Tools register on `models.tools` via `wireTools`. The coder's allowlist in `CODING_AGENT.tools` controls visibility.
+- Tools register on `models.tools` via `wireTools`. Per-agent allowlists in `PLANNING_AGENT.tools` / `CODING_AGENT.tools` control visibility.
 - Approval-gated writes route through the existing `INLINE_APPROVAL` flow (`src/components/makeCobwebApproval.tsx`), the same path used by `edit_editor` / `write_device_file`.
 - `localStorage` and the Cache API are platform built-ins — no new dependencies.
 
@@ -177,7 +177,7 @@ Per-board persistent memory. The agent reads and updates a markdown blob keyed b
 
 - Key: `cobweb:board-notes:${machineName}`.
 - Value: a plain markdown string. No frontmatter, no JSON wrapper — keep it editable both by the agent and (later) by a settings-panel UI without parsing overhead.
-- Cap: 64 KB per board. Writes that would exceed the cap return an error.
+- No size cap in phase 1. Notes share the localStorage origin quota (~5 MB) with everything else; revisit if usage shows the agent over-recording.
 
 ### Bindings extension — `src/agent/wireTools.ts`
 
@@ -290,9 +290,6 @@ async call({ content }, _ctx): Promise<string> {
   const { boardIdentity } = this.getBindings();
   if (boardIdentity.status === 'disconnected') return 'No board connected. Notes are scoped per-board.';
   if (boardIdentity.status === 'probing') return 'Identifying the connected board… try again in a moment.';
-  if (content.length > 64 * 1024) {
-    return `Content exceeds 64 KB note cap (${content.length} bytes). Trim before saving.`;
-  }
   localStorage.setItem(`cobweb:board-notes:${boardIdentity.machineName}`, content);
   return `Saved ${content.length} bytes to notes for "${boardIdentity.machineName}".`;
 }
@@ -330,7 +327,6 @@ async call({ old_string, new_string }, _ctx): Promise<string> {
   if (occurrences === 0) return `old_string not found in current notes.`;
   if (occurrences > 1) return `old_string appears ${occurrences} times in current notes. Add surrounding context to make it unique.`;
   const updated = current.replace(old_string, new_string);
-  if (updated.length > 64 * 1024) return `Updated content exceeds 64 KB note cap. Trim before saving.`;
   localStorage.setItem(key, updated);
   return `Notes updated for "${boardIdentity.machineName}".`;
 }
@@ -340,13 +336,18 @@ The uniqueness contract mirrors `edit_editor` / `edit_device_file`. Same family 
 
 ### Approval rendering
 
-Phase 1 uses the default approval card — the user sees the tool name, the args (the full content for `write_board_notes`, the `old_string` / `new_string` pair for `edit_board_notes`), and approves or rejects. Custom diff rendering inside `makeCobwebApproval.tsx` is a polish item; defer until the basic flow is observed.
+Both write tools render diffs against the current notes:
+
+- `edit_board_notes` reuses `EditApprovalCard` with `surface: 'notes'` (the existing focused-diff card with notes-flavoured copy) so the user sees the same context-window view that `edit_editor` and `edit_device_file` produce.
+- `write_board_notes` renders a new `NotesWriteApprovalCard` that prints a unified `diffLines` view of *current → proposed*. When notes are empty (first write) the entire proposed body shows as additions; when notes already exist, the user sees what's changing rather than re-reading the full new blob.
+
+Both cards need access to the current notes content. `App.tsx` exposes a synchronous `getBoardNotes(): string | null` to `makeCobwebApproval`: `null` when `boardIdentity.status !== 'ready'`, otherwise the localStorage entry (or `''` if absent). When `null`, the approval card renders a "no board connected" notice with approve disabled, mirroring the binary-file path on `DeviceEditApprovalLoader`.
 
 ### Tests — three tool files plus the hook
 
 - `BoardNotesReadTool.test.ts` — `disconnected` → "No board connected" message; `probing` → "Identifying…" message; `ready` with no entry → ""; `ready` with entry → returns it.
-- `BoardNotesWriteTool.test.ts` — `disconnected` and `probing` → respective messages, localStorage unchanged; `ready` with small content → written, success message returned; `ready` with oversize content → cap error, localStorage unchanged.
-- `BoardNotesEditTool.test.ts` — `disconnected` and `probing` short-circuit before localStorage access; uniqueness violations (zero / multiple occurrences) → corresponding error strings; valid edit → localStorage updated; oversize result → cap error.
+- `BoardNotesWriteTool.test.ts` — `disconnected` and `probing` → respective messages, localStorage unchanged; `ready` → content written, success message returned.
+- `BoardNotesEditTool.test.ts` — `disconnected` and `probing` short-circuit before localStorage access; uniqueness violations (zero / multiple occurrences) → corresponding error strings; valid edit → localStorage updated.
 - `useMachineName.test.ts` — `renderHook` with a fake `runCode`. Initial state: `disconnected`. On `connectionState` → `'connected'`: status flips to `probing`, then `ready` with the trimmed machine string when the probe resolves. Empty probe output keeps status `probing`. `runCode` rejection keeps status `probing`. On `connectionState` → `'disconnected'`: status flips to `disconnected`.
 
 Tests stub `localStorage` on `globalThis` (or use `happy-dom`'s built-in).
@@ -365,20 +366,21 @@ Tests stub `localStorage` on `globalThis` (or use `happy-dom`'s built-in).
 
 **Modify:**
 - `src/agent/wireTools.ts` — export `BoardIdentity` discriminated union; extend `ToolBindings` with `boardIdentity: BoardIdentity`; register the three new tools.
-- `src/agent/config.ts` — append `'read_board_notes'`, `'write_board_notes'`, `'edit_board_notes'` to `CODING_AGENT.tools`. Add a sentence to coder instructions: *"At the start of work on a connected board, call `read_board_notes` to recall context from previous sessions. When you learn something durable about the board (vendor modules, useful docs URLs, pin assignments, gotchas), update the notes via `edit_board_notes` (or `write_board_notes` for the first entry) so future sessions benefit."*
-- `src/App.tsx` — invoke `useMachineName`; pass the returned `BoardIdentity` into `wireTools` bindings.
+- `src/components/makeCobwebApproval.tsx` and `src/components/CobwebApproval.tsx` — accept `getBoardNotes`, render `edit_board_notes` via the focused-diff card and `write_board_notes` via the new unified-diff card.
+- `src/agent/config.ts` — append `'read_board_notes'`, `'write_board_notes'`, `'edit_board_notes'` to both `PLANNING_AGENT.tools` and `CODING_AGENT.tools`. Add a paragraph to coder instructions establishing *when* to call the notes tools, *what* belongs in them, and *which concrete events trigger an update*. Both negative carve-outs are load-bearing: without the "what" list the agent treats anything "useful for next time" (filesystem listings, current `main.py` body) as note-worthy; without explicit triggers, "when you learn something durable" leaves the model to judge, and it either over-records or skips facts it just discovered. The paragraph: *"At the start of work on a connected board, call `read_board_notes` to recall context from previous sessions. Board notes are about the BOARD HARDWARE — vendor modules, pin assignments, hardware quirks, useful docs URLs. They are NOT about the current application: do not record filesystem listings, current main.py contents, project-specific code, or anything that would be wrong after a different program is flashed. Update the notes via `edit_board_notes` (or `write_board_notes` for the first entry) when one of these specific triggers fires: (a) `list_installed_modules` reveals a vendor or community module not already in the notes; (b) the user states a hardware fact (\"GP25 is the onboard LED\", \"this board has 264 KB SRAM\", \"I2C is on pins 4 and 5\"); (c) you fix a bug whose root cause was a board-specific quirk worth remembering; (d) you consult a docs URL you would want to find again from a future session. Update at the END of a successful turn, not mid-task — once you know the fact is correct and useful. Do not update notes just because something feels generally informative; if no trigger fires, do not write."*
+- `src/App.tsx` — invoke `useMachineName`; pass the returned `BoardIdentity` into `wireTools` bindings; build a `getBoardNotes` callback (reads localStorage when `boardIdentity.status === 'ready'`, else `null`) and pass it into `makeCobwebApproval`.
 
 ---
 
 ## 4. System-prompt budget
 
-Three sentences total appended to `CODING_AGENT.instructions`:
+Three additions total appended to `CODING_AGENT.instructions`:
 
-1. *"At the start of work on a connected board, call `read_board_notes` to recall context from previous sessions. When you learn something durable about the board (vendor modules, useful docs URLs, pin assignments, gotchas), update the notes via `edit_board_notes` (or `write_board_notes` for the first entry) so future sessions benefit."*
+1. *"At the start of work on a connected board, call `read_board_notes` to recall context from previous sessions. Board notes are about the BOARD HARDWARE — vendor modules, pin assignments, hardware quirks, useful docs URLs. They are NOT about the current application: do not record filesystem listings, current main.py contents, project-specific code, or anything that would be wrong after a different program is flashed. Update the notes via `edit_board_notes` (or `write_board_notes` for the first entry) when one of these specific triggers fires: (a) `list_installed_modules` reveals a vendor or community module not already in the notes; (b) the user states a hardware fact (\"GP25 is the onboard LED\", \"this board has 264 KB SRAM\", \"I2C is on pins 4 and 5\"); (c) you fix a bug whose root cause was a board-specific quirk worth remembering; (d) you consult a docs URL you would want to find again from a future session. Update at the END of a successful turn, not mid-task — once you know the fact is correct and useful. Do not update notes just because something feels generally informative; if no trigger fires, do not write."*
 2. *"When you are unsure whether a vendor or community module is available on the connected board, call `list_installed_modules` before writing imports."*
 3. *"When the user provides a docs URL, when board notes record one, or when you need a known docs page (e.g. upstream MicroPython library RST at `https://raw.githubusercontent.com/micropython/micropython/master/docs/library/<module>.rst`), call `fetch_url`."*
 
-These are append-only string additions to the existing instructions literal. No mutation, no per-turn assembly. The tool descriptions themselves carry the bulk of the "when to call" guidance; the system-prompt sentences exist only to nudge tool *order* (read notes first, fetch known URLs before searching, probe modules before importing unknowns).
+These are append-only string additions to the existing instructions literal. No mutation, no per-turn assembly. The tool descriptions themselves carry the bulk of the "when to call" guidance; the system-prompt sentences exist only to nudge tool *order* (read notes first, fetch known URLs before searching, probe modules before importing unknowns) and — for board notes specifically — *what* to record vs. leave to filesystem read tools.
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,12 +19,14 @@ import { useReplConnection } from './hooks/useReplConnection';
 import { useEditor, type EditorOrigin } from './hooks/useEditor';
 import { useDeviceFs } from './hooks/useDeviceFs';
 import { useLayout } from './hooks/useLayout';
+import { useMachineName } from './hooks/useMachineName';
 import { useProviderConfig } from './hooks/useProviderConfig';
 import { useTheme } from './hooks/useTheme';
 import { createModels } from './models';
 import { createAdapter } from './providers/factory';
 import { PLANNING_AGENT } from './agent/config';
 import { wireTools } from './agent/wireTools';
+import { boardNotesKey } from './agent/tools/boardNotesStorage';
 import { createDelegateToCoderTool } from './agent/tools/DelegateToCoderTool';
 import { DeviceFs } from './DeviceFs';
 import { saveEditor } from './lib/saveEditor';
@@ -47,6 +49,8 @@ export function App() {
     setOriginAndContent,
     isModified,
   } = useEditor(theme);
+
+  const boardIdentity = useMachineName({ connectionState, runCode });
 
   const deviceFsHook = useDeviceFs({ connectionState, sendRaw });
   const {
@@ -272,6 +276,7 @@ export function App() {
     onData,
     deviceFs,
     sendInterrupt: () => send('\x03'),
+    boardIdentity,
   });
 
   const runner = useMemo(() => {
@@ -302,9 +307,20 @@ export function App() {
     [deviceReadBytes],
   );
 
+  const getBoardNotes = useCallback((): string | null => {
+    if (boardIdentity.status !== 'ready') return null;
+    return localStorage.getItem(boardNotesKey(boardIdentity.machineName)) ?? '';
+  }, [boardIdentity]);
+
   const renderApproval = useMemo(
-    () => makeCobwebApproval(getContent, revealRange, readDeviceFileForApproval),
-    [getContent, revealRange, readDeviceFileForApproval],
+    () =>
+      makeCobwebApproval(
+        getContent,
+        revealRange,
+        readDeviceFileForApproval,
+        getBoardNotes,
+      ),
+    [getContent, revealRange, readDeviceFileForApproval, getBoardNotes],
   );
 
   const savedConversation = useMemo(

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -9,7 +9,7 @@ export const PLANNING_AGENT = createAgent({
 
 For trivial questions you can answer from the read-only tools (e.g. board info, file listings, current editor contents), answer directly without delegating.
 
-For any task that requires changing the editor, the device filesystem, or running code, call delegate_to_coder with a self-contained task string. The coder starts each call with no conversation history, so the task string must stand alone — but it does have the same read tools as you (read_editor, read_device_file, list_device_files, read_repl_history, get_board_info). Refer to files by path and let the coder read them; do not paste file contents into the task string. Include only what the coder cannot reconstruct from reading: the user's intent, exact constraints (line numbers, function names, before/after behaviour), and success criteria.
+For any task that requires changing the editor, the device filesystem, or running code, call delegate_to_coder with a self-contained task string. The coder starts each call with no conversation history, so the task string must stand alone — but it does have the same read tools as you (read_editor, read_device_file, list_device_files, read_repl_history, get_board_info). Refer to files by path and let the coder read them; do not paste file contents into the task string. Include only what the coder cannot reconstruct from reading: the user's intent, exact constraints (line numbers, function names, before/after behaviour), and success criteria. The coder writes to the editor by default; only ask it to write to the device when the user explicitly requested device persistence.
 
 Multi-step requests can call delegate_to_coder multiple times in one turn. After each delegation, briefly summarise what was done before deciding the next step.`,
   tools: [
@@ -18,6 +18,9 @@ Multi-step requests can call delegate_to_coder multiple times in one turn. After
     'list_device_files',
     'read_repl_history',
     'get_board_info',
+    'read_board_notes',
+    'write_board_notes',
+    'edit_board_notes',
     'delegate_to_coder',
   ],
 });
@@ -27,18 +30,20 @@ export const CODING_AGENT = createAgent({
   instructions: `You are a MicroPython coding assistant for the Cobweb IDE.
 You have access to the user's code editor and a live MicroPython REPL connected to a microcontroller.
 Help the user write, debug, and understand MicroPython code.
+DEFAULT SURFACE: When asked to write, modify, or scaffold code, write it in the EDITOR (write_editor / edit_editor). Do not write to the device filesystem unless the user explicitly asks for it (e.g. "save this as main.py", "create lib/foo.py on the board", "update boot.py"). The editor is where the user iterates; the device is where finished code is persisted. If the user gives a path on the device but does not say to save it there, write to the editor and ask whether they want to save it to the device.
 EDITING RULE: If there is already code in the editor and you need to change any part of it, you MUST use edit_editor. Do not use write_editor. edit_editor takes old_string (the exact text to replace — must appear exactly once; add surrounding context to disambiguate) and new_string (the replacement). The user sees a focused diff before it applies.
 For multiple changes to the editor, call edit_editor once per change — the user reviews and approves each individually.
 write_editor is only permitted in two situations: (1) the buffer is empty and you are writing the first version of a program, or (2) the user has explicitly asked you to replace all the code. In every other situation, use edit_editor.
 To run the editor's contents (typically a full program that may run for a long time), use run_editor. It returns as soon as the program starts; the user watches output directly in the REPL. After run_editor, simply tell the user the program started — do NOT follow up with read_repl_history or run_editor again unless the user asks.
 For short evaluations whose output you need back (sensor reads, expression eval, library probes), use run_snippet. If run_snippet returns "still running", call read_repl_history once to fetch what's been emitted so far, then report back.
 To inspect the device's filesystem (e.g. to confirm what's on the board before writing or running code), use list_device_files. To read the contents of a specific file on the device, use read_device_file; it returns "binary file — cannot read" for non-UTF-8 files.
-To change an existing file on the device, you MUST use edit_device_file — same old_string/new_string contract as edit_editor. For multiple changes to the same device file, call edit_device_file once per change. Do not use write_device_file for edits. write_device_file is only permitted for brand-new device files or explicit full rewrites. Prefer edit_editor or write_editor for buffers the user is iterating on; only write to the device when explicitly asked or when the change is meant to persist (e.g. main.py, boot.py).
+Device-write tools (write_device_file, edit_device_file, save_editor_to_device) are only for when the user has explicitly asked you to put code on the device. To change an existing file on the device, you MUST use edit_device_file — same old_string/new_string contract as edit_editor. For multiple changes to the same device file, call edit_device_file once per change. Do not use write_device_file for edits. write_device_file is only permitted for brand-new device files or explicit full rewrites.
 To delete a file on the device, use delete_device_file. It does not delete directories and requires user approval.
 To create a directory on the device, use make_device_dir. The parent directory must already exist; it requires user approval.
 Use stop_program to send Ctrl+C and interrupt a running program.
 Use get_board_info to learn the board's firmware version, platform, and available RAM before writing board-specific code.
-Use open_device_file_in_editor to open a device file in the editor in one step (instead of read_device_file + write_editor). Use save_editor_to_device to save the editor buffer to a device path in one step (instead of read_editor + write_device_file).`,
+Use open_device_file_in_editor to open a device file in the editor in one step (instead of read_device_file + write_editor). Use save_editor_to_device to save the editor buffer to a device path in one step (instead of read_editor + write_device_file).
+At the start of work on a connected board, call read_board_notes to recall context from previous sessions. Board notes are about the BOARD HARDWARE — vendor modules, pin assignments, hardware quirks, useful docs URLs. They are NOT about the current application: do not record filesystem listings, current main.py contents, project-specific code, or anything that would be wrong after a different program is flashed. Update the notes via edit_board_notes (or write_board_notes for the first entry) when one of these specific triggers fires: (a) list_installed_modules reveals a vendor or community module not already in the notes; (b) the user states a hardware fact ("GP25 is the onboard LED", "this board has 264 KB SRAM", "I2C is on pins 4 and 5"); (c) you fix a bug whose root cause was a board-specific quirk worth remembering; (d) you consult a docs URL you would want to find again from a future session. Update at the END of a successful turn, not mid-task — once you know the fact is correct and useful. Do not update notes just because something feels generally informative; if no trigger fires, do not write.`,
   tools: [
     'read_editor',
     'write_editor',
@@ -56,5 +61,8 @@ Use open_device_file_in_editor to open a device file in the editor in one step (
     'get_board_info',
     'open_device_file_in_editor',
     'save_editor_to_device',
+    'read_board_notes',
+    'write_board_notes',
+    'edit_board_notes',
   ],
 });

--- a/src/agent/tools/BoardNotesEditTool.test.ts
+++ b/src/agent/tools/BoardNotesEditTool.test.ts
@@ -1,0 +1,124 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BoardNotesEditTool } from './BoardNotesEditTool';
+import type { ToolBindings, BoardIdentity } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    sendInterrupt: () => {},
+    boardIdentity: { status: 'disconnected' },
+    ...overrides,
+  };
+}
+
+const READY: BoardIdentity = { status: 'ready', machineName: 'Pico' };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('BoardNotesEditTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new BoardNotesEditTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('edit_board_notes');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('short-circuits with disconnected message and leaves localStorage untouched', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', 'foo');
+    const tool = new BoardNotesEditTool(() =>
+      makeBindings({ boardIdentity: { status: 'disconnected' } }),
+    );
+    await expect(
+      tool.call({ old_string: 'foo', new_string: 'bar' }),
+    ).resolves.toBe('No board connected. Notes are scoped per-board.');
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe('foo');
+  });
+
+  it('short-circuits with probing message and leaves localStorage untouched', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', 'foo');
+    const tool = new BoardNotesEditTool(() =>
+      makeBindings({ boardIdentity: { status: 'probing' } }),
+    );
+    await expect(
+      tool.call({ old_string: 'foo', new_string: 'bar' }),
+    ).resolves.toBe('Identifying the connected board… try again in a moment.');
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe('foo');
+  });
+
+  it('returns "old_string not found" when target is absent', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', 'hello world');
+    const tool = new BoardNotesEditTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await expect(
+      tool.call({ old_string: 'missing', new_string: 'x' }),
+    ).resolves.toBe('old_string not found in current notes.');
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe('hello world');
+  });
+
+  it('returns "old_string not found" when notes are empty', async () => {
+    const tool = new BoardNotesEditTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await expect(
+      tool.call({ old_string: 'anything', new_string: 'x' }),
+    ).resolves.toBe('old_string not found in current notes.');
+  });
+
+  it('returns ambiguous error when old_string appears more than once', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', 'foo\nbar\nfoo\nfoo\n');
+    const tool = new BoardNotesEditTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await expect(
+      tool.call({ old_string: 'foo', new_string: 'baz' }),
+    ).resolves.toBe(
+      'old_string appears 3 times in current notes. Add surrounding context to make it unique.',
+    );
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe('foo\nbar\nfoo\nfoo\n');
+  });
+
+  it('replaces the unique occurrence and updates localStorage', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', 'a = 1\nb = 2\nc = 3\n');
+    const tool = new BoardNotesEditTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await expect(
+      tool.call({ old_string: 'b = 2', new_string: 'b = 42' }),
+    ).resolves.toBe('Notes updated for "Pico".');
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe(
+      'a = 1\nb = 42\nc = 3\n',
+    );
+  });
+
+  it('handles multi-line replacements', async () => {
+    localStorage.setItem(
+      'cobweb:board-notes:Pico',
+      '## Pins\nGP25: LED\n\n## Modules\nrp2, machine\n',
+    );
+    const tool = new BoardNotesEditTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await expect(
+      tool.call({
+        old_string: '## Pins\nGP25: LED',
+        new_string: '## Pins\nGP25: LED (onboard)',
+      }),
+    ).resolves.toBe('Notes updated for "Pico".');
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe(
+      '## Pins\nGP25: LED (onboard)\n\n## Modules\nrp2, machine\n',
+    );
+  });
+});

--- a/src/agent/tools/BoardNotesEditTool.ts
+++ b/src/agent/tools/BoardNotesEditTool.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+import { findUniqueOccurrence } from '../../lib/editApproval';
+import { boardNotesKey } from './boardNotesStorage';
+
+export interface BoardNotesEditArgs {
+  old_string: string;
+  new_string: string;
+}
+
+export class BoardNotesEditTool implements Tool<BoardNotesEditArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'edit_board_notes',
+      description:
+        'Edits the persistent notes for the currently connected board by replacing one occurrence of old_string with new_string. Notes are scoped to the board hardware (vendor modules, pin assignments, hardware quirks, useful docs URLs) — NOT to the current application or files on the device. Do not record filesystem listings, current code contents, or project-specific state. old_string must appear exactly once in the current notes; add surrounding context to disambiguate if necessary. The user reviews the change before it is saved.',
+      parameters: {
+        type: 'object',
+        properties: {
+          old_string: {
+            type: 'string',
+            description:
+              'The exact substring currently in the notes to replace. Must appear exactly once.',
+          },
+          new_string: {
+            type: 'string',
+            description: 'The replacement text.',
+          },
+        },
+        required: ['old_string', 'new_string'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: BoardNotesEditArgs): Promise<string> {
+    const { boardIdentity } = this.getBindings();
+    if (boardIdentity.status === 'disconnected') {
+      return 'No board connected. Notes are scoped per-board.';
+    }
+    if (boardIdentity.status === 'probing') {
+      return 'Identifying the connected board… try again in a moment.';
+    }
+    const key = boardNotesKey(boardIdentity.machineName);
+    const current = localStorage.getItem(key) ?? '';
+    const result = findUniqueOccurrence(current, args.old_string);
+    if (result.kind === 'missing') return 'old_string not found in current notes.';
+    if (result.kind === 'ambiguous') {
+      return `old_string appears ${result.count} times in current notes. Add surrounding context to make it unique.`;
+    }
+    const updated =
+      current.slice(0, result.index) +
+      args.new_string +
+      current.slice(result.index + args.old_string.length);
+    localStorage.setItem(key, updated);
+    return `Notes updated for "${boardIdentity.machineName}".`;
+  }
+}

--- a/src/agent/tools/BoardNotesReadTool.test.ts
+++ b/src/agent/tools/BoardNotesReadTool.test.ts
@@ -1,0 +1,79 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BoardNotesReadTool } from './BoardNotesReadTool';
+import type { ToolBindings, BoardIdentity } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    sendInterrupt: () => {},
+    boardIdentity: { status: 'disconnected' },
+    ...overrides,
+  };
+}
+
+const READY: BoardIdentity = { status: 'ready', machineName: 'Pico' };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('BoardNotesReadTool', () => {
+  it('definition has correct name, scope, and no approval', () => {
+    const tool = new BoardNotesReadTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('read_board_notes');
+    expect(def.scope).toBe('read');
+    expect(def.requiresApproval).toBe(false);
+  });
+
+  it('returns disconnected message when no board is connected', async () => {
+    const tool = new BoardNotesReadTool(() =>
+      makeBindings({ boardIdentity: { status: 'disconnected' } }),
+    );
+    await expect(tool.call()).resolves.toBe(
+      'No board connected. Notes are scoped per-board; connect a device to read its notes.',
+    );
+  });
+
+  it('returns probing message while identifying the board', async () => {
+    const tool = new BoardNotesReadTool(() =>
+      makeBindings({ boardIdentity: { status: 'probing' } }),
+    );
+    await expect(tool.call()).resolves.toBe(
+      'Identifying the connected board… try again in a moment.',
+    );
+  });
+
+  it('returns "" when ready and no entry exists for the board', async () => {
+    const tool = new BoardNotesReadTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await expect(tool.call()).resolves.toBe('');
+  });
+
+  it('returns the stored entry when ready', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', '# Notes for Pico\n');
+    const tool = new BoardNotesReadTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await expect(tool.call()).resolves.toBe('# Notes for Pico\n');
+  });
+
+  it('does not leak across boards', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', 'pico notes');
+    localStorage.setItem('cobweb:board-notes:Esp32', 'esp32 notes');
+    const tool = new BoardNotesReadTool(() =>
+      makeBindings({ boardIdentity: { status: 'ready', machineName: 'Esp32' } }),
+    );
+    await expect(tool.call()).resolves.toBe('esp32 notes');
+  });
+});

--- a/src/agent/tools/BoardNotesReadTool.ts
+++ b/src/agent/tools/BoardNotesReadTool.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+import { boardNotesKey } from './boardNotesStorage';
+
+export class BoardNotesReadTool implements Tool<Record<string, never>, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'read_board_notes',
+      description:
+        'Reads the persistent notes for the currently connected board. Notes are scoped per-board (by os.uname().machine) and survive across sessions. Notes describe the board itself — vendor module surface, pin assignments, hardware quirks, useful docs URLs — not whatever happens to be on its filesystem at the moment. Use list_device_files / read_device_file to inspect application state; use this to recall durable board facts the agent established in previous conversations. Returns "" if no notes exist yet.',
+      parameters: {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+      scope: 'read',
+      requiresApproval: false,
+    };
+  }
+
+  async call(): Promise<string> {
+    const { boardIdentity } = this.getBindings();
+    if (boardIdentity.status === 'disconnected') {
+      return 'No board connected. Notes are scoped per-board; connect a device to read its notes.';
+    }
+    if (boardIdentity.status === 'probing') {
+      return 'Identifying the connected board… try again in a moment.';
+    }
+    return localStorage.getItem(boardNotesKey(boardIdentity.machineName)) ?? '';
+  }
+}

--- a/src/agent/tools/BoardNotesWriteTool.test.ts
+++ b/src/agent/tools/BoardNotesWriteTool.test.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { BoardNotesWriteTool } from './BoardNotesWriteTool';
+import type { ToolBindings, BoardIdentity } from '../wireTools';
+
+function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
+  return {
+    getEditorContent: () => '',
+    setEditorContent: () => {},
+    replaceEditorRange: () => {},
+    runCode: async () => ({ stdout: '', stderr: '' }),
+    getReplHistory: () => [],
+    onData: () => () => {},
+    deviceFs: null,
+    sendInterrupt: () => {},
+    boardIdentity: { status: 'disconnected' },
+    ...overrides,
+  };
+}
+
+const READY: BoardIdentity = { status: 'ready', machineName: 'Pico' };
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('BoardNotesWriteTool', () => {
+  it('definition has correct name, scope, and approval flag', () => {
+    const tool = new BoardNotesWriteTool(() => makeBindings());
+    const def = tool.definition();
+    expect(def.name).toBe('write_board_notes');
+    expect(def.scope).toBe('write');
+    expect(def.requiresApproval).toBe(true);
+  });
+
+  it('returns disconnected message and leaves localStorage unchanged', async () => {
+    const tool = new BoardNotesWriteTool(() =>
+      makeBindings({ boardIdentity: { status: 'disconnected' } }),
+    );
+    await expect(tool.call({ content: 'x' })).resolves.toBe(
+      'No board connected. Notes are scoped per-board.',
+    );
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('returns probing message and leaves localStorage unchanged', async () => {
+    const tool = new BoardNotesWriteTool(() =>
+      makeBindings({ boardIdentity: { status: 'probing' } }),
+    );
+    await expect(tool.call({ content: 'x' })).resolves.toBe(
+      'Identifying the connected board… try again in a moment.',
+    );
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('writes content to localStorage and reports byte count when ready', async () => {
+    const tool = new BoardNotesWriteTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    const content = '# Pico\nGP25 is the onboard LED.';
+    await expect(tool.call({ content })).resolves.toBe(
+      `Saved ${content.length} bytes to notes for "Pico".`,
+    );
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe(content);
+  });
+
+  it('overwrites existing notes', async () => {
+    localStorage.setItem('cobweb:board-notes:Pico', 'old notes');
+    const tool = new BoardNotesWriteTool(() =>
+      makeBindings({ boardIdentity: READY }),
+    );
+    await tool.call({ content: 'new notes' });
+    expect(localStorage.getItem('cobweb:board-notes:Pico')).toBe('new notes');
+  });
+});

--- a/src/agent/tools/BoardNotesWriteTool.ts
+++ b/src/agent/tools/BoardNotesWriteTool.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+import type { ToolBindings } from '../wireTools';
+import { boardNotesKey } from './boardNotesStorage';
+
+export interface BoardNotesWriteArgs {
+  content: string;
+}
+
+export class BoardNotesWriteTool implements Tool<BoardNotesWriteArgs, string> {
+  constructor(private getBindings: () => ToolBindings) {}
+
+  definition(): ToolDefinition {
+    return {
+      name: 'write_board_notes',
+      description:
+        'Replaces the persistent notes for the currently connected board with the provided content. Notes are scoped to the board hardware (vendor modules, pin assignments, hardware quirks, useful docs URLs) — NOT to the current application or whatever files happen to be on the device. Do not record filesystem listings, current main.py contents, project-specific code, or anything that would change when a different program is flashed. Prefer edit_board_notes for incremental changes; use this for the first write or full rewrites. The user reviews the proposed content before it is saved.',
+      parameters: {
+        type: 'object',
+        properties: {
+          content: {
+            type: 'string',
+            description: 'The new full notes content (markdown).',
+          },
+        },
+        required: ['content'],
+        additionalProperties: false,
+      },
+      scope: 'write',
+      requiresApproval: true,
+    };
+  }
+
+  async call(args: BoardNotesWriteArgs): Promise<string> {
+    const { boardIdentity } = this.getBindings();
+    if (boardIdentity.status === 'disconnected') {
+      return 'No board connected. Notes are scoped per-board.';
+    }
+    if (boardIdentity.status === 'probing') {
+      return 'Identifying the connected board… try again in a moment.';
+    }
+    localStorage.setItem(boardNotesKey(boardIdentity.machineName), args.content);
+    return `Saved ${args.content.length} bytes to notes for "${boardIdentity.machineName}".`;
+  }
+}

--- a/src/agent/tools/boardNotesStorage.ts
+++ b/src/agent/tools/boardNotesStorage.ts
@@ -1,0 +1,6 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+export function boardNotesKey(machineName: string): string {
+  return `cobweb:board-notes:${machineName}`;
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -15,6 +15,7 @@ function makeBindings(overrides: Partial<ToolBindings> = {}): ToolBindings {
     onData: () => () => {},
     deviceFs: null,
     sendInterrupt: () => {},
+    boardIdentity: { status: 'disconnected' },
     ...overrides,
   };
 }
@@ -26,12 +27,14 @@ describe('wireTools', () => {
     const names = tools.getTools().map((t) => t.name).sort();
     expect(names).toEqual([
       'delete_device_file',
+      'edit_board_notes',
       'edit_device_file',
       'edit_editor',
       'get_board_info',
       'list_device_files',
       'make_device_dir',
       'open_device_file_in_editor',
+      'read_board_notes',
       'read_device_file',
       'read_editor',
       'read_repl_history',
@@ -39,6 +42,7 @@ describe('wireTools', () => {
       'run_snippet',
       'save_editor_to_device',
       'stop_program',
+      'write_board_notes',
       'write_device_file',
       'write_editor',
     ]);
@@ -48,7 +52,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(16);
+    expect(tools.getTools()).toHaveLength(19);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -20,6 +20,14 @@ import { StopProgramTool } from './tools/StopProgramTool';
 import { GetBoardInfoTool } from './tools/GetBoardInfoTool';
 import { OpenDeviceFileInEditorTool } from './tools/OpenDeviceFileInEditorTool';
 import { SaveEditorToDeviceTool } from './tools/SaveEditorToDeviceTool';
+import { BoardNotesReadTool } from './tools/BoardNotesReadTool';
+import { BoardNotesWriteTool } from './tools/BoardNotesWriteTool';
+import { BoardNotesEditTool } from './tools/BoardNotesEditTool';
+
+export type BoardIdentity =
+  | { status: 'disconnected' }
+  | { status: 'probing' }
+  | { status: 'ready'; machineName: string };
 
 export interface ToolBindings {
   getEditorContent(): string;
@@ -34,6 +42,15 @@ export interface ToolBindings {
   onData(handler: (data: Uint8Array) => void): () => void;
   deviceFs: DeviceFs | null;
   sendInterrupt(): void;
+  /**
+   * State of the connect-time `os.uname().machine` probe. The notes tools
+   * branch on `status` so that "no board connected" (a legitimate workflow
+   * — editing local files without a device) and "board connected, still
+   * identifying it" (a transient state in the first ~hundred ms after
+   * connect) produce distinct messages, rather than collapsing the latter
+   * into a misleading "Board not connected".
+   */
+  boardIdentity: BoardIdentity;
 }
 
 const REGISTERED = new WeakSet<ToolRegistry>();
@@ -66,4 +83,7 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new GetBoardInfoTool(get));
   tools.register(new OpenDeviceFileInEditorTool(get));
   tools.register(new SaveEditorToDeviceTool(get));
+  tools.register(new BoardNotesReadTool(get));
+  tools.register(new BoardNotesWriteTool(get));
+  tools.register(new BoardNotesEditTool(get));
 }

--- a/src/components/CobwebApproval.tsx
+++ b/src/components/CobwebApproval.tsx
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { diffWords, type ChangeObject } from 'diff';
+import { diffLines, diffWords, type ChangeObject } from 'diff';
 import {
   InlineApproval,
   type PendingApproval,
@@ -19,6 +19,7 @@ interface CobwebApprovalProps extends ApprovalSlotProps {
   getEditorContent: () => string;
   revealEditorRange: (from: number, to: number) => void;
   readDeviceFile: (path: string) => Promise<string | null>;
+  getBoardNotes: () => string | null;
 }
 
 export function CobwebApproval({
@@ -27,6 +28,7 @@ export function CobwebApproval({
   getEditorContent,
   revealEditorRange,
   readDeviceFile,
+  getBoardNotes,
 }: CobwebApprovalProps): ReactNode {
   switch (entry.name) {
     case 'edit_editor':
@@ -48,6 +50,50 @@ export function CobwebApproval({
           readDeviceFile={readDeviceFile}
         />
       );
+    case 'edit_board_notes': {
+      const current = getBoardNotes();
+      if (current === null) {
+        return (
+          <NoBoardApprovalCard
+            entry={entry}
+            approval={approval}
+            header={<>Edit board notes</>}
+          />
+        );
+      }
+      return (
+        <EditApprovalCard
+          entry={entry}
+          approval={approval}
+          surface="notes"
+          headerLabel={<>Edit board notes</>}
+          source={current}
+        />
+      );
+    }
+    case 'write_board_notes': {
+      const wbnArgs = entry.args as { content?: unknown } | undefined;
+      const wbnContent =
+        typeof wbnArgs?.content === 'string' ? wbnArgs.content : '';
+      const wbnCurrent = getBoardNotes();
+      if (wbnCurrent === null) {
+        return (
+          <NoBoardApprovalCard
+            entry={entry}
+            approval={approval}
+            header={<>Save board notes</>}
+          />
+        );
+      }
+      return (
+        <NotesWriteApprovalCard
+          entry={entry}
+          approval={approval}
+          current={wbnCurrent}
+          proposed={wbnContent}
+        />
+      );
+    }
     case 'write_editor': {
       const weArgs = entry.args as { code?: unknown } | undefined;
       const code = typeof weArgs?.code === 'string' ? weArgs.code : '';
@@ -317,7 +363,7 @@ function OpenDeviceFileApprovalLoader({
 
 interface EditApprovalCardProps extends ApprovalSlotProps {
   source: string;
-  surface: 'editor' | 'file';
+  surface: 'editor' | 'file' | 'notes';
   headerLabel: ReactNode;
   revealRange?: (from: number, to: number) => void;
 }
@@ -352,10 +398,11 @@ function EditApprovalCard({
     revealRange(find.index, find.index + oldString.length);
   }, [find, oldString.length, revealRange]);
 
-  const surfaceWord = surface === 'editor' ? 'editor' : 'file';
-  const missingNotice = `old_string was not found in the current ${surfaceWord} — the ${
-    surface === 'editor' ? 'buffer' : 'file'
-  } may have changed since the agent proposed this edit.`;
+  const surfaceWord =
+    surface === 'editor' ? 'editor' : surface === 'notes' ? 'notes' : 'file';
+  const surfaceContainer =
+    surface === 'editor' ? 'buffer' : surface === 'notes' ? 'notes' : 'file';
+  const missingNotice = `old_string was not found in the current ${surfaceWord} — the ${surfaceContainer} may have changed since the agent proposed this edit.`;
   const missingRespond = `old_string not found in ${surfaceWord}.`;
   const ambiguousNotice = (count: number) =>
     `old_string is now ambiguous — it appears ${count} times in the current ${surfaceWord}.`;
@@ -406,6 +453,62 @@ function EditApprovalCard({
 
       <ApprovalActions
         approveDisabled={find.kind !== 'unique'}
+        onApprove={approval.approve}
+        onReject={approval.reject}
+      />
+    </div>
+  );
+}
+
+// ----- NotesWriteApprovalCard ------------------------------------------------
+
+interface NotesWriteApprovalCardProps extends ApprovalSlotProps {
+  current: string;
+  proposed: string;
+}
+
+function NotesWriteApprovalCard({
+  entry,
+  approval,
+  current,
+  proposed,
+}: NotesWriteApprovalCardProps): ReactNode {
+  return (
+    <div className="cobweb-approval-card" data-tool-name={entry.name}>
+      <div className="cobweb-approval-header">
+        <span className="cobweb-approval-title">Save board notes</span>
+        <span className="cobweb-approval-status">requires approval</span>
+      </div>
+      <UnifiedDiffBlock current={current} proposed={proposed} />
+      <ApprovalActions onApprove={approval.approve} onReject={approval.reject} />
+    </div>
+  );
+}
+
+// ----- NoBoardApprovalCard --------------------------------------------------
+
+interface NoBoardApprovalCardProps extends ApprovalSlotProps {
+  header: ReactNode;
+}
+
+function NoBoardApprovalCard({
+  entry,
+  approval,
+  header,
+}: NoBoardApprovalCardProps): ReactNode {
+  return (
+    <div className="cobweb-approval-card" data-tool-name={entry.name}>
+      <div className="cobweb-approval-header">
+        <span className="cobweb-approval-title">{header}</span>
+        <span className="cobweb-approval-status">requires approval</span>
+      </div>
+      <NoLongerAppliesNotice
+        message="No board connected — cannot preview or save notes."
+        respondMessage="No board connected. Notes are scoped per-board."
+        onRespondWith={approval.reject}
+      />
+      <ApprovalActions
+        approveDisabled
         onApprove={approval.approve}
         onReject={approval.reject}
       />
@@ -509,6 +612,61 @@ function DiffBlock({ source, index, oldString, newString }: DiffBlockProps): Rea
       ))}
     </pre>
   );
+}
+
+// ----- UnifiedDiffBlock ------------------------------------------------------
+
+interface UnifiedDiffBlockProps {
+  current: string;
+  proposed: string;
+}
+
+/**
+ * Whole-content diff for tools that replace an entire blob (e.g.
+ * `write_board_notes`). Uses `diffLines` so the user sees what's changing
+ * without having to read the full new content end-to-end.
+ */
+function UnifiedDiffBlock({ current, proposed }: UnifiedDiffBlockProps): ReactNode {
+  const changes = useMemo(() => diffLines(current, proposed), [current, proposed]);
+
+  // Track the running line numbers in the *current* (left) and *proposed*
+  // (right) versions so each row can show its source-side line number.
+  // Lines added by the change have no left-side number; removed lines have
+  // no right-side number — we render the left number for removed/context
+  // and leave it blank for added rows, matching `DiffBlock`.
+  let leftLine = 1;
+  const rows: ReactNode[] = [];
+  let key = 0;
+  for (const change of changes) {
+    const lines = change.value.split('\n');
+    // `diffLines` chunks end with the trailing newline included, so the
+    // split yields a final empty string we should drop to avoid a phantom
+    // blank row per chunk.
+    if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+    for (const line of lines) {
+      if (change.added) {
+        rows.push(
+          <DiffLine key={`u-${key++}`} kind="added" lineNumber={null}>
+            {line}
+          </DiffLine>,
+        );
+      } else if (change.removed) {
+        rows.push(
+          <DiffLine key={`u-${key++}`} kind="removed" lineNumber={leftLine++}>
+            {line}
+          </DiffLine>,
+        );
+      } else {
+        rows.push(
+          <DiffLine key={`u-${key++}`} kind="context" lineNumber={leftLine++}>
+            {line}
+          </DiffLine>,
+        );
+      }
+    }
+  }
+
+  return <pre className="cobweb-diff">{rows}</pre>;
 }
 
 function renderHalf(changes: ChangeObject<string>[], side: 'removed' | 'added'): ReactNode[] {

--- a/src/components/makeCobwebApproval.tsx
+++ b/src/components/makeCobwebApproval.tsx
@@ -8,6 +8,7 @@ export function makeCobwebApproval(
   getEditorContent: () => string,
   revealEditorRange: (from: number, to: number) => void,
   readDeviceFile: (path: string) => Promise<string | null>,
+  getBoardNotes: () => string | null,
 ): RenderApproval {
   return (entry, approval) => (
     <CobwebApproval
@@ -16,6 +17,7 @@ export function makeCobwebApproval(
       getEditorContent={getEditorContent}
       revealEditorRange={revealEditorRange}
       readDeviceFile={readDeviceFile}
+      getBoardNotes={getBoardNotes}
     />
   );
 }

--- a/src/hooks/useMachineName.test.ts
+++ b/src/hooks/useMachineName.test.ts
@@ -1,0 +1,108 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useMachineName } from './useMachineName';
+import type { RunResult } from '../ReplInterface';
+import type { ConnectionState } from './useReplConnection';
+
+function makeRunCode(impl: () => Promise<RunResult>) {
+  return vi.fn(impl);
+}
+
+describe('useMachineName', () => {
+  it('starts in disconnected state', () => {
+    const runCode = makeRunCode(async () => ({ stdout: '', stderr: '' }));
+    const { result } = renderHook(() =>
+      useMachineName({ connectionState: 'disconnected', runCode }),
+    );
+    expect(result.current).toEqual({ status: 'disconnected' });
+    expect(runCode).not.toHaveBeenCalled();
+  });
+
+  it('flips to probing then ready with the trimmed machine string on connect', async () => {
+    const runCode = makeRunCode(async () => ({
+      stdout: '  Raspberry Pi Pico with RP2040  \n',
+      stderr: '',
+    }));
+    const { result, rerender } = renderHook(
+      ({ state }: { state: ConnectionState }) =>
+        useMachineName({ connectionState: state, runCode }),
+      { initialProps: { state: 'disconnected' as ConnectionState } },
+    );
+    expect(result.current).toEqual({ status: 'disconnected' });
+
+    rerender({ state: 'connected' });
+    expect(result.current).toEqual({ status: 'probing' });
+    expect(runCode).toHaveBeenCalledWith('import os; print(os.uname().machine)');
+
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'ready',
+        machineName: 'Raspberry Pi Pico with RP2040',
+      }),
+    );
+  });
+
+  it('keeps status === probing when probe stdout is empty', async () => {
+    const runCode = makeRunCode(async () => ({ stdout: '   \n', stderr: '' }));
+    const { result } = renderHook(() =>
+      useMachineName({ connectionState: 'connected', runCode }),
+    );
+    await waitFor(() => expect(runCode).toHaveBeenCalled());
+    // Allow microtasks to flush.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(result.current).toEqual({ status: 'probing' });
+  });
+
+  it('keeps status === probing when runCode rejects', async () => {
+    const runCode = makeRunCode(async () => {
+      throw new Error('Not connected');
+    });
+    const { result } = renderHook(() =>
+      useMachineName({ connectionState: 'connected', runCode }),
+    );
+    await waitFor(() => expect(runCode).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(result.current).toEqual({ status: 'probing' });
+  });
+
+  it('flips back to disconnected when connection drops', async () => {
+    const runCode = makeRunCode(async () => ({ stdout: 'Pico\n', stderr: '' }));
+    const { result, rerender } = renderHook(
+      ({ state }: { state: ConnectionState }) =>
+        useMachineName({ connectionState: state, runCode }),
+      { initialProps: { state: 'connected' as ConnectionState } },
+    );
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: 'ready', machineName: 'Pico' }),
+    );
+
+    rerender({ state: 'disconnected' });
+    expect(result.current).toEqual({ status: 'disconnected' });
+  });
+
+  it('re-probes on reconnect', async () => {
+    const runCode = makeRunCode(async () => ({ stdout: 'BoardA\n', stderr: '' }));
+    const { result, rerender } = renderHook(
+      ({ state }: { state: ConnectionState }) =>
+        useMachineName({ connectionState: state, runCode }),
+      { initialProps: { state: 'connected' as ConnectionState } },
+    );
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: 'ready', machineName: 'BoardA' }),
+    );
+
+    rerender({ state: 'disconnected' });
+    expect(result.current).toEqual({ status: 'disconnected' });
+
+    runCode.mockResolvedValueOnce({ stdout: 'BoardB\n', stderr: '' });
+    rerender({ state: 'connected' });
+    expect(result.current).toEqual({ status: 'probing' });
+    await waitFor(() =>
+      expect(result.current).toEqual({ status: 'ready', machineName: 'BoardB' }),
+    );
+    expect(runCode).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useMachineName.ts
+++ b/src/hooks/useMachineName.ts
@@ -1,0 +1,67 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { useEffect, useState } from 'react';
+import type { BoardIdentity } from '../agent/wireTools';
+import type { RunResult } from '../ReplInterface';
+import type { ConnectionState } from './useReplConnection';
+
+const PROBE_SNIPPET = 'import os; print(os.uname().machine)';
+
+interface UseMachineNameArgs {
+  connectionState: ConnectionState;
+  runCode: (code: string) => Promise<RunResult>;
+}
+
+/**
+ * Probes `os.uname().machine` once per connect transition and surfaces the
+ * result as a discriminated `BoardIdentity` so notes tools can distinguish
+ * "no board" from "board connected, identifying it".
+ */
+export function useMachineName(args: UseMachineNameArgs): BoardIdentity {
+  const { connectionState, runCode } = args;
+  // Lazy-init so a hook mounted with an already-connected board starts in
+  // 'probing' rather than briefly reporting 'disconnected'.
+  const [identity, setIdentity] = useState<BoardIdentity>(() =>
+    connectionState === 'connected'
+      ? { status: 'probing' }
+      : { status: 'disconnected' },
+  );
+  // Reset to a connection-derived baseline whenever connectionState changes,
+  // using the documented "adjust state during render" pattern. The async
+  // probe below then writes 'ready' once stdout returns.
+  const [prevState, setPrevState] = useState<ConnectionState>(connectionState);
+  if (prevState !== connectionState) {
+    setPrevState(connectionState);
+    setIdentity(
+      connectionState === 'connected'
+        ? { status: 'probing' }
+        : { status: 'disconnected' },
+    );
+  }
+
+  useEffect(() => {
+    if (connectionState !== 'connected') return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const { stdout } = await runCode(PROBE_SNIPPET);
+        if (cancelled) return;
+        const value = stdout.trim();
+        // Empty probe output keeps status === 'probing' rather than
+        // misrepresenting it as ready-with-empty-name. The agent retries
+        // on the next turn (cheap; same as a transient REPL hiccup).
+        if (value) setIdentity({ status: 'ready', machineName: value });
+      } catch {
+        // Probe failure leaves status === 'probing'; the agent's next
+        // notes-touching turn surfaces the "still identifying" message
+        // rather than silently degrading to disconnected-shaped errors.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [connectionState, runCode]);
+
+  return identity;
+}


### PR DESCRIPTION
## Summary

- Adds three notes tools (`read_board_notes`, `write_board_notes`, `edit_board_notes`) keyed by `os.uname().machine`, captured at connect via the new `useMachineName` hook. Solves cross-conversation memory: durable board facts the agent established last time are recoverable in the next session.
- Approval cards render diffs: `edit_board_notes` reuses the focused-diff `EditApprovalCard` with a `'notes'` surface, and `write_board_notes` uses a new `NotesWriteApprovalCard` rendering a unified `diffLines` view of current → proposed.
- `CODING_AGENT.instructions` get a `DEFAULT SURFACE` rule (editor unless user asked for the device), a paragraph scoping notes to board hardware (not application state), and four concrete update triggers (vendor module discovery, user-stated hardware fact, board-quirk bugfix, docs URL worth keeping). `PLANNING_AGENT` gets the notes tools too so it can recall and update without delegating.
- SPEC §3 / §4 updated; the 64 KB cap was dropped per discussion.

Closes #162.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (501 passing, including 6 new board-notes/hook tests)
- [x] `npm run build`
- [x] Manual browser verification per SPEC §7 A:
  - Connect a board, ask the agent to remember a note → `write_board_notes` approval card shows a unified diff, approve, success.
  - Refresh page, new conversation, ask "what do you know about this board?" → `read_board_notes` returns the saved note.
  - Disconnect, connect a different board → `read_board_notes` returns "" (no leakage).
  - Edit an existing note via `edit_board_notes` → focused-diff approval card, approve, success.
  - With no board connected → all three tools return "No board connected".
  - Notes-touching message in the brief connect/probe window → "Identifying the connected board…" rather than misreporting as disconnected.