### PR TITLE
feat(docs-context): add fetch_url tool

### DIFF
--- a/docs/docs-context/SPEC.md
+++ b/docs/docs-context/SPEC.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The PRD identifies three primitives for phase 1: per-board persistent notes, generic URL fetching, and module-surface introspection. Each is a small additive tool registered on the existing `models.tools` registry. The board-notes tools are allowlisted to both `PLANNING_AGENT` and `CODING_AGENT` so the planner can recall and update notes without delegating; `fetch_url` and `list_installed_modules` stay coder-only.
+The PRD identifies three primitives for phase 1: per-board persistent notes, generic URL fetching, and module-surface introspection. Each is a small additive tool registered on the existing `models.tools` registry. The board-notes and `fetch_url` tools are allowlisted to both `PLANNING_AGENT` and `CODING_AGENT` so the planner can recall notes and read docs URLs the user pastes without round-tripping through the coder; `list_installed_modules` stays coder-only because it requires a connected device and only matters when actually writing imports.
 
 The framework provides every primitive needed:
 
@@ -163,7 +163,7 @@ Tests stub `fetch` on `globalThis`.
 
 **Modify:**
 - `src/agent/wireTools.ts` — register the new tool.
-- `src/agent/config.ts` — append `'fetch_url'` to `CODING_AGENT.tools`. Add a sentence to coder instructions: *"When the user provides a docs URL, when board notes record one, or when you need a known docs page (e.g. upstream MicroPython library RST at `https://raw.githubusercontent.com/micropython/micropython/master/docs/library/<module>.rst`), call `fetch_url`."*
+- `src/agent/config.ts` — append `'fetch_url'` to both `PLANNING_AGENT.tools` and `CODING_AGENT.tools`. Add a sentence to coder instructions: *"When the user provides a docs URL, when board notes record one, or when you need a known docs page (e.g. upstream MicroPython library RST at `https://raw.githubusercontent.com/micropython/micropython/master/docs/library/<module>.rst`), call `fetch_url`."*
 
 ---
 

--- a/src/agent/config.ts
+++ b/src/agent/config.ts
@@ -21,6 +21,7 @@ Multi-step requests can call delegate_to_coder multiple times in one turn. After
     'read_board_notes',
     'write_board_notes',
     'edit_board_notes',
+    'fetch_url',
     'delegate_to_coder',
   ],
 });
@@ -43,7 +44,8 @@ To create a directory on the device, use make_device_dir. The parent directory m
 Use stop_program to send Ctrl+C and interrupt a running program.
 Use get_board_info to learn the board's firmware version, platform, and available RAM before writing board-specific code.
 Use open_device_file_in_editor to open a device file in the editor in one step (instead of read_device_file + write_editor). Use save_editor_to_device to save the editor buffer to a device path in one step (instead of read_editor + write_device_file).
-At the start of work on a connected board, call read_board_notes to recall context from previous sessions. Board notes are about the BOARD HARDWARE — vendor modules, pin assignments, hardware quirks, useful docs URLs. They are NOT about the current application: do not record filesystem listings, current main.py contents, project-specific code, or anything that would be wrong after a different program is flashed. Update the notes via edit_board_notes (or write_board_notes for the first entry) when one of these specific triggers fires: (a) list_installed_modules reveals a vendor or community module not already in the notes; (b) the user states a hardware fact ("GP25 is the onboard LED", "this board has 264 KB SRAM", "I2C is on pins 4 and 5"); (c) you fix a bug whose root cause was a board-specific quirk worth remembering; (d) you consult a docs URL you would want to find again from a future session. Update at the END of a successful turn, not mid-task — once you know the fact is correct and useful. Do not update notes just because something feels generally informative; if no trigger fires, do not write.`,
+At the start of work on a connected board, call read_board_notes to recall context from previous sessions. Board notes are about the BOARD HARDWARE — vendor modules, pin assignments, hardware quirks, useful docs URLs. They are NOT about the current application: do not record filesystem listings, current main.py contents, project-specific code, or anything that would be wrong after a different program is flashed. Update the notes via edit_board_notes (or write_board_notes for the first entry) when one of these specific triggers fires: (a) list_installed_modules reveals a vendor or community module not already in the notes; (b) the user states a hardware fact ("GP25 is the onboard LED", "this board has 264 KB SRAM", "I2C is on pins 4 and 5"); (c) you fix a bug whose root cause was a board-specific quirk worth remembering; (d) you consult a docs URL you would want to find again from a future session. Update at the END of a successful turn, not mid-task — once you know the fact is correct and useful. Do not update notes just because something feels generally informative; if no trigger fires, do not write.
+When the user provides a docs URL, when board notes record one, or when you need a known docs page (e.g. upstream MicroPython library RST at https://raw.githubusercontent.com/micropython/micropython/master/docs/library/<module>.rst), call fetch_url.`,
   tools: [
     'read_editor',
     'write_editor',
@@ -64,5 +66,6 @@ At the start of work on a connected board, call read_board_notes to recall conte
     'read_board_notes',
     'write_board_notes',
     'edit_board_notes',
+    'fetch_url',
   ],
 });

--- a/src/agent/tools/FetchUrlTool.test.ts
+++ b/src/agent/tools/FetchUrlTool.test.ts
@@ -1,0 +1,209 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { FetchUrlTool, translateGitHubUrl } from './FetchUrlTool';
+
+function ok(body: string): Response {
+  return new Response(body, { status: 200 });
+}
+
+function notFound(): Response {
+  return new Response('not found', { status: 404 });
+}
+
+function serverError(): Response {
+  return new Response('boom', { status: 500 });
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('translateGitHubUrl', () => {
+  it('returns repo candidate for https://github.com/owner/repo', () => {
+    expect(translateGitHubUrl('https://github.com/pimoroni/presto')).toEqual({
+      kind: 'repo',
+      owner: 'pimoroni',
+      repo: 'presto',
+      url: 'https://raw.githubusercontent.com/pimoroni/presto/main/README.md',
+    });
+  });
+
+  it('translates blob URLs to raw.githubusercontent.com', () => {
+    expect(
+      translateGitHubUrl(
+        'https://github.com/micropython/micropython/blob/master/docs/library/machine.rst',
+      ),
+    ).toEqual({
+      kind: 'single',
+      url: 'https://raw.githubusercontent.com/micropython/micropython/master/docs/library/machine.rst',
+    });
+  });
+
+  it('translates blob URLs with nested paths', () => {
+    expect(
+      translateGitHubUrl(
+        'https://github.com/owner/repo/blob/main/a/b/c.md',
+      ),
+    ).toEqual({
+      kind: 'single',
+      url: 'https://raw.githubusercontent.com/owner/repo/main/a/b/c.md',
+    });
+  });
+
+  it('returns immediate "directory listing not supported" for tree URLs', () => {
+    expect(
+      translateGitHubUrl('https://github.com/micropython/micropython/tree/master/docs'),
+    ).toEqual({
+      kind: 'immediate',
+      message: 'Directory listing is not supported. Provide a specific file URL.',
+    });
+  });
+
+  it('passes non-github URLs through unchanged', () => {
+    expect(translateGitHubUrl('https://example.com/foo.html')).toEqual({
+      kind: 'single',
+      url: 'https://example.com/foo.html',
+    });
+  });
+
+  it('passes invalid URLs through unchanged', () => {
+    expect(translateGitHubUrl('not a url')).toEqual({
+      kind: 'single',
+      url: 'not a url',
+    });
+  });
+});
+
+describe('FetchUrlTool', () => {
+  it('definition has correct name, scope, and no approval', () => {
+    const def = new FetchUrlTool().definition();
+    expect(def.name).toBe('fetch_url');
+    expect(def.scope).toBe('read');
+    expect(def.requiresApproval).toBe(false);
+    expect(def.parameters.required).toEqual(['url']);
+  });
+
+  it('returns body for a successful plain URL fetch', async () => {
+    fetchMock.mockResolvedValueOnce(ok('hello world'));
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://example.com/page.txt' })).resolves.toBe(
+      'hello world',
+    );
+    expect(fetchMock).toHaveBeenCalledWith('https://example.com/page.txt');
+  });
+
+  it('translates GitHub repo URL and returns README from main', async () => {
+    fetchMock.mockResolvedValueOnce(ok('# Presto README'));
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://github.com/pimoroni/presto' })).resolves.toBe(
+      '# Presto README',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/pimoroni/presto/main/README.md',
+    );
+  });
+
+  it('falls back to master when main returns 404', async () => {
+    fetchMock
+      .mockResolvedValueOnce(notFound())
+      .mockResolvedValueOnce(ok('legacy README'));
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://github.com/owner/repo' })).resolves.toBe(
+      'legacy README',
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      'https://raw.githubusercontent.com/owner/repo/main/README.md',
+    );
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      'https://raw.githubusercontent.com/owner/repo/master/README.md',
+    );
+  });
+
+  it('returns "No README.md found" when both branches 404', async () => {
+    fetchMock
+      .mockResolvedValueOnce(notFound())
+      .mockResolvedValueOnce(notFound());
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://github.com/owner/repo' })).resolves.toBe(
+      'No README.md found on main or master branches of owner/repo.',
+    );
+  });
+
+  it('translates GitHub blob URL and fetches via raw host', async () => {
+    fetchMock.mockResolvedValueOnce(ok('rst body'));
+    const tool = new FetchUrlTool();
+    await expect(
+      tool.call({
+        url: 'https://github.com/micropython/micropython/blob/master/docs/library/machine.rst',
+      }),
+    ).resolves.toBe('rst body');
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/micropython/micropython/master/docs/library/machine.rst',
+    );
+  });
+
+  it('returns "Directory listing is not supported" for tree URLs without fetching', async () => {
+    const tool = new FetchUrlTool();
+    await expect(
+      tool.call({
+        url: 'https://github.com/micropython/micropython/tree/master/docs',
+      }),
+    ).resolves.toBe('Directory listing is not supported. Provide a specific file URL.');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns descriptive CORS error string when fetch rejects', async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'));
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://blocked.example.com/page' })).resolves.toBe(
+      'Could not fetch https://blocked.example.com/page: Failed to fetch. The host may have blocked cross-origin access. Try search_documentation, paste the relevant section into chat, or provide a github.com URL instead.',
+    );
+  });
+
+  it('returns "HTTP 500" string for non-OK responses on plain URLs', async () => {
+    fetchMock.mockResolvedValueOnce(serverError());
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://example.com/bad' })).resolves.toBe(
+      'Fetched https://example.com/bad returned HTTP 500.',
+    );
+  });
+
+  it('returns "HTTP 500" string for non-OK responses on GitHub repo branches without retrying', async () => {
+    fetchMock.mockResolvedValueOnce(serverError());
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://github.com/owner/repo' })).resolves.toBe(
+      'Fetched https://raw.githubusercontent.com/owner/repo/main/README.md returned HTTP 500.',
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('truncates bodies over 30 KB and adds the marker', async () => {
+    const big = 'x'.repeat(30 * 1024 + 500);
+    fetchMock.mockResolvedValueOnce(ok(big));
+    const tool = new FetchUrlTool();
+    const url = 'https://example.com/big.txt';
+    const result = await tool.call({ url });
+    expect(result.startsWith('x'.repeat(30 * 1024))).toBe(true);
+    expect(result.endsWith(`... [truncated, see full file at ${url}]\n`)).toBe(true);
+    expect(result.length).toBeLessThan(big.length);
+  });
+
+  it('does not truncate bodies at or under the 30 KB cap', async () => {
+    const exact = 'y'.repeat(30 * 1024);
+    fetchMock.mockResolvedValueOnce(ok(exact));
+    const tool = new FetchUrlTool();
+    await expect(tool.call({ url: 'https://example.com/exact' })).resolves.toBe(exact);
+  });
+});

--- a/src/agent/tools/FetchUrlTool.ts
+++ b/src/agent/tools/FetchUrlTool.ts
@@ -1,0 +1,141 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import type { Tool, ToolDefinition } from '@mast-ai/core';
+
+export interface FetchUrlArgs {
+  url: string;
+}
+
+const MAX_BYTES = 30 * 1024;
+
+interface RepoCandidate {
+  kind: 'repo';
+  url: string;
+  owner: string;
+  repo: string;
+}
+
+interface SingleCandidate {
+  kind: 'single';
+  url: string;
+}
+
+interface ImmediateResult {
+  kind: 'immediate';
+  message: string;
+}
+
+type Translation = RepoCandidate | SingleCandidate | ImmediateResult;
+
+export function translateGitHubUrl(input: string): Translation {
+  let parsed: URL;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return { kind: 'single', url: input };
+  }
+  if (parsed.host !== 'github.com') {
+    return { kind: 'single', url: input };
+  }
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  if (segments.length < 2) {
+    return { kind: 'single', url: input };
+  }
+  const [owner, repo, kind, ...rest] = segments;
+  if (kind === undefined) {
+    return { kind: 'repo', owner, repo, url: rawReadmeUrl(owner, repo, 'main') };
+  }
+  if (kind === 'tree') {
+    return {
+      kind: 'immediate',
+      message: 'Directory listing is not supported. Provide a specific file URL.',
+    };
+  }
+  if (kind === 'blob') {
+    if (rest.length < 2) return { kind: 'single', url: input };
+    const [branch, ...path] = rest;
+    const rawPath = path.map(encodeURIComponent).join('/');
+    return {
+      kind: 'single',
+      url: `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${rawPath}`,
+    };
+  }
+  return { kind: 'single', url: input };
+}
+
+function rawReadmeUrl(owner: string, repo: string, branch: string): string {
+  return `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/README.md`;
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+function truncate(body: string, url: string): string {
+  if (body.length <= MAX_BYTES) return body;
+  return body.slice(0, MAX_BYTES) + `\n\n... [truncated, see full file at ${url}]\n`;
+}
+
+async function fetchOnce(url: string): Promise<string | { status: number } | { error: string }> {
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (err) {
+    return { error: describeError(err) };
+  }
+  if (!response.ok) return { status: response.status };
+  return await response.text();
+}
+
+export class FetchUrlTool implements Tool<FetchUrlArgs, string> {
+  definition(): ToolDefinition {
+    return {
+      name: 'fetch_url',
+      description:
+        'Fetches the contents of a URL and returns the body as text. Use this when the user provides a documentation URL, when board notes record a URL worth consulting, or when you need to read a known docs page (including raw GitHub files for MicroPython upstream docs). GitHub repo and blob URLs auto-translate to raw.githubusercontent.com. On failure, returns a descriptive error string (CORS-blocked, 404, network error) so you can decide on a fallback.',
+      parameters: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description: 'The URL to fetch (http or https).',
+          },
+        },
+        required: ['url'],
+        additionalProperties: false,
+      },
+      scope: 'read',
+      requiresApproval: false,
+    };
+  }
+
+  async call(args: FetchUrlArgs): Promise<string> {
+    const translation = translateGitHubUrl(args.url);
+    if (translation.kind === 'immediate') return translation.message;
+
+    if (translation.kind === 'repo') {
+      const branches = ['main', 'master'];
+      for (const branch of branches) {
+        const url = rawReadmeUrl(translation.owner, translation.repo, branch);
+        const result = await fetchOnce(url);
+        if (typeof result === 'string') return truncate(result, url);
+        if ('error' in result) {
+          return `Could not fetch ${url}: ${result.error}. The host may have blocked cross-origin access. Try search_documentation, paste the relevant section into chat, or provide a github.com URL instead.`;
+        }
+        if (result.status === 404) continue;
+        return `Fetched ${url} returned HTTP ${result.status}.`;
+      }
+      return `No README.md found on main or master branches of ${translation.owner}/${translation.repo}.`;
+    }
+
+    const url = translation.url;
+    const result = await fetchOnce(url);
+    if (typeof result === 'string') return truncate(result, url);
+    if ('error' in result) {
+      return `Could not fetch ${url}: ${result.error}. The host may have blocked cross-origin access. Try search_documentation, paste the relevant section into chat, or provide a github.com URL instead.`;
+    }
+    return `Fetched ${url} returned HTTP ${result.status}.`;
+  }
+}

--- a/src/agent/wireTools.test.ts
+++ b/src/agent/wireTools.test.ts
@@ -30,6 +30,7 @@ describe('wireTools', () => {
       'edit_board_notes',
       'edit_device_file',
       'edit_editor',
+      'fetch_url',
       'get_board_info',
       'list_device_files',
       'make_device_dir',
@@ -52,7 +53,7 @@ describe('wireTools', () => {
     const tools = new ToolRegistry();
     wireTools(tools, makeBindings());
     expect(() => wireTools(tools, makeBindings())).not.toThrow();
-    expect(tools.getTools()).toHaveLength(19);
+    expect(tools.getTools()).toHaveLength(20);
   });
 
   it('updates bindings on subsequent calls so tools see the latest callbacks', async () => {

--- a/src/agent/wireTools.ts
+++ b/src/agent/wireTools.ts
@@ -23,6 +23,7 @@ import { SaveEditorToDeviceTool } from './tools/SaveEditorToDeviceTool';
 import { BoardNotesReadTool } from './tools/BoardNotesReadTool';
 import { BoardNotesWriteTool } from './tools/BoardNotesWriteTool';
 import { BoardNotesEditTool } from './tools/BoardNotesEditTool';
+import { FetchUrlTool } from './tools/FetchUrlTool';
 
 export type BoardIdentity =
   | { status: 'disconnected' }
@@ -86,4 +87,5 @@ export function wireTools(tools: ToolRegistry, bindings: ToolBindings): void {
   tools.register(new BoardNotesReadTool(get));
   tools.register(new BoardNotesWriteTool(get));
   tools.register(new BoardNotesEditTool(get));
+  tools.register(new FetchUrlTool());
 }


### PR DESCRIPTION
## Summary

- Adds `FetchUrlTool` (`src/agent/tools/FetchUrlTool.ts`) that fetches arbitrary URLs and returns the body as text. Failures (network/CORS, non-OK HTTP) surface as descriptive strings — the tool never throws — so the agent can reason about them and pick a fallback.
- GitHub URL translation: `github.com/owner/repo` → tries `raw.githubusercontent.com/owner/repo/main/README.md`, falls back to `master`; `blob/<branch>/<path>` → raw; `tree/...` → "Directory listing is not supported." Other hosts pass through.
- 30 KB truncation cap with a `[truncated, see full file at <url>]` marker.
- Allowlisted to **both** `PLANNING_AGENT` and `CODING_AGENT` so the planner can resolve pasted docs URLs without round-tripping through the coder. (SPEC §2 had originally scoped it to coder-only; updated alongside this change.)
- Coder instructions get one nudge sentence pointing at upstream MicroPython library RST URLs.

Closes #163.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` — 18 new tests in `FetchUrlTool.test.ts` cover translation (repo/blob/tree/non-github/invalid), success, 404 fallthrough, both-branches-404, CORS rejection, HTTP 500, and truncation at and over the 30 KB cap. `wireTools.test.ts` updated for the new tool name and count. 519 tests pass.
- [x] `npm run build`
- [x] Manual browser verification (per SPEC §7 B): pasted a `github.com/owner/repo` URL → README returned; pasted a `blob/...` URL → translated to raw; pasted a CORS-rejecting URL → descriptive error string returned without crashing the chat.

## Notes

- Surfaced an unrelated pre-existing crash in conversation persistence (`JSON.stringify` on circular Window ref) while testing — filed as #167. Not introduced by this change.