### PR TITLE
chore(settings): refresh Gemini model list and default

### DIFF
--- a/src/components/SettingsPanel.test.tsx
+++ b/src/components/SettingsPanel.test.tsx
@@ -45,17 +45,17 @@ describe('SettingsPanel', () => {
     render(
       <SettingsPanel
         {...makeDefaults({
-          config: { provider: 'google-genai', apiKey: 'AIza', model: 'gemini-2.5-pro' },
+          config: { provider: 'google-genai', apiKey: 'AIza', model: 'gemini-3.5-flash' },
         })}
       />,
     );
-    expect(screen.getByLabelText<HTMLSelectElement>('Model').value).toBe('gemini-2.5-pro');
+    expect(screen.getByLabelText<HTMLSelectElement>('Model').value).toBe('gemini-3.5-flash');
   });
 
-  it('defaults the model to Gemini 3.1 Flash-Lite Preview when no config is set', () => {
+  it('defaults the model to Gemini 3.1 Flash-Lite when no config is set', () => {
     render(<SettingsPanel {...makeDefaults()} />);
     expect(screen.getByLabelText<HTMLSelectElement>('Model').value).toBe(
-      'gemini-3.1-flash-lite-preview',
+      'gemini-3.1-flash-lite',
     );
   });
 
@@ -86,13 +86,13 @@ describe('SettingsPanel', () => {
     render(<SettingsPanel {...makeDefaults({ onSave, onClose })} />);
 
     await userEvent.type(screen.getByLabelText('API key'), '  AIza-new  ');
-    await userEvent.selectOptions(screen.getByLabelText('Model'), 'gemini-2.5-flash');
+    await userEvent.selectOptions(screen.getByLabelText('Model'), 'gemini-3.5-flash');
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     expect(onSave).toHaveBeenCalledWith({
       provider: 'google-genai',
       apiKey: 'AIza-new',
-      model: 'gemini-2.5-flash',
+      model: 'gemini-3.5-flash',
     });
     expect(onClose).toHaveBeenCalledOnce();
   });

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -10,15 +10,12 @@ import { Button } from './ui/button';
 type ProviderId = 'google-genai';
 
 const GEMINI_MODELS = [
-  { id: 'gemini-2.5-pro', label: 'Gemini 2.5 Pro' },
-  { id: 'gemini-2.5-flash', label: 'Gemini 2.5 Flash' },
-  { id: 'gemini-2.5-flash-lite', label: 'Gemini 2.5 Flash-Lite' },
-  { id: 'gemini-3-flash-preview', label: 'Gemini 3 Flash Preview' },
-  { id: 'gemini-3.1-pro-preview', label: 'Gemini 3.1 Pro Preview' },
-  { id: 'gemini-3.1-flash-lite-preview', label: 'Gemini 3.1 Flash-Lite Preview' },
+  { id: 'gemini-3.1-flash-lite', label: 'Gemini 3.1 Flash-Lite' },
+  { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash' },
+  { id: 'gemini-pro-latest', label: 'Gemini Pro Latest' },
 ] as const;
 
-const DEFAULT_GEMINI_MODEL = 'gemini-3.1-flash-lite-preview';
+const DEFAULT_GEMINI_MODEL = 'gemini-3.1-flash-lite';
 
 interface SettingsPanelProps {
   isOpen: boolean;
@@ -37,11 +34,9 @@ interface SettingsFormProps {
 
 function SettingsForm({ config, onClose, onSave, onClear }: SettingsFormProps) {
   const [provider, setProvider] = useState<ProviderId>('google-genai');
-  const [apiKey, setApiKey] = useState(
-    config?.provider === 'google-genai' ? config.apiKey : '',
-  );
+  const [apiKey, setApiKey] = useState(config?.provider === 'google-genai' ? config.apiKey : '');
   const [model, setModel] = useState<string>(
-    config?.provider === 'google-genai' && config.model ? config.model : DEFAULT_GEMINI_MODEL,
+    config?.provider === 'google-genai' && config.model ? config.model : DEFAULT_GEMINI_MODEL
   );
 
   function handleSave(event: React.FormEvent) {


### PR DESCRIPTION
## Summary
- Replaces the 2.5-era Gemini options in the settings dropdown with `gemini-3.1-flash-lite`, `gemini-3.5-flash`, and `gemini-pro-latest`.
- Moves the default selection to `gemini-3.1-flash-lite`.
- Updates `SettingsPanel` tests to assert against the new options and default; the prefill, default, and select-on-save tests previously referenced model IDs no longer present in the dropdown.

The provider factory, storage, and types treat the model as an opaque string and required no change. Docs and README only mention Gemini generically.

## Test plan
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npm run test` (526 passing)
- [x] Manual verification in browser by author