### PR TITLE
fix(docs-context): catch and diagnose conversation persistence crashes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { createDelegateToCoderTool } from './agent/tools/DelegateToCoderTool';
 import { DeviceFs } from './DeviceFs';
 import { saveEditor } from './lib/saveEditor';
 import { dirname, join } from './lib/devicePath';
+import { findCycle } from './lib/findCycle';
 
 const models = createModels();
 
@@ -364,7 +365,27 @@ export function App() {
         return INLINE_APPROVAL;
       }}
       onConversationChange={(history, entries) => {
-        localStorage.setItem('cobweb:conversation', JSON.stringify({ history, entries }));
+        const snapshot = { history, entries };
+        let serialized: string;
+        try {
+          serialized = JSON.stringify(snapshot);
+        } catch (err) {
+          // Persistence is best-effort: skip this turn rather than crashing
+          // the inner ConversationErrorBoundary into a remount. Log enough to
+          // root-cause the offending field — see #167.
+          const hit = findCycle(snapshot);
+          console.error('[cobweb] Failed to persist conversation:', err);
+          if (hit) {
+            console.error(
+              `[cobweb] Cycle at "${hit.path}" (constructor: ${hit.constructor}). Snapshot:`,
+              snapshot,
+            );
+          } else {
+            console.error('[cobweb] No cycle detected by walker. Snapshot:', snapshot);
+          }
+          return;
+        }
+        localStorage.setItem('cobweb:conversation', serialized);
       }}
       initialHistory={savedConversation?.history as never}
       initialEntries={savedConversation?.entries as never}

--- a/src/lib/findCycle.test.ts
+++ b/src/lib/findCycle.test.ts
@@ -1,0 +1,52 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest';
+import { findCycle } from './findCycle';
+
+describe('findCycle', () => {
+  it('returns null for plain serialisable data', () => {
+    expect(findCycle({ a: 1, b: 'x', c: [1, 2, { d: true }] })).toBeNull();
+  });
+
+  it('returns null for shared but non-circular references', () => {
+    const shared = { value: 1 };
+    expect(findCycle({ x: shared, y: shared, z: [shared, shared] })).toBeNull();
+  });
+
+  it('finds a direct self-reference', () => {
+    const obj: Record<string, unknown> = { a: 1 };
+    obj.self = obj;
+    expect(findCycle(obj)).toEqual({ path: 'self', constructor: 'Object' });
+  });
+
+  it('finds a cycle through nested objects and arrays', () => {
+    const root: { entries: Array<Record<string, unknown>> } = { entries: [{}] };
+    root.entries[0].back = root.entries;
+    expect(findCycle(root)).toEqual({ path: 'entries[0].back', constructor: 'Array' });
+  });
+
+  it('reports the constructor name of class instances', () => {
+    class Widget {
+      ref!: Widget;
+    }
+    const w = new Widget();
+    w.ref = w;
+    const hit = findCycle({ outer: w });
+    expect(hit).toEqual({ path: 'outer.ref', constructor: 'Widget' });
+  });
+
+  it('reports a path of "" when the root is its own first cycle target', () => {
+    const a: Record<string, unknown> = {};
+    const b: Record<string, unknown> = { a };
+    a.b = b;
+    expect(findCycle(a)).toEqual({ path: 'b.a', constructor: 'Object' });
+  });
+
+  it('returns null for primitives at the root', () => {
+    expect(findCycle(null)).toBeNull();
+    expect(findCycle(undefined)).toBeNull();
+    expect(findCycle(42)).toBeNull();
+    expect(findCycle('hello')).toBeNull();
+  });
+});

--- a/src/lib/findCycle.ts
+++ b/src/lib/findCycle.ts
@@ -1,0 +1,45 @@
+// Copyright 2026 Andre Cipriani Bandarra
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Diagnostic for `JSON.stringify` failures on circular structures.
+ *
+ * Mirrors `JSON.stringify`'s walk: only objects on the active recursion stack
+ * count as cycles, so legitimate shared (non-circular) references return `null`.
+ * Non-plain values (Window, Response, etc.) become cycles only when the host
+ * object self-references — which is exactly the Window case behind #167.
+ */
+
+export interface CycleHit {
+  /** Dot/bracket path from the root, e.g. `entries[0].contentBlocks[2].args.window`. */
+  path: string;
+  /** `obj.constructor.name` of the re-encountered node, or `'Object'` if unset. */
+  constructor: string;
+}
+
+export function findCycle(root: unknown): CycleHit | null {
+  return walk(root, '', new WeakSet<object>());
+}
+
+function walk(value: unknown, path: string, stack: WeakSet<object>): CycleHit | null {
+  if (value === null || typeof value !== 'object') return null;
+  const obj = value as object;
+  if (stack.has(obj)) {
+    return { path, constructor: obj.constructor?.name ?? 'Object' };
+  }
+  stack.add(obj);
+  let hit: CycleHit | null = null;
+  if (Array.isArray(obj)) {
+    for (let i = 0; i < obj.length && !hit; i++) {
+      hit = walk(obj[i], `${path}[${i}]`, stack);
+    }
+  } else {
+    for (const key of Object.keys(obj)) {
+      if (hit) break;
+      const childPath = path ? `${path}.${key}` : key;
+      hit = walk((obj as Record<string, unknown>)[key], childPath, stack);
+    }
+  }
+  stack.delete(obj);
+  return hit;
+}


### PR DESCRIPTION
## Summary

- Wrap `JSON.stringify` in `onConversationChange` (`src/App.tsx`) so a non-serialisable value in `history`/`entries` no longer crashes the inner `ConversationErrorBoundary` into a remount.
- Add `src/lib/findCycle.ts`, a small walker that mirrors `JSON.stringify`'s recursion-stack semantics and returns the path + constructor of the first re-encountered node.
- On failure, log the underlying error plus `findCycle`'s path/constructor and the live snapshot, so the offending field can be drilled into via DevTools.

Deliberately not added: a replacer that strips cycles. Persistence is skipped for the failing turn rather than silently rewritten — the root cause (likely an upstream `args`/`result`/`provider_metadata` carrying a `Window`/`Response`) stays visible until reproduced.

Refs #167 — does **not** close it; the underlying leak still needs to be fixed once we capture the path on a future repro.

## Test plan

- [x] `npm run lint`
- [x] `npm run test` (526 tests, all pass; 7 new for `findCycle`)
- [x] `npm run build`
- [ ] Manual: reproduce the crash, confirm UI does not remount, capture `[cobweb] Cycle at ...` in console for follow-up.